### PR TITLE
Mac OS X: Fix Window vanishing if losing focus

### DIFF
--- a/src/cocoa/cocoamain.mm
+++ b/src/cocoa/cocoamain.mm
@@ -1025,6 +1025,7 @@ void InitTextWindow() {
     [TW setFrameAutosaveName:@"TextWindow"];
     [TW setFloatingPanel:YES];
     [TW setBecomesKeyOnlyIfNeeded:YES];
+    [TW setHidesOnDeactivate:NO];
     [GW addChildWindow:TW ordered:NSWindowAbove];
 
     NSScrollView *scrollView = [[NSScrollView alloc] init];


### PR DESCRIPTION
I don't know if this is the intended behavior for other platforms, but on Mac OS X, all SolveSpace windows completely disappear if the app loses focus, for example by clicking on another program. It is then no longer visible in the Mac 'Mission Control' that should show all opened windows. After clicking on the dock icon, the window reappears.

When setting this flag on the browser window, both windows stay visible when losing focus. This resembles the expected behavior on this platform.