### PR TITLE
Fix resource path resolution

### DIFF
--- a/src/platform/gtkmain.cpp
+++ b/src/platform/gtkmain.cpp
@@ -1589,9 +1589,8 @@ int main(int argc, char** argv) {
     /* Are we running from a build directory, as opposed to a global install? */
     if(std::string(argv[0]).find('/') != std::string::npos) {
         resource_dir = argv[0]; // .../src/solvespace
-        resource_dir.erase(resource_dir.rfind('/'));
-        resource_dir.erase(resource_dir.rfind('/'));
-        resource_dir += "/res"; // .../res
+        resource_dir.erase(resource_dir.rfind('/')+1);
+        resource_dir += "../res"; // .../res
     }
 
     Gtk::Main main(argc, argv);


### PR DESCRIPTION
Attempting to execute
  build$ src/solvespace
crashes, because resource_dir.erase(resource_dir.rfind('/')); is executed twice, but the second rfind() will return string::npos.

This only goes back one slash to get the directory and then assembles the path as a relative path.

So both:
  build$ src/solvespace
  solvespace$ build/src/solvespace
will work.