### PR TITLE
Switch icon placements on toolbar

### DIFF
--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -42,8 +42,8 @@ static ToolIcon Toolbar[] = {
 
     { "extrude",         Command::GROUP_EXTRUDE,  "New group extruding active sketch",                {} },
     { "lathe",           Command::GROUP_LATHE,    "New group rotating active sketch",                 {} },
-    { "step-rotate",     Command::GROUP_ROT,      "New group step and repeat rotating",               {} },
     { "step-translate",  Command::GROUP_TRANS,    "New group step and repeat translating",            {} },
+    { "step-rotate",     Command::GROUP_ROT,      "New group step and repeat rotating",               {} },
     { "sketch-in-plane", Command::GROUP_WRKPL,    "New group in new workplane (thru given entities)", {} },
     { "sketch-in-3d",    Command::GROUP_3D,       "New group in 3d",                                  {} },
     { "assemble",        Command::GROUP_LINK,     "New group linking / assembling file",              {} },


### PR DESCRIPTION
1) under "Extrude" must be "Step translate"
2) under "Lathe" must be "Step rotate"