### PR TITLE
if DOF > 0, indicate in group list

### DIFF
--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -107,6 +107,9 @@ void TextWindow::ShowListOfGroups() {
         bool shown = g->visible;
         bool ok = g->IsSolvedOkay();
         bool ref = (g->h.v == Group::HGROUP_REFERENCES.v);
+	bool no_dof = !g->solved.dof;
+	char dof[3] = { 'D', g->solved.dof > 9 ? '+' :
+	    (char) ('0' + g->solved.dof), 0 };
         Printf(false, "%Bp%Fd "
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
@@ -123,8 +126,9 @@ void TextWindow::ShowListOfGroups() {
                 g->h.v, (&TextWindow::ScreenToggleGroupShown),
                 afterActive ? "" : (shown ? checkTrue : checkFalse),
             // Link to the errors, if a problem occured while solving
-            ok ? 's' : 'x', g->h.v, (&TextWindow::ScreenHowGroupSolved),
-                ok ? "ok" : "",
+            ok ? no_dof ? 's' : 'm' : 'x', g->h.v,
+		(&TextWindow::ScreenHowGroupSolved),
+                ok ? no_dof ? "ok" : dof : "",
                 ok ? "" : "NO",
             // Link to a screen that gives more details on the group
             g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str());


### PR DESCRIPTION
This should help to have a better overview of which groups need some DOF cleanup:
When a group's status would be "ok" (green), but it has > 0 DOF, then show "Dn" (yellow), where "n" is the number of DOF.
If the number is greater that nine, "D+" is shown.

Obligatory screenshot:
![show-dof](https://cloud.githubusercontent.com/assets/1292352/22842872/a6b9df1e-efb5-11e6-8668-1ed03a81d722.png)
