### PR TITLE
"ok" is not always okay

### DIFF
--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -110,6 +110,17 @@ void TextWindow::ShowListOfGroups() {
 	bool no_dof = !g->solved.dof;
 	char dof[3] = { 'D', g->solved.dof > 9 ? '+' :
 	    (char) ('0' + g->solved.dof), 0 };
+	char status_color = 's';	// all is well
+
+	if (!ok) {
+		status_color = 'x';	// "serious" error
+	} else if (!no_dof) {
+		status_color = 'm';	// dangling DOF
+	} else if (g->polyError.how != PolyError::GOOD &&
+	    g->type == Group::Type::DRAWING_WORKPLANE) {
+		// logic above follows Group::DrawPolyError
+		status_color = 'm';	// minor issue
+	}
         Printf(false, "%Bp%Fd "
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
@@ -126,7 +137,7 @@ void TextWindow::ShowListOfGroups() {
                 g->h.v, (&TextWindow::ScreenToggleGroupShown),
                 afterActive ? "" : (shown ? checkTrue : checkFalse),
             // Link to the errors, if a problem occured while solving
-            ok ? no_dof ? 's' : 'm' : 'x', g->h.v,
+	        status_color, g->h.v,
 		(&TextWindow::ScreenHowGroupSolved),
                 ok ? no_dof ? "ok" : dof : "",
                 ok ? "" : "NO",

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -107,6 +107,9 @@ void TextWindow::ShowListOfGroups() {
         bool shown = g->visible;
         bool ok = g->IsSolvedOkay();
         bool ref = (g->h.v == Group::HGROUP_REFERENCES.v);
+	bool no_dof = !g->solved.dof;
+	char dof[3] = { 'D', g->solved.dof > 9 ? '+' :
+	    (char) ('0' + g->solved.dof), 0 };
         Printf(false, "%Bp%Fd "
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
@@ -123,8 +126,9 @@ void TextWindow::ShowListOfGroups() {
                 g->h.v, (&TextWindow::ScreenToggleGroupShown),
                 afterActive ? "" : (shown ? checkTrue : checkFalse),
             // Link to the errors, if a problem occured while solving
-            ok ? 's' : 'x', g->h.v, (&TextWindow::ScreenHowGroupSolved),
-                ok ? "ok" : "",
+            ok ? no_dof ? 's' : 'm' : 'x', g->h.v,
+		(&TextWindow::ScreenHowGroupSolved),
+                ok ? no_dof ? "ok" : dof : "",
                 ok ? "" : "NO",
             // Link to a screen that gives more details on the group
             g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str());


### PR DESCRIPTION
A sketch may contain errors that cause later groups to fail, but the group list still says that everything is "ok". Here is an example:

[not-okay.zip](https://github.com/solvespace/solvespace/files/769622/not-okay.zip)

g004-extrude is based on the outline in g003-sk-outline, which in turn uses geometry from g002-sk-bad-influence.

- select g002-sk-bad-influence, change c00a-pt-pt-distance to REF, drag the right point to the left of the left point.
- activate g004-extrude. The extrusion is now a mess, because g003 has become self-intersecting. But the group list still shows a reassuringly green "ok".

With this commit, the "ok" of a group containing a sketch with problems will be shown in yellow:
![not-ok-example](https://cloud.githubusercontent.com/assets/1292352/22866005/8da9a92a-f14d-11e6-92d6-cf0c98d45609.png)

Note that this commit touches the same area a my previous DOF indication changed. Since each makes the color selection a little more complicated, I disentangled it here.

Addendum: the "ok" may not turn yellow immediate. E.g., in the above example, it remains green until the group is recalculated, which doesn't happen automatically/immediately in this case.