### PR TITLE
Decorate GtkEntry fields with CSS to ensure that they are visible

### DIFF
--- a/src/platform/gtkmain.cpp
+++ b/src/platform/gtkmain.cpp
@@ -17,6 +17,7 @@
 #include <glibmm/convert.h>
 #include <giomm/file.h>
 #include <gdkmm/cursor.h>
+#include <gtkmm/cssprovider.h>
 #include <gtkmm/drawingarea.h>
 #include <gtkmm/glarea.h>
 #include <gtkmm/scrollbar.h>
@@ -1409,6 +1410,19 @@ int main(int argc, char** argv) {
     gtk_disable_setlocale();
 
     Gtk::Main main(argc, argv);
+
+    // Add our application-specific styles, to override GTK defaults.
+    Glib::RefPtr<Gtk::CssProvider> style_provider = Gtk::CssProvider::create();
+    style_provider->load_from_data(R"(
+      entry {
+        background: black;
+        color: white;
+        font-size: 12px;
+      }
+    )");
+    Gtk::StyleContext::add_provider_for_screen(Gdk::Screen::get_default(),
+                                               style_provider,
+                                               600 /*Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION*/);
 
 #ifdef HAVE_SPACEWARE
     gdk_window_add_filter(NULL, GdkSpnavFilter, NULL);


### PR DESCRIPTION
The code is based on [this patch](https://github.com/solvespace/solvespace/issues/184#issuecomment-277509013), I only changed CSS code.

Before:
![before](https://cloud.githubusercontent.com/assets/1071872/24083143/b346eae6-0cda-11e7-894c-e9ff8286a6b4.png)
After:
![after](https://cloud.githubusercontent.com/assets/1071872/24083144/bc99ee40-0cda-11e7-9c6d-032c80037389.png)
