### PR TITLE
Update README.md with caveats building Solvespace on 16.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ is built as `build/bin/solvespace-cli.exe`.
 
 Space Navigator support will not be available.
 
+If using Ubuntu 16.04 LTS (Xenial Xerus), the `mingw-w64` package provided by the distribution
+will not have headers new enough to build ANGLE successfully. However, the `mingw-w64` package
+from 17.10 (Artful Aardvark) is known to work. This can be installed by downloading
+the `mingw-w64` deb from [artful](https://packages.ubuntu.com/artful/all/mingw-w64/download) and
+running the following command: `sudo dpkg -i /path/to/mingw-w64_5.0.2-2_all.deb`.
+
+If one does not wish to install the entirity of `mingw-w64`, the following packages must
+be upgraded using instructions similar to the above:
+
+* `gcc-mingw-w64-base` 
+* `gcc-mingw-w64-{i686, x86-64}`
+* `g++-mingw-w64-{i686, x86-64}`
+* `mingw-w64-common`
+* `mingw-w64-{i686, x86-64}-dev`
+
 Building on macOS
 -----------------
 


### PR DESCRIPTION
As you probably saw in IRC today/recently, I had some difficulties building Solvespace, even cross-compiling from Linux. It turns out the mingw-w64 package provided by default is too old.

I'm certain many people use Ubuntu 16.04 (or 14.04) LTS, so I've provided some instructions on how to build on LTS distros in the README.md to save others some moderate frustration. All upgraded packages do not depend on any newer libraries than those already provided by 16.04 by default (can't speak for 14.04).