### PR TITLE
Updating dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ Building on Linux
 
 ### Building for Linux
 
-You will need CMake, libpng, zlib, json-c, fontconfig, freetype, gtkmm 2.4,
+You will need CMake, libpng, zlib, json-c, fontconfig, freetype, gtkmm 3.0, x11,
 pangomm 1.4, OpenGL, OpenGL GLU and OpenGL GLEW, and optionally, the Space Navigator
 client library.
 On a Debian derivative (e.g. Ubuntu) these can be installed with:
 
-    apt-get install libpng12-dev libjson-c-dev libfreetype6-dev \
-                    libfontconfig1-dev libgtkmm-2.4-dev libpangomm-1.4-dev \
+    apt-get install libpng12-dev libjson-c-dev libfreetype6-dev libx11-dev \
+                    libfontconfig1-dev libgtkmm-3.0-dev libpangomm-1.4-dev \
                     libgl-dev libglu-dev libglew-dev libspnav-dev cmake
 
 Before building, check out the necessary submodules:
 
-    git submodule update --init extlib/libdxfrw
+    git submodule update --init
 
 After that, build SolveSpace as following:
 


### PR DESCRIPTION
`libgtkmm` is wrong version is `x11` is missing from the packages to install. All git submodules were needed on my system (or at least more than just `libdxfrw`.)

Might also want to mention in the README that the repo should be cloned, not downloaded from the downloads page, but I'll leave that to someone else.