### PR TITLE
Yet another Show DOF in text window

### DIFF
--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -97,7 +97,7 @@ void TextWindow::ShowListOfGroups() {
                *checkFalse = " " CHECK_FALSE " ";
 
     Printf(true, "%Ft active");
-    Printf(false, "%Ft    shown ok  group-name%E");
+    Printf(false, "%Ft    shown dof group-name%E");
     int i;
     bool afterActive = false;
     for(i = 0; i < SK.groupOrder.n; i++) {
@@ -106,11 +106,20 @@ void TextWindow::ShowListOfGroups() {
         bool active = (g->h.v == SS.GW.activeGroup.v);
         bool shown = g->visible;
         bool ok = g->IsSolvedOkay();
+        int dof = g->solved.dof;
+        char sdof[16] = "ok ";
+        if(ok && dof > 0) {
+            if(dof > 999) {
+              strcpy(sdof, "###");
+            } else {
+              sprintf(sdof, "%3d", dof);
+            }
+        }
         bool ref = (g->h.v == Group::HGROUP_REFERENCES.v);
         Printf(false, "%Bp%Fd "
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
-               "%Fp%D%f%s%Ll%s%E  "
+               "%Fp%D%f%s%Ll%s%E "
                "%Fl%Ll%D%f%s",
             // Alternate between light and dark backgrounds, for readability
                 (i & 1) ? 'd' : 'a',
@@ -123,9 +132,9 @@ void TextWindow::ShowListOfGroups() {
                 g->h.v, (&TextWindow::ScreenToggleGroupShown),
                 afterActive ? "" : (shown ? checkTrue : checkFalse),
             // Link to the errors, if a problem occured while solving
-            ok ? 's' : 'x', g->h.v, (&TextWindow::ScreenHowGroupSolved),
-                ok ? "ok" : "",
-                ok ? "" : "NO",
+            ok ? (dof > 0 ? 'i' : 's') : 'x', g->h.v, (&TextWindow::ScreenHowGroupSolved),
+                ok ? sdof : "",
+                ok ? "" : "ERR",
             // Link to a screen that gives more details on the group
             g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str());
 

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -133,7 +133,7 @@ void TextWindow::ShowListOfGroups() {
                 afterActive ? " - " : "",
                 g->h.v, (&TextWindow::ScreenToggleGroupShown),
                 afterActive ? "" : (shown ? checkTrue : checkFalse),
-            // Link to the errors, if a problem occured while solving
+            // Link to the errors, if a problem occurred while solving
             ok ? (dof > 0 ? 'i' : 's') : 'x', g->h.v, (&TextWindow::ScreenHowGroupSolved),
                 ok ? sdof.c_str() : "",
                 ok ? "" : "ERR",

--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -189,25 +189,27 @@ static Button *buttons[] = {
     &occludedLinesButton,
 };
 
+/** Foreground color codes. */
 const TextWindow::Color TextWindow::fgColors[] = {
-    { 'd', RGBi(255, 255, 255) },
+    { 'd', RGBi(255, 255, 255) },  // Default   : white
     { 'l', RGBi(100, 100, 255) },
     { 't', RGBi(255, 200,   0) },
     { 'h', RGBi( 90,  90,  90) },
-    { 's', RGBi( 40, 255,  40) },
+    { 's', RGBi( 40, 255,  40) },  // Ok        : green
     { 'm', RGBi(200, 200,   0) },
-    { 'r', RGBi(  0,   0,   0) },
-    { 'x', RGBi(255,  20,  20) },
-    { 'i', RGBi(  0, 255, 255) },
+    { 'r', RGBi(  0,   0,   0) },  // Reverse   : black
+    { 'x', RGBi(255,  20,  20) },  // Error     : red
+    { 'i', RGBi(  0, 255, 255) },  // Info      : cyan
     { 'g', RGBi(160, 160, 160) },
     { 'b', RGBi(200, 200, 200) },
     { 0,   RGBi(  0,   0,   0) }
 };
+/** Background color codes. */
 const TextWindow::Color TextWindow::bgColors[] = {
-    { 'd', RGBi(  0,   0,   0) },
+    { 'd', RGBi(  0,   0,   0) },  // Default   : black
     { 't', RGBi( 34,  15,  15) },
-    { 'a', RGBi( 25,  25,  25) },
-    { 'r', RGBi(255, 255, 255) },
+    { 'a', RGBi( 25,  25,  25) },  // Alternate : dark gray
+    { 'r', RGBi(255, 255, 255) },  // Reverse   : white
     { 0,   RGBi(  0,   0,   0) }
 };
 


### PR DESCRIPTION
Shows the group's DOF in the group list. The ok-column is changed into a dof-column. It shows 'ERR' when there is an error, 'ok' when DOF==0, '###' if DOF>999, and otherwise the DOF itself.

Compared to other patches: 
- #200: uses 'D2' instead of 'ok' to show the DOF. If DOF>9 shows 'D+'.
- #204: leaves the ok-column as is and adds a separate dof-column.