### PR TITLE
Misc. trivial typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ std::string SolveSpace::Dirname(std::string filename) {
 Debugging code
 --------------
 
-SolveSpace releases are throughly tested but sometimes they contain crash
+SolveSpace releases are thoroughly tested but sometimes they contain crash
 bugs anyway. The reason for such crashes can be determined only if the executable
 was built with debug information.
 

--- a/cmake/FindVendoredPackage.cmake
+++ b/cmake/FindVendoredPackage.cmake
@@ -6,7 +6,7 @@
 #
 # The rest of the arguments are VARIABLE VALUE pairs. If the library is not found,
 # every VARIABLE will be set to VALUE and find_package will be rerun with the REQUIRED flag.
-# Regardless of where the library was found, only the specfied VARIABLEs that start with
+# Regardless of where the library was found, only the specified VARIABLEs that start with
 # ${PKG_NAME} will be set in the parent scope.
 #
 # All warnings in the in-tree package are disabled.

--- a/exposed/DOC.txt
+++ b/exposed/DOC.txt
@@ -456,7 +456,7 @@ USING THE SOLVER
 ================
 
 The solver is provided as a DLL, and will be usable with most
-Windows-based developement tools. Examples are provided:
+Windows-based development tools. Examples are provided:
 
     in C/C++        - CDemo.c
 

--- a/exposed/VbDemo.vb
+++ b/exposed/VbDemo.vb
@@ -606,7 +606,7 @@ Module VbDemo
         End Function
 
         ' After a failing call to Solve(), this returns the list of
-        ' constraints, identified by ther handle, that would fix the
+        ' constraints, identified by their handle, that would fix the
         ' system if they were deleted. This list will be populated only
         ' if calculateFaileds is True in the Solve() call.
         Public Function GetFaileds() As List(Of UInteger)

--- a/res/locales/en_US.po
+++ b/res/locales/en_US.po
@@ -1475,8 +1475,8 @@ msgid "Don't Save"
 msgstr "Don't Save"
 
 #: platform/cocoamain.mm:880
-msgid "An autosave file is availible for this project."
-msgstr "An autosave file is availible for this project."
+msgid "An autosave file is available for this project."
+msgstr "An autosave file is available for this project."
 
 #: platform/cocoamain.mm:882
 msgid "Do you want to load the autosave file instead?"
@@ -1574,11 +1574,11 @@ msgstr "Do_n't Save"
 
 #: platform/gtkmain.cpp:1066 platform/w32main.cpp:1193
 msgid ""
-"An autosave file is availible for this project.\n"
+"An autosave file is available for this project.\n"
 "\n"
 "Do you want to load the autosave file instead?"
 msgstr ""
-"An autosave file is availible for this project.\n"
+"An autosave file is available for this project.\n"
 "\n"
 "Do you want to load the autosave file instead?"
 

--- a/res/locales/ru_RU.po
+++ b/res/locales/ru_RU.po
@@ -1506,7 +1506,7 @@ msgid "Don't Save"
 msgstr "Не Сохранять"
 
 #: platform/cocoamain.mm:880
-msgid "An autosave file is availible for this project."
+msgid "An autosave file is available for this project."
 msgstr "Файлы автосохранения доступны для данного проекта."
 
 #: platform/cocoamain.mm:882
@@ -1605,7 +1605,7 @@ msgstr "Не Сохранять"
 
 #: platform/gtkmain.cpp:1066 platform/w32main.cpp:1193
 msgid ""
-"An autosave file is availible for this project.\n"
+"An autosave file is available for this project.\n"
 "\n"
 "Do you want to load the autosave file instead?"
 msgstr ""

--- a/res/locales/uk_UA.po
+++ b/res/locales/uk_UA.po
@@ -1314,7 +1314,7 @@ msgid "Don't Save"
 msgstr ""
 
 #: platform/cocoamain.mm:880
-msgid "An autosave file is availible for this project."
+msgid "An autosave file is available for this project."
 msgstr ""
 
 #: platform/cocoamain.mm:882
@@ -1407,7 +1407,7 @@ msgstr ""
 
 #: platform/gtkmain.cpp:1066 platform/w32main.cpp:1193
 msgid ""
-"An autosave file is availible for this project.\n"
+"An autosave file is available for this project.\n"
 "\n"
 "Do you want to load the autosave file instead?"
 msgstr ""

--- a/res/shaders/edge.frag
+++ b/res/shaders/edge.frag
@@ -27,7 +27,7 @@ void main() {
     // perform antialising
     float k = smoothstep(1.0 - 2.0 * feather * pixel / (width + feather * pixel), 1.0, abs(dist));
 
-    // perfrom alpha-test
+    // perform alpha-test
     if(k == 1.0) discard;
 
     // write resulting color

--- a/src/exportvector.cpp
+++ b/src/exportvector.cpp
@@ -279,7 +279,7 @@ public:
 
                         ref = pi.Plus(bisect.WithMagnitude(c->disp.offset.Magnitude()));
 
-                        // Get lines agian to write exact line.
+                        // Get lines again to write exact line.
                         a0 = a->VectorGetStartPoint();
                         b0 = b->VectorGetStartPoint();
                         da = a->VectorGetNum();
@@ -439,7 +439,7 @@ public:
             // Rational bezier
             // We'd like to export rational beziers exactly, but the resulting DXF
             // files can only be read by AutoCAD; LibreCAD/QCad simply do not
-            // implement the feature. So, export as piecewise linear for compatiblity.
+            // implement the feature. So, export as piecewise linear for compatibility.
             writeBezierAsPwl(sb);
         } else {
             // Any other curve

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -341,7 +341,7 @@ void GraphicsWindow::LoopOverPoints(const std::vector<Entity *> &entities,
                 HandlePointForZoomToFit(p, pmax, pmin, wmin, usePerspective);
             }
         } else {
-            // We have to iterate children points, because we can select entites without points
+            // We have to iterate children points, because we can select entities without points
             for(int i = 0; i < MAX_POINTS_IN_ENTITY; i++) {
                 if(e->point[i].v == 0) break;
                 Vector p = SK.GetEntity(e->point[i])->PointGetNum();

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -321,7 +321,7 @@ void Group::TransformImportedBy(Vector t, Quaternion q) {
 bool Group::IsForcedToMeshBySource() const {
     const Group *srcg = this;
     if(type == Type::TRANSLATE || type == Type::ROTATE) {
-        // A step and repeat gets merged against the group's prevous group,
+        // A step and repeat gets merged against the group's previous group,
         // not our own previous group.
         srcg = SK.GetGroup(opA);
         if(srcg->forceToMesh) return true;

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -199,7 +199,7 @@ void Group::GenerateShellAndMesh() {
     }
 
     if(type == Type::TRANSLATE || type == Type::ROTATE) {
-        // A step and repeat gets merged against the group's prevous group,
+        // A step and repeat gets merged against the group's previous group,
         // not our own previous group.
         srcg = SK.GetGroup(opA);
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -849,7 +849,7 @@ void SKdNode::FindEdgeOn(Vector a, Vector b, int cnt, bool coplanarIsInter,
             }
             // Record the triangle
             info->tr = tr;
-            // And record which vertexes a and b correspond to
+            // And record which vertices a and b correspond to
             info->ai = a.Equals(tr->a) ? 0 : (a.Equals(tr->b) ? 1 : 2);
             info->bi = b.Equals(tr->a) ? 0 : (b.Equals(tr->b) ? 1 : 2);
         } else if(((a.Equals(tr->a) && b.Equals(tr->b)) ||

--- a/src/platform/cocoamain.mm
+++ b/src/platform/cocoamain.mm
@@ -877,7 +877,7 @@ SolveSpace::DialogChoice SolveSpace::SaveFileYesNoCancel() {
 SolveSpace::DialogChoice SolveSpace::LoadAutosaveYesNo() {
     NSAlert *alert = [[NSAlert alloc] init];
     [alert setMessageText:
-        Wrap(_("An autosave file is availible for this project."))];
+        Wrap(_("An autosave file is available for this project."))];
     [alert setInformativeText:
         Wrap(_("Do you want to load the autosave file instead?"))];
     [alert addButtonWithTitle:Wrap(C_("button", "Load"))];

--- a/src/platform/gtkmain.cpp
+++ b/src/platform/gtkmain.cpp
@@ -1063,7 +1063,7 @@ DialogChoice SaveFileYesNoCancel(void) {
 
 DialogChoice LoadAutosaveYesNo(void) {
     Glib::ustring message =
-        _("An autosave file is availible for this project.\n\n"
+        _("An autosave file is available for this project.\n\n"
           "Do you want to load the autosave file instead?");
     Gtk::MessageDialog dialog(*GW, message, /*use_markup*/ true, Gtk::MESSAGE_QUESTION,
                               Gtk::BUTTONS_NONE, /*is_modal*/ true);

--- a/src/platform/w32main.cpp
+++ b/src/platform/w32main.cpp
@@ -1190,7 +1190,7 @@ DialogChoice SolveSpace::LoadAutosaveYesNo()
     EnableWindow(TextWnd, false);
 
     int r = MessageBoxW(GraphicsWnd,
-        Widen(_("An autosave file is availible for this project.\n\n"
+        Widen(_("An autosave file is available for this project.\n\n"
                 "Do you want to load the autosave file instead?")).c_str(),
         Title(C_("title", "Autosave Available")).c_str(),
         MB_YESNO | MB_ICONWARNING);
@@ -1395,7 +1395,7 @@ static void CreateMainWindows()
         WS_CHILD | ES_AUTOHSCROLL | WS_TABSTOP | WS_CLIPSIBLINGS,
         50, 50, 100, 21, GraphicsWnd, NULL, Instance, NULL);
 
-    // The text window, with a comand line and some textual information
+    // The text window, with a command line and some textual information
     // about the sketch.
     wc.style           &= ~CS_DBLCLKS;
     wc.lpfnWndProc      = (WNDPROC)TextWndProc;

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -145,7 +145,7 @@ bool SEdge::EdgeCrosses(Vector ea, Vector eb, Vector *ppi, SPointList *spl) cons
     if(sqrt(fabs(d.Dot(dthis))) > (m - LENGTH_EPS)) {
         // The edges are parallel.
         if(fabs(a.DistanceToLine(ea, d)) > LENGTH_EPS) {
-            // and not coincident, so can't be interesecting
+            // and not coincident, so can't be intersecting
             return false;
         }
         // The edges are coincident. Make sure that neither endpoint lies

--- a/src/render/gl3shader.cpp
+++ b/src/render/gl3shader.cpp
@@ -9,7 +9,7 @@
 namespace SolveSpace {
 
 //-----------------------------------------------------------------------------
-// Floating point data sturctures
+// Floating point data structures
 //-----------------------------------------------------------------------------
 
 Vector2f Vector2f::From(float x, float y) {

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -122,7 +122,7 @@ void TextWindow::ShowListOfGroups() {
                 afterActive ? " - " : "",
                 g->h.v, (&TextWindow::ScreenToggleGroupShown),
                 afterActive ? "" : (shown ? checkTrue : checkFalse),
-            // Link to the errors, if a problem occured while solving
+            // Link to the errors, if a problem occurred while solving
             ok ? 's' : 'x', g->h.v, (&TextWindow::ScreenHowGroupSolved),
                 ok ? "ok" : "",
                 ok ? "" : "NO",
@@ -191,7 +191,7 @@ void TextWindow::ScreenChangeGroupOption(int link, uint32_t v) {
             if(g->type == Group::Type::EXTRUDE) {
                 // When an extrude group is first created, it's positioned for a union
                 // extrusion. If no constraints were added, flip it when we switch between
-                // union and difference modes to avoid manual work doing the smae.
+                // union and difference modes to avoid manual work doing the same.
                 if(g->meshCombine != (Group::CombineAs)v && g->GetNumConstraints() == 0 &&
                         ((Group::CombineAs)v == Group::CombineAs::DIFFERENCE ||
                         g->meshCombine == Group::CombineAs::DIFFERENCE)) {


### PR DESCRIPTION
A few user-facing. Most are trvial source comment typos. Found using `codespell -q 3 --skip=".po,*.pot"`