### PR TITLE
Add a linker option to work around the stack overflow on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,9 @@ if(MSVC)
     # We rely on these /we flags. They correspond to the GNU-style flags below as
     # follows: /w4062=-Wswitch
     set(WARNING_FLAGS   "${WARNING_FLAGS} /we4062")
+
+    # Needed to avoid crash on start with VS2017, etc.
+    set(CMAKE_EXE_LINKER_FLAGS "/STACK:33554432 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
This was needed to successfully run a build from VS2017. This is basically just putting the patch from #92 into a convenient place in the build system and making a pull request.