### PR TITLE
Small optimization to Vector::Equals to improve performance.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -429,11 +429,12 @@ double Vector::Element(int i) const {
 
 bool Vector::Equals(Vector v, double tol) const {
     // Quick axis-aligned tests before going further
-    double dx = v.x - x; if(dx < -tol || dx > tol) return false;
-    double dy = v.y - y; if(dy < -tol || dy > tol) return false;
-    double dz = v.z - z; if(dz < -tol || dz > tol) return false;
+    const Vector dv = this->Minus(v);
+    if (std::abs(dv.x) > tol) return false;
+    if (std::abs(dv.y) > tol) return false;
+    if (std::abs(dv.z) > tol) return false;
 
-    return (this->Minus(v)).MagSquared() < tol*tol;
+    return dv.MagSquared() < tol*tol;
 }
 
 bool Vector::EqualsExactly(Vector v) const {


### PR DESCRIPTION
This (as well as some other unexpected locations, like https://github.com/solvespace/solvespace/blob/c6fc0125a21aa27f89ab6e0bb16037f04bc39fd4/src/polygon.cpp#L23 and https://github.com/solvespace/solvespace/blob/c6fc0125a21aa27f89ab6e0bb16037f04bc39fd4/src/util.cpp#L587 ) showed up as a substantial hot-spot when I ran the VS CPU profiler in VS2017 on an x64 build of the latest master, looking at time periods when the GUI was non-responsive and SolveSpace was consuming a full core of CPU "doing something".

This is a fairly small change, but it seemed to improve the profiling results here. I imagine there are further ways to do this, or better ways (do we have profiling data that the early-outs actually improve performance? since this is "inner-loop" code essentially - they might just be extra pain for the branch predictor...), so please do perform your own verification of whether this improves perf for you before merging.