### PR TITLE
Fix GIT_COMMIT_HASH to autoset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,13 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE_CXX
 # NOTE TO PACKAGERS: The embedded git commit hash is critical for rapid bug triage when the builds
 # can come from a variety of sources. If you are mirroring the sources or otherwise build when
 # the .git directory is not present, please comment the following line:
-include(GetGitCommitHash)
 # and instead uncomment the following, adding the complete git hash of the checkout you are using:
 # set(GIT_COMMIT_HASH 0000000000000000000000000000000000000000)
+if (EXISTS ".git/") 
+    include(GetGitCommitHash)
+else() 
+    set(GIT_COMMIT_HASH 0000000000000000000000000000000000000000)
+endif()
 
 project(solvespace)
 set(solvespace_VERSION_MAJOR 3)


### PR DESCRIPTION
When build from git, GIT_COMMIT_HASH set to correct value.
When build from tarball, GIT_COMMIT_HASH set to 000000 as recommended