### PR TITLE
Import styles from linked sketches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Bugs fixed:
   * Paste Transformed with a negative scale does not invert arcs.
   * The tangent arc now modifies the original entities instead of deleting
     them, such that their constraints are retained.
+  * When linking a sketch file, missing custom styles are now imported from 
+    the linked file.
 
 2.x
 ---

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -732,7 +732,13 @@ bool SolveSpaceUI::LoadEntitiesFromFile(const Platform::Path &filename, EntityLi
         } else if(strcmp(line, "AddConstraint")==0) {
 
         } else if(strcmp(line, "AddStyle")==0) {
-
+            // Linked file contains a style that we don't have yet,
+            // so import it.
+            if (SK.style.FindByIdNoOops(sv.s.h) == nullptr) {
+                SK.style.Add(&(sv.s));
+            }
+            sv.s = {};
+            Style::FillDefaultStyle(&sv.s);
         } else if(strcmp(line, VERSION_STRING)==0) {
 
         } else if(StrStartsWith(line, "Triangle ")) {


### PR DESCRIPTION
When a sketch that contains no custom styles links a sketch that does contain a custom style, a new custom style is created with the default format. This patch changes that and creates a new style with the same format as in the linked file.