### PR TITLE
Implement Q3DO export

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,9 @@
 [submodule "extlib/angle"]
 	path = extlib/angle
 	url = https://github.com/solvespace/angle
+[submodule "extlib/flatbuffers"]
+	path = extlib/flatbuffers
+	url = https://github.com/google/flatbuffers
+[submodule "extlib/q3d"]
+	path = extlib/q3d
+	url = https://github.com/q3k/q3d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ New export/import features:
   * Wavefront OBJ: a material file is exported alongside the model, containing
     mesh color information.
   * DXF/DWG: 3D DXF files are imported as construction entities, in 3d.
+  * Q3D: [Q3D](https://github.com/q3k/q3d/) triangle meshes can now be
+    exported. This format allows to easily hack on triangle mesh data created
+    in SolveSpace, supports colour information and is more space efficient than
+    most other formats.
 
 New rendering features:
   * The "Show/hide hidden lines" button is now a tri-state button that allows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,20 +307,6 @@ add_subdirectory(extlib/flatbuffers
                  ${CMAKE_CURRENT_BINARY_DIR}/extlib/flatbuffers
                  EXCLUDE_FROM_ALL)
 
-# Buld Q3D header file from schema
-set(q3d_schema ${CMAKE_CURRENT_SOURCE_DIR}/extlib/q3d/object.fbs)
-set(q3d_outdir ${CMAKE_CURRENT_BINARY_DIR}/extlib/q3d)
-set(q3d_header ${q3d_outdir}/object_generated.h)
-
-add_custom_command(
-    OUTPUT ${q3d_header}
-    COMMAND $<TARGET_FILE:flatc> --cpp --no-includes -o ${q3d_outdir}
-            ${q3d_schema}
-    DEPENDS flatc)
-
-add_custom_target(gen_q3d_header DEPENDS ${q3d_header})
-set(Q3D_INCLUDE_DIR ${q3d_outdir})
-
 # application components
 
 add_subdirectory(res)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,6 @@ set(ENABLE_COVERAGE   OFF CACHE BOOL
     "Whether code coverage information will be collected")
 set(ENABLE_SANITIZERS OFF CACHE BOOL
     "Whether to enable Clang's AddressSanitizer and UndefinedBehaviorSanitizer")
-set(ENABLE_Q3D        ON CACHE BOOL
-    "Whether to enable Q3D file export")
 
 set(OPENGL 3 CACHE STRING "OpenGL version to use (one of: 1 3)")
 
@@ -300,28 +298,28 @@ if(ENABLE_COVERAGE)
     set(COVERAGE_LIBRARY --coverage)
 endif()
 
-if(ENABLE_Q3D)
-    set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "")
-    set(FLATBUFFERS_BUILD_FLATC ON CACHE BOOL "")
-    set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "")
-    set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "")
-    add_subdirectory(extlib/flatbuffers
-                     ${CMAKE_CURRENT_BINARY_DIR}/extlib/flatbuffers
-                     EXCLUDE_FROM_ALL)
+# FlatBuffers
+set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "")
+set(FLATBUFFERS_BUILD_FLATC ON CACHE BOOL "")
+set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "")
+set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "")
+add_subdirectory(extlib/flatbuffers
+                 ${CMAKE_CURRENT_BINARY_DIR}/extlib/flatbuffers
+                 EXCLUDE_FROM_ALL)
 
-    set(q3d_schema ${CMAKE_CURRENT_SOURCE_DIR}/extlib/q3d/object.fbs)
-    set(q3d_outdir ${CMAKE_CURRENT_BINARY_DIR}/extlib/q3d)
-    set(q3d_header ${q3d_outdir}/object_generated.h)
+# Buld Q3D header file from schema
+set(q3d_schema ${CMAKE_CURRENT_SOURCE_DIR}/extlib/q3d/object.fbs)
+set(q3d_outdir ${CMAKE_CURRENT_BINARY_DIR}/extlib/q3d)
+set(q3d_header ${q3d_outdir}/object_generated.h)
 
-    add_custom_command(
-        OUTPUT ${q3d_header}
-        COMMAND $<TARGET_FILE:flatc> --cpp --no-includes -o ${q3d_outdir}
-                ${q3d_schema}
-        DEPENDS flatc)
+add_custom_command(
+    OUTPUT ${q3d_header}
+    COMMAND $<TARGET_FILE:flatc> --cpp --no-includes -o ${q3d_outdir}
+            ${q3d_schema}
+    DEPENDS flatc)
 
-    add_custom_target(gen_q3d_header DEPENDS ${q3d_header})
-    set(Q3D_INCLUDE_DIR ${q3d_outdir})
-endif()
+add_custom_target(gen_q3d_header DEPENDS ${q3d_header})
+set(Q3D_INCLUDE_DIR ${q3d_outdir})
 
 # application components
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ set(ENABLE_COVERAGE   OFF CACHE BOOL
     "Whether code coverage information will be collected")
 set(ENABLE_SANITIZERS OFF CACHE BOOL
     "Whether to enable Clang's AddressSanitizer and UndefinedBehaviorSanitizer")
+set(ENABLE_Q3D        ON CACHE BOOL
+    "Whether to enable Q3D file export")
 
 set(OPENGL 3 CACHE STRING "OpenGL version to use (one of: 1 3)")
 
@@ -296,6 +298,29 @@ if(ENABLE_COVERAGE)
     # this is not useful for us.
     set(COVERAGE_FLAGS -fno-exceptions --coverage)
     set(COVERAGE_LIBRARY --coverage)
+endif()
+
+if(ENABLE_Q3D)
+    set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "")
+    set(FLATBUFFERS_BUILD_FLATC ON CACHE BOOL "")
+    set(FLATBUFFERS_BUILD_FLATHASH OFF CACHE BOOL "")
+    set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "")
+    add_subdirectory(extlib/flatbuffers
+                     ${CMAKE_CURRENT_BINARY_DIR}/extlib/flatbuffers
+                     EXCLUDE_FROM_ALL)
+
+    set(q3d_schema ${CMAKE_CURRENT_SOURCE_DIR}/extlib/q3d/object.fbs)
+    set(q3d_outdir ${CMAKE_CURRENT_BINARY_DIR}/extlib/q3d)
+    set(q3d_header ${q3d_outdir}/object_generated.h)
+
+    add_custom_command(
+        OUTPUT ${q3d_header}
+        COMMAND $<TARGET_FILE:flatc> --cpp --no-includes -o ${q3d_outdir}
+                ${q3d_schema}
+        DEPENDS flatc)
+
+    add_custom_target(gen_q3d_header DEPENDS ${q3d_header})
+    set(Q3D_INCLUDE_DIR ${q3d_outdir})
 endif()
 
 # application components

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,8 +79,7 @@ include_directories(
     ${ZLIB_INCLUDE_DIR}
     ${PNG_PNG_INCLUDE_DIR}
     ${FREETYPE_INCLUDE_DIRS}
-    ${CAIRO_INCLUDE_DIRS}
-    ${Q3D_INCLUDE_DIR})
+    ${CAIRO_INCLUDE_DIRS})
 
 if(Backtrace_FOUND)
     include_directories(
@@ -212,7 +211,11 @@ add_library(solvespace-core STATIC
     ${solvespace_core_HEADERS}
     ${solvespace_core_SOURCES})
 
-add_dependencies(solvespace-core gen_q3d_header)
+
+set(Q3D_HEADER_DIR ${CMAKE_BINARY_DIR}/extlib/q3d)
+add_subdirectory(${CMAKE_SOURCE_DIR}/extlib/q3d ${CMAKE_BINARY_DIR}/extlib/q3d)
+add_dependencies(solvespace-core q3d_header)
+include_directories(${Q3D_HEADER_DIR})
 
 target_link_libraries(solvespace-core
     dxfrw

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,6 @@ endif()
 
 set(HAVE_SPACEWARE ${SPACEWARE_FOUND})
 
-set(HAVE_Q3D ${ENABLE_Q3D})
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
@@ -81,7 +79,8 @@ include_directories(
     ${ZLIB_INCLUDE_DIR}
     ${PNG_PNG_INCLUDE_DIR}
     ${FREETYPE_INCLUDE_DIRS}
-    ${CAIRO_INCLUDE_DIRS})
+    ${CAIRO_INCLUDE_DIRS}
+    ${Q3D_INCLUDE_DIR})
 
 if(Backtrace_FOUND)
     include_directories(
@@ -213,29 +212,23 @@ add_library(solvespace-core STATIC
     ${solvespace_core_HEADERS}
     ${solvespace_core_SOURCES})
 
+add_dependencies(solvespace-core gen_q3d_header)
+
 target_link_libraries(solvespace-core
     dxfrw
     ${util_LIBRARIES}
     ${ZLIB_LIBRARY}
     ${PNG_LIBRARY}
-    ${FREETYPE_LIBRARY})
+    ${FREETYPE_LIBRARY}
+    flatbuffers)
 
 if(Backtrace_FOUND)
     target_link_libraries(solvespace-core
         ${Backtrace_LIBRARY})
-    add_dependencies(solvespace-core gen_q3d_header)
-endif()
-
-if(ENABLE_Q3D)
-    target_link_libraries(solvespace-core
-        flatbuffers)
-    add_dependencies(solvespace-core gen_q3d_header)
-    include_directories(${Q3D_INCLUDE_DIR})
 endif()
 
 target_compile_options(solvespace-core
     PRIVATE ${COVERAGE_FLAGS})
-
 
 # solvespace translations
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ endif()
 
 set(HAVE_SPACEWARE ${SPACEWARE_FOUND})
 
+set(HAVE_Q3D ${ENABLE_Q3D})
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
@@ -221,10 +223,19 @@ target_link_libraries(solvespace-core
 if(Backtrace_FOUND)
     target_link_libraries(solvespace-core
         ${Backtrace_LIBRARY})
+    add_dependencies(solvespace-core gen_q3d_header)
+endif()
+
+if(ENABLE_Q3D)
+    target_link_libraries(solvespace-core
+        flatbuffers)
+    add_dependencies(solvespace-core gen_q3d_header)
+    include_directories(${Q3D_INCLUDE_DIR})
 endif()
 
 target_compile_options(solvespace-core
     PRIVATE ${COVERAGE_FLAGS})
+
 
 # solvespace translations
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -16,4 +16,7 @@
 #cmakedefine HAVE_BACKTRACE
 #define BACKTRACE_HEADER @BACKTRACE_HEADER@
 
+/* Do we have Q3D C++ stubs and the FlatBuffer library? */
+#cmakedefine HAVE_Q3D
+
 #endif

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -16,7 +16,4 @@
 #cmakedefine HAVE_BACKTRACE
 #define BACKTRACE_HEADER @BACKTRACE_HEADER@
 
-/* Do we have Q3D C++ stubs and the FlatBuffer library? */
-#cmakedefine HAVE_Q3D
-
 #endif

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -7,6 +7,7 @@
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
+#include "config.h"
 
 void SolveSpaceUI::ExportSectionTo(const Platform::Path &filename) {
     Vector gn = (SS.GW.projRight).Cross(SS.GW.projUp);
@@ -826,6 +827,8 @@ void SolveSpaceUI::ExportMeshTo(const Platform::Path &filename) {
         ExportMeshAsObjTo(f, fMtl, m);
 
         fclose(fMtl);
+    } else if(filename.HasExtension("q3do")) {
+        ExportMeshAsQ3doTo(f, m);
     } else if(filename.HasExtension("js") ||
               filename.HasExtension("html")) {
         SOutlineList *e = &(SK.GetGroup(SS.GW.activeGroup)->displayOutlines);
@@ -876,6 +879,63 @@ void SolveSpaceUI::ExportMeshAsStlTo(FILE *f, SMesh *sm) {
         fputc(0, f);
     }
 }
+
+//-----------------------------------------------------------------------------
+// Export the mesh as a Q3DO (https://github.com/q3k/q3d) file.
+//-----------------------------------------------------------------------------
+#ifndef HAVE_Q3D
+
+void SolveSpaceUI::ExportMeshAsQ3doTo(FILE *f, SMesh *sm) {
+    Error("SolveSpace has been built without Q3D(O) support.");
+}
+
+#else // HAVE_Q3D
+
+#include "object_generated.h"
+void SolveSpaceUI::ExportMeshAsQ3doTo(FILE *f, SMesh *sm) {
+    flatbuffers::FlatBufferBuilder builder(1024);
+    double s = SS.exportScale;
+
+    // Create a material for every colour used, keep note of triangles belonging to color/material.
+    std::map<RgbaColor, flatbuffers::Offset<q3d::Material>, RgbaColorCompare> materials;
+    std::map<RgbaColor, std::vector<flatbuffers::Offset<q3d::Triangle>>, RgbaColorCompare> materialTriangles;
+    for (const STriangle &t : sm->l) {
+        auto color = t.meta.color;
+        if (materials.find(color) == materials.end()) {
+            auto name = builder.CreateString(ssprintf("Color #%02x%02x%02x%02x", color.red, color.green, color.blue, color.alpha));
+            auto co = q3d::CreateColor(builder, color.red, color.green, color.blue, color.alpha);
+            auto mo = q3d::CreateMaterial(builder, name, co);
+            materials.emplace(color, mo);
+        }
+
+        Vector faceNormal = t.Normal();
+        auto a = q3d::Vector3(t.a.x/s, t.a.y/s, t.a.z/s);
+        auto b = q3d::Vector3(t.b.x/s, t.b.y/s, t.b.z/s);
+        auto c = q3d::Vector3(t.c.x/s, t.c.y/s, t.c.z/s);
+        auto fn = q3d::Vector3(faceNormal.x, faceNormal.y, faceNormal.x);
+        auto n1 = q3d::Vector3(t.normals[0].x, t.normals[0].y, t.normals[0].z);
+        auto n2 = q3d::Vector3(t.normals[1].x, t.normals[1].y, t.normals[1].z);
+        auto n3 = q3d::Vector3(t.normals[2].x, t.normals[2].y, t.normals[2].z);
+        auto tri = q3d::CreateTriangle(builder, &a, &b, &c, &fn, &n1, &n2, &n3);
+        materialTriangles[color].push_back(tri);
+    }
+
+    // Build all meshes sorted by material.
+    std::vector<flatbuffers::Offset<q3d::Mesh>> meshes;
+    for (auto &it : materials) {
+        auto &mato = it.second;
+        auto to = builder.CreateVector(materialTriangles[it.first]);
+        auto mo = q3d::CreateMesh(builder, to, mato);
+        meshes.push_back(mo);
+    }
+
+    auto mo = builder.CreateVector(meshes);
+    auto o = q3d::CreateObject(builder, mo);
+    q3d::FinishObjectBuffer(builder, o);
+    fwrite(builder.GetBufferPointer(), builder.GetSize(), 1, f);
+}
+
+#endif // HAVE_Q3D
 
 //-----------------------------------------------------------------------------
 // Export the mesh as Wavefront OBJ format. This requires us to reduce all the

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -883,13 +883,6 @@ void SolveSpaceUI::ExportMeshAsStlTo(FILE *f, SMesh *sm) {
 //-----------------------------------------------------------------------------
 // Export the mesh as a Q3DO (https://github.com/q3k/q3d) file.
 //-----------------------------------------------------------------------------
-#ifndef HAVE_Q3D
-
-void SolveSpaceUI::ExportMeshAsQ3doTo(FILE *f, SMesh *sm) {
-    Error("SolveSpace has been built without Q3D(O) support.");
-}
-
-#else // HAVE_Q3D
 
 #include "object_generated.h"
 void SolveSpaceUI::ExportMeshAsQ3doTo(FILE *f, SMesh *sm) {
@@ -934,8 +927,6 @@ void SolveSpaceUI::ExportMeshAsQ3doTo(FILE *f, SMesh *sm) {
     q3d::FinishObjectBuffer(builder, o);
     fwrite(builder.GetBufferPointer(), builder.GetSize(), 1, f);
 }
-
-#endif // HAVE_Q3D
 
 //-----------------------------------------------------------------------------
 // Export the mesh as Wavefront OBJ format. This requires us to reduce all the

--- a/src/platform/gui.cpp
+++ b/src/platform/gui.cpp
@@ -4,6 +4,7 @@
 // Copyright 2018 whitequark
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
+#include "config.h"
 
 namespace SolveSpace {
 namespace Platform {
@@ -94,6 +95,9 @@ std::vector<FileFilter> MeshFileFilters = {
     { CN_("file-type", "Wavefront OBJ mesh"), { "obj" } },
     { CN_("file-type", "Three.js-compatible mesh, with viewer"), { "html" } },
     { CN_("file-type", "Three.js-compatible mesh, mesh only"), { "js" } },
+#ifdef HAVE_Q3D
+    { CN_("file-type", "Q3D Object file"), { "q3do" } },
+#endif
 };
 
 std::vector<FileFilter> SurfaceFileFilters = {

--- a/src/platform/gui.cpp
+++ b/src/platform/gui.cpp
@@ -4,7 +4,6 @@
 // Copyright 2018 whitequark
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
-#include "config.h"
 
 namespace SolveSpace {
 namespace Platform {
@@ -95,9 +94,7 @@ std::vector<FileFilter> MeshFileFilters = {
     { CN_("file-type", "Wavefront OBJ mesh"), { "obj" } },
     { CN_("file-type", "Three.js-compatible mesh, with viewer"), { "html" } },
     { CN_("file-type", "Three.js-compatible mesh, mesh only"), { "js" } },
-#ifdef HAVE_Q3D
     { CN_("file-type", "Q3D Object file"), { "q3do" } },
-#endif
 };
 
 std::vector<FileFilter> SurfaceFileFilters = {

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -693,6 +693,7 @@ public:
     void ExportAsPngTo(const Platform::Path &filename);
     void ExportMeshTo(const Platform::Path &filename);
     void ExportMeshAsStlTo(FILE *f, SMesh *sm);
+    void ExportMeshAsQ3doTo(FILE *f, SMesh *sm);
     void ExportMeshAsObjTo(FILE *fObj, FILE *fMtl, SMesh *sm);
     void ExportMeshAsThreeJsTo(FILE *f, const Platform::Path &filename,
                                SMesh *sm, SOutlineList *sol);


### PR DESCRIPTION
This PR implements support for the [Q3D(o)](https://github.com/q3k/q3d/) 3d mesh format.

We ship FlatBuffers and Q3D as git submodules, add CMake machinery (behind an enable flag), and implement the export functionality.