### PR TITLE
Fix: disable mnemonic accelerator keys in menu's path labels

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -281,7 +281,7 @@ void GraphicsWindow::PopulateMainMenu() {
         } else if(Menu[i].cmd == Command::LOCALE) {
             Platform::MenuRef localeMenu = currentSubMenu->AddSubMenu(label);
             for(const Locale &locale : Locales()) {
-                localeMenu->AddItem(locale.displayName, [&]() {
+                localeMenu->AddItem(locale.displayName, true, [&]() {
                     SetLocale(locale.Culture());
                     Platform::GetSettings()->FreezeString("Locale", locale.Culture());
 
@@ -344,7 +344,7 @@ static void PopulateMenuWithPathnames(Platform::MenuRef menu,
         menuItem->SetEnabled(false);
     } else {
         for(Platform::Path pathname : pathnames) {
-            Platform::MenuItemRef menuItem = menu->AddItemRaw(pathname.raw);
+            Platform::MenuItemRef menuItem = menu->AddItem(pathname.raw, false);
             menuItem->onTrigger = [=]() { onTrigger(pathname); };
         }
     }

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -344,7 +344,7 @@ static void PopulateMenuWithPathnames(Platform::MenuRef menu,
         menuItem->SetEnabled(false);
     } else {
         for(Platform::Path pathname : pathnames) {
-            Platform::MenuItemRef menuItem = menu->AddItem(pathname.raw);
+            Platform::MenuItemRef menuItem = menu->AddItemRaw(pathname.raw);
             menuItem->onTrigger = [=]() { onTrigger(pathname); };
         }
     }

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -281,7 +281,7 @@ void GraphicsWindow::PopulateMainMenu() {
         } else if(Menu[i].cmd == Command::LOCALE) {
             Platform::MenuRef localeMenu = currentSubMenu->AddSubMenu(label);
             for(const Locale &locale : Locales()) {
-                localeMenu->AddItem(locale.displayName, true, [&]() {
+                localeMenu->AddItem(locale.displayName, /*mnemonics=*/true, [&]() {
                     SetLocale(locale.Culture());
                     Platform::GetSettings()->FreezeString("Locale", locale.Culture());
 
@@ -294,7 +294,7 @@ void GraphicsWindow::PopulateMainMenu() {
             subMenuStack.push_back(currentSubMenu);
             currentSubMenu = currentSubMenu->AddSubMenu(label);
         } else {
-            Platform::MenuItemRef menuItem = currentSubMenu->AddItem(label);
+            Platform::MenuItemRef menuItem = currentSubMenu->AddItem(label, /*mnemonics=*/true);
             menuItem->SetIndicator(Menu[i].kind);
             if(Menu[i].accel != 0) {
                 menuItem->SetAccelerator(AcceleratorForCommand(Menu[i].cmd));
@@ -340,11 +340,11 @@ static void PopulateMenuWithPathnames(Platform::MenuRef menu,
                                       std::function<void(const Platform::Path &)> onTrigger) {
     menu->Clear();
     if(pathnames.empty()) {
-        Platform::MenuItemRef menuItem = menu->AddItem(_("(no recent files)"));
+        Platform::MenuItemRef menuItem = menu->AddItem(_("(no recent files)"), /*mnemonics=*/true);
         menuItem->SetEnabled(false);
     } else {
         for(Platform::Path pathname : pathnames) {
-            Platform::MenuItemRef menuItem = menu->AddItem(pathname.raw, false);
+            Platform::MenuItemRef menuItem = menu->AddItem(pathname.raw, /*mnemonics=*/false);
             menuItem->onTrigger = [=]() { onTrigger(pathname); };
         }
     }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -557,7 +557,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             for(const Style &s : SK.style) {
                 if(s.h.v < Style::FIRST_CUSTOM) continue;
 
-                styleMenu->AddItem(s.DescriptionString(), [&]() {
+                styleMenu->AddItem(s.DescriptionString(), true, [&]() {
                     Style::AssignSelectionToStyle(s.h.v);
                 });
                 empty = false;
@@ -565,17 +565,17 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
 
             if(!empty) styleMenu->AddSeparator();
 
-            styleMenu->AddItem(_("No Style"), [&]() {
+            styleMenu->AddItem(_("No Style"), true, [&]() {
                 Style::AssignSelectionToStyle(0);
             });
-            styleMenu->AddItem(_("Newly Created Custom Style..."), [&]() {
+            styleMenu->AddItem(_("Newly Created Custom Style..."), true, [&]() {
                 uint32_t vs = Style::CreateCustomStyle();
                 Style::AssignSelectionToStyle(vs);
                 ForceTextWindowShown();
             });
         }
         if(gs.n + gs.constraints == 1) {
-            menu->AddItem(_("Group Info"), [&]() {
+            menu->AddItem(_("Group Info"), true, [&]() {
                 hGroup hg;
                 if(gs.entities == 1) {
                     hg = SK.GetEntity(gs.entity[0])->group;
@@ -595,7 +595,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             });
         }
         if(gs.n + gs.constraints == 1 && gs.stylables == 1) {
-            menu->AddItem(_("Style Info"), [&]() {
+            menu->AddItem(_("Style Info"), true, [&]() {
                 hStyle hs;
                 if(gs.entities == 1) {
                     hs = Style::ForEntity(gs.entity[0]);
@@ -615,24 +615,24 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             });
         }
         if(gs.withEndpoints > 0) {
-            menu->AddItem(_("Select Edge Chain"),
+            menu->AddItem(_("Select Edge Chain"), true,
                           [&]() { MenuEdit(Command::SELECT_CHAIN); });
         }
         if(gs.constraints == 1 && gs.n == 0) {
             Constraint *c = SK.GetConstraint(gs.constraint[0]);
             if(c->HasLabel() && c->type != Constraint::Type::COMMENT) {
-                menu->AddItem(_("Toggle Reference Dimension"),
+                menu->AddItem(_("Toggle Reference Dimension"), true,
                               [&]() { Constraint::MenuConstrain(Command::REFERENCE); });
             }
             if(c->type == Constraint::Type::ANGLE ||
                c->type == Constraint::Type::EQUAL_ANGLE)
             {
-                menu->AddItem(_("Other Supplementary Angle"),
+                menu->AddItem(_("Other Supplementary Angle"), true,
                               [&]() { Constraint::MenuConstrain(Command::OTHER_ANGLE); });
             }
         }
         if(gs.constraintLabels > 0 || gs.points > 0) {
-            menu->AddItem(_("Snap to Grid"),
+            menu->AddItem(_("Snap to Grid"), true,
                           [&]() { MenuEdit(Command::SNAP_TO_GRID); });
         }
 
@@ -641,7 +641,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             int index = r->IndexOfPoint(gs.point[0]);
             if((r->type == Request::Type::CUBIC && (index > 1 && index < r->extraPoints + 2)) ||
                     r->type == Request::Type::CUBIC_PERIODIC) {
-                menu->AddItem(_("Remove Spline Point"), [&]() {
+                menu->AddItem(_("Remove Spline Point"), true, [&]() {
                     int index = r->IndexOfPoint(gs.point[0]);
                     ssassert(r->extraPoints != 0,
                              "Expected a bezier with interior control points");
@@ -676,7 +676,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
                 ssassert(addAfterPoint != -1, "Expected a nearest bezier point to be located");
                 // Skip derivative point.
                 if(r->type == Request::Type::CUBIC) addAfterPoint++;
-                menu->AddItem(_("Add Spline Point"), [&]() {
+                menu->AddItem(_("Add Spline Point"), true, [&]() {
                     int pointCount = r->extraPoints +
                                      ((r->type == Request::Type::CUBIC_PERIODIC) ? 3 : 4);
                     if(pointCount >= MAX_POINTS_IN_ENTITY) {
@@ -705,7 +705,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             }
         }
         if(gs.entities == gs.n) {
-            menu->AddItem(_("Toggle Construction"),
+            menu->AddItem(_("Toggle Construction"), true,
                           [&]() { MenuRequest(Command::CONSTRUCTION); });
         }
 
@@ -720,7 +720,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
                 }
             }
             if(c) {
-                menu->AddItem(_("Delete Point-Coincident Constraint"), [&]() {
+                menu->AddItem(_("Delete Point-Coincident Constraint"), true, [&]() {
                     if(!p->IsPoint()) return;
 
                     SS.UndoRemember();
@@ -739,35 +739,35 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
         }
         menu->AddSeparator();
         if(LockedInWorkplane()) {
-            menu->AddItem(_("Cut"),
+            menu->AddItem(_("Cut"), true,
                           [&]() { MenuClipboard(Command::CUT); });
-            menu->AddItem(_("Copy"),
+            menu->AddItem(_("Copy"), true,
                           [&]() { MenuClipboard(Command::COPY); });
         }
     } else {
-        menu->AddItem(_("Select All"),
+        menu->AddItem(_("Select All"), true,
                       [&]() { MenuEdit(Command::SELECT_ALL); });
     }
 
     if((SS.clipboard.r.n > 0 || SS.clipboard.c.n > 0) && LockedInWorkplane()) {
-        menu->AddItem(_("Paste"),
+        menu->AddItem(_("Paste"), true,
                       [&]() { MenuClipboard(Command::PASTE); });
-        menu->AddItem(_("Paste Transformed..."),
+        menu->AddItem(_("Paste Transformed..."), true,
                       [&]() { MenuClipboard(Command::PASTE_TRANSFORM); });
     }
 
     if(itemsSelected) {
-        menu->AddItem(_("Delete"),
+        menu->AddItem(_("Delete"), true,
                       [&]() { MenuClipboard(Command::DELETE); });
         menu->AddSeparator();
-        menu->AddItem(_("Unselect All"),
+        menu->AddItem(_("Unselect All"), true,
                       [&]() { MenuEdit(Command::UNSELECT_ALL); });
     }
     // If only one item is selected, then it must be the one that we just
     // selected from the hovered item; in which case unselect all and hovered
     // are equivalent.
     if(!hover.IsEmpty() && selection.n > 1) {
-        menu->AddItem(_("Unselect Hovered"), [&] {
+        menu->AddItem(_("Unselect Hovered"), true, [&] {
             if(!hover.IsEmpty()) {
                 MakeUnselected(&hover, /*coincidentPointTrick=*/true);
             }
@@ -776,7 +776,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
 
     if(itemsSelected) {
         menu->AddSeparator();
-        menu->AddItem(_("Zoom to Fit"),
+        menu->AddItem(_("Zoom to Fit"), true,
                       [&]() { MenuView(Command::ZOOM_TO_FIT); });
     }
 

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -557,7 +557,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             for(const Style &s : SK.style) {
                 if(s.h.v < Style::FIRST_CUSTOM) continue;
 
-                styleMenu->AddItem(s.DescriptionString(), true, [&]() {
+                styleMenu->AddItem(s.DescriptionString(), /*mnemonics=*/true, [&]() {
                     Style::AssignSelectionToStyle(s.h.v);
                 });
                 empty = false;
@@ -565,17 +565,17 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
 
             if(!empty) styleMenu->AddSeparator();
 
-            styleMenu->AddItem(_("No Style"), true, [&]() {
+            styleMenu->AddItem(_("No Style"), /*mnemonics=*/true, [&]() {
                 Style::AssignSelectionToStyle(0);
             });
-            styleMenu->AddItem(_("Newly Created Custom Style..."), true, [&]() {
+            styleMenu->AddItem(_("Newly Created Custom Style..."), /*mnemonics=*/true, [&]() {
                 uint32_t vs = Style::CreateCustomStyle();
                 Style::AssignSelectionToStyle(vs);
                 ForceTextWindowShown();
             });
         }
         if(gs.n + gs.constraints == 1) {
-            menu->AddItem(_("Group Info"), true, [&]() {
+            menu->AddItem(_("Group Info"), /*mnemonics=*/true, [&]() {
                 hGroup hg;
                 if(gs.entities == 1) {
                     hg = SK.GetEntity(gs.entity[0])->group;
@@ -595,7 +595,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             });
         }
         if(gs.n + gs.constraints == 1 && gs.stylables == 1) {
-            menu->AddItem(_("Style Info"), true, [&]() {
+            menu->AddItem(_("Style Info"), /*mnemonics=*/true, [&]() {
                 hStyle hs;
                 if(gs.entities == 1) {
                     hs = Style::ForEntity(gs.entity[0]);
@@ -615,24 +615,24 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             });
         }
         if(gs.withEndpoints > 0) {
-            menu->AddItem(_("Select Edge Chain"), true,
+            menu->AddItem(_("Select Edge Chain"), /*mnemonics=*/true,
                           [&]() { MenuEdit(Command::SELECT_CHAIN); });
         }
         if(gs.constraints == 1 && gs.n == 0) {
             Constraint *c = SK.GetConstraint(gs.constraint[0]);
             if(c->HasLabel() && c->type != Constraint::Type::COMMENT) {
-                menu->AddItem(_("Toggle Reference Dimension"), true,
+                menu->AddItem(_("Toggle Reference Dimension"), /*mnemonics=*/true,
                               [&]() { Constraint::MenuConstrain(Command::REFERENCE); });
             }
             if(c->type == Constraint::Type::ANGLE ||
                c->type == Constraint::Type::EQUAL_ANGLE)
             {
-                menu->AddItem(_("Other Supplementary Angle"), true,
+                menu->AddItem(_("Other Supplementary Angle"), /*mnemonics=*/true,
                               [&]() { Constraint::MenuConstrain(Command::OTHER_ANGLE); });
             }
         }
         if(gs.constraintLabels > 0 || gs.points > 0) {
-            menu->AddItem(_("Snap to Grid"), true,
+            menu->AddItem(_("Snap to Grid"), /*mnemonics=*/true,
                           [&]() { MenuEdit(Command::SNAP_TO_GRID); });
         }
 
@@ -641,7 +641,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             int index = r->IndexOfPoint(gs.point[0]);
             if((r->type == Request::Type::CUBIC && (index > 1 && index < r->extraPoints + 2)) ||
                     r->type == Request::Type::CUBIC_PERIODIC) {
-                menu->AddItem(_("Remove Spline Point"), true, [&]() {
+                menu->AddItem(_("Remove Spline Point"), /*mnemonics=*/true, [&]() {
                     int index = r->IndexOfPoint(gs.point[0]);
                     ssassert(r->extraPoints != 0,
                              "Expected a bezier with interior control points");
@@ -676,7 +676,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
                 ssassert(addAfterPoint != -1, "Expected a nearest bezier point to be located");
                 // Skip derivative point.
                 if(r->type == Request::Type::CUBIC) addAfterPoint++;
-                menu->AddItem(_("Add Spline Point"), true, [&]() {
+                menu->AddItem(_("Add Spline Point"), /*mnemonics=*/true, [&]() {
                     int pointCount = r->extraPoints +
                                      ((r->type == Request::Type::CUBIC_PERIODIC) ? 3 : 4);
                     if(pointCount >= MAX_POINTS_IN_ENTITY) {
@@ -705,7 +705,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             }
         }
         if(gs.entities == gs.n) {
-            menu->AddItem(_("Toggle Construction"), true,
+            menu->AddItem(_("Toggle Construction"), /*mnemonics=*/true,
                           [&]() { MenuRequest(Command::CONSTRUCTION); });
         }
 
@@ -720,7 +720,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
                 }
             }
             if(c) {
-                menu->AddItem(_("Delete Point-Coincident Constraint"), true, [&]() {
+                menu->AddItem(_("Delete Point-Coincident Constraint"), /*mnemonics=*/true, [&]() {
                     if(!p->IsPoint()) return;
 
                     SS.UndoRemember();
@@ -739,35 +739,35 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
         }
         menu->AddSeparator();
         if(LockedInWorkplane()) {
-            menu->AddItem(_("Cut"), true,
+            menu->AddItem(_("Cut"), /*mnemonics=*/true,
                           [&]() { MenuClipboard(Command::CUT); });
-            menu->AddItem(_("Copy"), true,
+            menu->AddItem(_("Copy"), /*mnemonics=*/true,
                           [&]() { MenuClipboard(Command::COPY); });
         }
     } else {
-        menu->AddItem(_("Select All"), true,
+        menu->AddItem(_("Select All"), /*mnemonics=*/true,
                       [&]() { MenuEdit(Command::SELECT_ALL); });
     }
 
     if((SS.clipboard.r.n > 0 || SS.clipboard.c.n > 0) && LockedInWorkplane()) {
-        menu->AddItem(_("Paste"), true,
+        menu->AddItem(_("Paste"), /*mnemonics=*/true,
                       [&]() { MenuClipboard(Command::PASTE); });
-        menu->AddItem(_("Paste Transformed..."), true,
+        menu->AddItem(_("Paste Transformed..."), /*mnemonics=*/true,
                       [&]() { MenuClipboard(Command::PASTE_TRANSFORM); });
     }
 
     if(itemsSelected) {
-        menu->AddItem(_("Delete"), true,
+        menu->AddItem(_("Delete"), /*mnemonics=*/true,
                       [&]() { MenuClipboard(Command::DELETE); });
         menu->AddSeparator();
-        menu->AddItem(_("Unselect All"), true,
+        menu->AddItem(_("Unselect All"), /*mnemonics=*/true,
                       [&]() { MenuEdit(Command::UNSELECT_ALL); });
     }
     // If only one item is selected, then it must be the one that we just
     // selected from the hovered item; in which case unselect all and hovered
     // are equivalent.
     if(!hover.IsEmpty() && selection.n > 1) {
-        menu->AddItem(_("Unselect Hovered"), true, [&] {
+        menu->AddItem(_("Unselect Hovered"), /*mnemonics=*/true, [&] {
             if(!hover.IsEmpty()) {
                 MakeUnselected(&hover, /*coincidentPointTrick=*/true);
             }
@@ -776,7 +776,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
 
     if(itemsSelected) {
         menu->AddSeparator();
-        menu->AddItem(_("Zoom to Fit"), true,
+        menu->AddItem(_("Zoom to Fit"), /*mnemonics=*/true,
                       [&]() { MenuView(Command::ZOOM_TO_FIT); });
     }
 

--- a/src/platform/gui.h
+++ b/src/platform/gui.h
@@ -172,6 +172,8 @@ public:
 
     virtual std::shared_ptr<MenuItem> AddItem(
         const std::string &label, std::function<void()> onTrigger = std::function<void()>()) = 0;
+    virtual std::shared_ptr<MenuItem> AddItemRaw(
+        const std::string &label, std::function<void()> onTrigger = std::function<void()>()) = 0;
     virtual std::shared_ptr<Menu> AddSubMenu(const std::string &label) = 0;
     virtual void AddSeparator() = 0;
 

--- a/src/platform/gui.h
+++ b/src/platform/gui.h
@@ -171,7 +171,7 @@ public:
     virtual ~Menu() {}
 
     virtual std::shared_ptr<MenuItem> AddItem(
-        const std::string &label, bool mnemonics = true,
+        const std::string &label, bool mnemonics,
         std::function<void()> onTrigger = std::function<void()>()) = 0;
     virtual std::shared_ptr<Menu> AddSubMenu(const std::string &label) = 0;
     virtual void AddSeparator() = 0;

--- a/src/platform/gui.h
+++ b/src/platform/gui.h
@@ -171,9 +171,8 @@ public:
     virtual ~Menu() {}
 
     virtual std::shared_ptr<MenuItem> AddItem(
-        const std::string &label, std::function<void()> onTrigger = std::function<void()>()) = 0;
-    virtual std::shared_ptr<MenuItem> AddItemRaw(
-        const std::string &label, std::function<void()> onTrigger = std::function<void()>()) = 0;
+        const std::string &label, bool mnemonics = true,
+        std::function<void()> onTrigger = std::function<void()>()) = 0;
     virtual std::shared_ptr<Menu> AddSubMenu(const std::string &label) = 0;
     virtual void AddSeparator() = 0;
 

--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -358,6 +358,16 @@ public:
         return menuItem;
     }
 
+    MenuItemRef AddItemRaw(const std::string &label,
+                           std::function<void()> onTrigger = NULL) override {
+        auto menuItem = std::dynamic_pointer_cast<MenuItemImplGtk>(AddItem("", onTrigger));
+
+        menuItem->gtkMenuItem.set_label(label);
+        menuItem->gtkMenuItem.set_use_underline(false);
+
+        return menuItem;
+    }
+
     MenuRef AddSubMenu(const std::string &label) override {
         auto menuItem = std::make_shared<MenuItemImplGtk>();
         menuItems.push_back(menuItem);

--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -344,26 +344,16 @@ public:
     std::vector<std::shared_ptr<MenuItemImplGtk>>   menuItems;
     std::vector<std::shared_ptr<MenuImplGtk>>       subMenus;
 
-    MenuItemRef AddItem(const std::string &label,
+    MenuItemRef AddItem(const std::string &label, bool mnemonics,
                         std::function<void()> onTrigger = NULL) override {
         auto menuItem = std::make_shared<MenuItemImplGtk>();
         menuItems.push_back(menuItem);
 
-        menuItem->gtkMenuItem.set_label(PrepareMnemonics(label));
-        menuItem->gtkMenuItem.set_use_underline(true);
+        menuItem->gtkMenuItem.set_label(mnemonics ? PrepareMnemonics(label) : label);
+        menuItem->gtkMenuItem.set_use_underline(mnemonics);
         menuItem->gtkMenuItem.show();
         menuItem->onTrigger = onTrigger;
         gtkMenu.append(menuItem->gtkMenuItem);
-
-        return menuItem;
-    }
-
-    MenuItemRef AddItemRaw(const std::string &label,
-                           std::function<void()> onTrigger = NULL) override {
-        auto menuItem = std::dynamic_pointer_cast<MenuItemImplGtk>(AddItem("", onTrigger));
-
-        menuItem->gtkMenuItem.set_label(label);
-        menuItem->gtkMenuItem.set_use_underline(false);
 
         return menuItem;
     }

--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -268,6 +268,15 @@ public:
         return menuItem;
     }
 
+    MenuItemRef AddItemRaw(const std::string &label,
+                           std::function<void()> onTrigger = NULL) override {
+        auto menuItem = std::dynamic_pointer_cast<MenuItemImplCocoa>(AddItem("", onTrigger));
+
+        [menuItem->nsMenuItem setTitle:Wrap(label)];
+
+        return menuItem;
+    }
+
     MenuRef AddSubMenu(const std::string &label) override {
         auto subMenu = std::make_shared<MenuImplCocoa>();
         subMenus.push_back(subMenu);

--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -256,23 +256,14 @@ public:
         [nsMenu setAutoenablesItems:NO];
     }
 
-    MenuItemRef AddItem(const std::string &label,
+    MenuItemRef AddItem(const std::string &label, bool mnemonics,
                         std::function<void()> onTrigger = NULL) override {
         auto menuItem = std::make_shared<MenuItemImplCocoa>();
         menuItems.push_back(menuItem);
 
         menuItem->onTrigger = onTrigger;
-        [menuItem->nsMenuItem setTitle:Wrap(PrepareMnemonics(label))];
+        [menuItem->nsMenuItem setTitle:Wrap(mnemonics ? PrepareMnemonics(label) : label)];
         [nsMenu addItem:menuItem->nsMenuItem];
-
-        return menuItem;
-    }
-
-    MenuItemRef AddItemRaw(const std::string &label,
-                           std::function<void()> onTrigger = NULL) override {
-        auto menuItem = std::dynamic_pointer_cast<MenuItemImplCocoa>(AddItem("", onTrigger));
-
-        [menuItem->nsMenuItem setTitle:Wrap(label)];
 
         return menuItem;
     }

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -103,6 +103,17 @@ BOOL ssAdjustWindowRectExForDpi(LPRECT lpRect, DWORD dwStyle, BOOL bMenu,
 // Utility functions
 //-----------------------------------------------------------------------------
 
+static std::string NegateMnemonics(std::string label) {
+    std::string search("&");
+    std::string replace("&&");
+    std::string::size_type p = 0;
+    while((p = label.find("&", p)) != std::string::npos) {
+        label.replace(p, search.size(), replace);
+        p += replace.size();
+    }
+    return label;
+}
+
 static std::wstring PrepareTitle(const std::string &s) {
     return Widen("SolveSpace - " + s);
 }
@@ -367,6 +378,19 @@ public:
         mii.cbSize     = sizeof(mii);
         mii.fMask      = MIIM_DATA;
         mii.dwItemData = (LONG_PTR)menuItem.get();
+        sscheck(SetMenuItemInfoW(hMenu, (UINT_PTR)menuItem.get(), FALSE, &mii));
+
+        return menuItem;
+    }
+
+    MenuItemRef AddItemRaw(const std::string &label,
+                           std::function<void()> onTrigger = NULL) override {
+        auto menuItem = std::dynamic_pointer_cast<MenuItemImplWin32>(AddItem("", onTrigger));
+
+	MENUITEMINFOW mii = {};
+        mii.cbSize     = sizeof(mii);
+        mii.fMask      = MIIM_STRING;
+        mii.dwTypeData = Widen(NegateMnemonics(label)).c_str();
         sscheck(SetMenuItemInfoW(hMenu, (UINT_PTR)menuItem.get(), FALSE, &mii));
 
         return menuItem;


### PR DESCRIPTION
**Solvespace version**: 3.0~46528bfc
**OS**: Gentoo GNU/Linux

_Already signed Solvespace's Contributor License Agreement._

### Bug

`File > Open Recent` and `New Group > Link Recent` replace/remove strings in file paths and activate mnemonic accelerator keys.

This means that on GNU/Linux the path `/tmp/_foo_&_bar_.slvs` is showed as `/tmp/foo_bar.slvs`.

**settings.json**
```
{
  "RecentFile_0":"\/tmp\/_foo_&_bar_.slvs"
}
```

![before](https://user-images.githubusercontent.com/6450450/55664631-45d8f900-5831-11e9-90d0-d3aaf030f2a3.png)

### Proposed solution

Add `mnemonics` argument to `Platform::Menu::AddItem` to treat as raw text label's mnemonic accelerator keys when it is `false` (`src/platform/gui.h`).

~~New pure virtual function `Platform::Menu::AddItemRaw` which treats as raw text label's mnemonic accelerator keys (`src/platform/gui.h`).~~

~~`AddItemRaw `doesn't replace/remove label's text (i.e. `guigtk.cpp '&' -> '_'`), nor it activates mnemonic accelerator keys.~~

![after](https://user-images.githubusercontent.com/6450450/55664633-54bfab80-5831-11e9-9c67-56c28216c4b8.png)

### Caveats

Solution tested only on Gentoo GNU/Linux.

The code in `src/platform/guiwin.cpp` and `src/platform/guimac.mm` isn't tested and may require amendments.

Does `NegateMnemonics` escape mnemonic accelerator keys correctly (`src/platform/guiwin.cpp`)?

~~Not sure if `AddItemRaw` in `guiwin.cpp` shall allocate a buffer before assigning it to `mii.dwTypeData`. Also, does `SetMenuItemInfoW` operate as expected updating the menu item's label?~~

Can someone review the code, please?
