### PR TITLE
Engraving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ New export/import features:
     exported. This format allows to easily hack on triangle mesh data created
     in SolveSpace, supports colour information and is more space efficient than
     most other formats.
+  * Export 2d section: custom styled entities that lie in the same 
+    plane as the exported section are included.
 
 New rendering features:
   * The "Show/hide hidden lines" button is now a tri-state button that allows

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -91,8 +91,9 @@ void SolveSpaceUI::ExportSectionTo(const Platform::Path &filename) {
         sb->auxA = Style::SOLID_EDGE;
     }
 
-    el.CullExtraneousEdges(true);
-    bl.CullIdenticalBeziers(true);
+    // Remove all overlapping edges/beziers to merge the areas they describe.
+    el.CullExtraneousEdges(/*both=*/true);
+    bl.CullIdenticalBeziers(/*both=*/true);
     
     // Collect lines and beziers with custom style & export.
     int i;
@@ -110,8 +111,8 @@ void SolveSpaceUI::ExportSectionTo(const Platform::Path &filename) {
     }
 
     // Only remove half of the overlapping edges/beziers to support TTF Stick Fonts.
-    el.CullExtraneousEdges(false);
-    bl.CullIdenticalBeziers(false);
+    el.CullExtraneousEdges(/*both=*/false);
+    bl.CullIdenticalBeziers(/*both=*/false);
 
     // And write the edges.
     VectorFileWriter *out = VectorFileWriter::ForFile(filename);

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -591,7 +591,7 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
     // If possible, then we will assemble these output curves into loops. They
     // will then get exported as closed paths.
     SBezierLoopSetSet sblss = {};
-    SBezierList leftovers = {};
+    SBezierLoopSet leftovers = {};
     SSurface srf = SSurface::FromPlane(Vector::From(0, 0, 0),
                                        Vector::From(1, 0, 0),
                                        Vector::From(0, 1, 0));
@@ -604,14 +604,11 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
                              &allClosed, &notClosedAt,
                              NULL, NULL,
                              &leftovers);
-    for(b = leftovers.l.First(); b; b = leftovers.l.NextAfter(b)) {
-        sblss.AddOpenPath(b);
-    }
+    sblss.l.Add(&leftovers);
 
     // Now write the lines and triangles to the output file
     out->OutputLinesAndMesh(&sblss, &sms);
 
-    leftovers.Clear();
     spxyz.Clear();
     sblss.Clear();
     smp.Clear();

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -329,8 +329,9 @@ bool SEdgeList::ContainsEdge(const SEdge *set) const {
 //-----------------------------------------------------------------------------
 // Remove unnecessary edges: if two are anti-parallel then remove both, and if
 // two are parallel then remove one.
+// If both is false, only one edge is removed.
 //-----------------------------------------------------------------------------
-void SEdgeList::CullExtraneousEdges() {
+void SEdgeList::CullExtraneousEdges(bool both) {
     l.ClearTags();
     int i, j;
     for(i = 0; i < l.n; i++) {
@@ -343,7 +344,7 @@ void SEdgeList::CullExtraneousEdges() {
             }
             if((set->a).Equals(se->b) && (set->b).Equals(se->a)) {
                 // Two anti-parallel edges exist; so keep neither.
-                se->tag = 1;
+                if (both) se->tag = 1;
                 set->tag = 1;
             }
         }

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -327,9 +327,11 @@ bool SEdgeList::ContainsEdge(const SEdge *set) const {
 }
 
 //-----------------------------------------------------------------------------
-// Remove unnecessary edges: if two are anti-parallel then remove both, and if
-// two are parallel then remove one.
-// If both is false, only one edge is removed.
+// Remove unnecessary edges:
+// - if two are anti-parallel then
+//     if both=true, remove both
+//     else remove only one.
+// - if two are parallel then remove one.
 //-----------------------------------------------------------------------------
 void SEdgeList::CullExtraneousEdges(bool both) {
     l.ClearTags();
@@ -343,7 +345,8 @@ void SEdgeList::CullExtraneousEdges(bool both) {
                 set->tag = 1;
             }
             if((set->a).Equals(se->b) && (set->b).Equals(se->a)) {
-                // Two anti-parallel edges exist; so keep neither.
+                // Two anti-parallel edges exist; if both=true, keep neither,
+                // otherwise keep only one.
                 if (both) se->tag = 1;
                 set->tag = 1;
             }

--- a/src/polygon.h
+++ b/src/polygon.h
@@ -58,7 +58,7 @@ public:
         Vector *pi=NULL, SPointList *spl=NULL) const;
     bool ContainsEdgeFrom(const SEdgeList *sel) const;
     bool ContainsEdge(const SEdge *se) const;
-    void CullExtraneousEdges();
+    void CullExtraneousEdges(bool both=true);
     void MergeCollinearSegments(Vector a, Vector b);
 };
 

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -483,6 +483,7 @@ public:
     bool HasEndpoints() const;
     Vector EndpointStart() const;
     Vector EndpointFinish() const;
+    bool IsInPlane(Vector norm, double distance) const;
 
     void RectGetPointsExprs(ExprVector *eap, ExprVector *ebp) const;
 

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -185,7 +185,7 @@ public:
 
     SPolygon                polyLoops;
     SBezierLoopSetSet       bezierLoops;
-    SBezierList             bezierOpens;
+    SBezierLoopSet          bezierOpens;
 
     struct {
         PolyError       how;

--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -492,7 +492,7 @@ bool SBezierLoop::IsClosed() const {
 SBezierLoopSet SBezierLoopSet::From(SBezierList *sbl, SPolygon *poly,
                                     double chordTol,
                                     bool *allClosed, SEdge *errorAt,
-                                    SBezierList *openContours)
+                                    SBezierLoopSet *openContours)
 {
     SBezierLoopSet ret = {};
 
@@ -505,12 +505,10 @@ SBezierLoopSet SBezierLoopSet::From(SBezierList *sbl, SPolygon *poly,
             // Record open loops in a separate list, if requested.
             *allClosed = false;
             if(openContours) {
-                SBezier *sb;
-                for(sb = loop.l.First(); sb; sb = loop.l.NextAfter(sb)) {
-                    openContours->l.Add(sb);
-                }
+                openContours->l.Add(&loop);
+            } else {
+                loop.Clear();
             }
-            loop.Clear();
         } else {
             ret.l.Add(&loop);
             poly->AddEmptyContour();
@@ -577,7 +575,7 @@ void SBezierLoopSetSet::FindOuterFacesFrom(SBezierList *sbl, SPolygon *spxyz,
                                    double chordTol,
                                    bool *allClosed, SEdge *notClosedAt,
                                    bool *allCoplanar, Vector *notCoplanarAt,
-                                   SBezierList *openContours)
+                                   SBezierLoopSet *openContours)
 {
     SSurface srfPlane;
     if(!srfuv) {
@@ -590,7 +588,9 @@ void SBezierLoopSetSet::FindOuterFacesFrom(SBezierList *sbl, SPolygon *spxyz,
             if(openContours) {
                 SBezier *sb;
                 for(sb = sbl->l.First(); sb; sb = sbl->l.NextAfter(sb)) {
-                    openContours->l.Add(sb);
+                    SBezierLoop sbl={};
+                    sbl.l.Add(sb);
+                    openContours->l.Add(&sbl);
                 }
             }
             return;
@@ -706,12 +706,10 @@ void SBezierLoopSetSet::FindOuterFacesFrom(SBezierList *sbl, SPolygon *spxyz,
         if(loop->tag == USED_LOOP) continue;
 
         if(openContours) {
-            SBezier *sb;
-            for(sb = loop->l.First(); sb; sb = loop->l.NextAfter(sb)) {
-                openContours->l.Add(sb);
-            }
+            openContours->l.Add(loop);
+        } else {
+            loop->Clear();
         }
-        loop->Clear();
         // but don't free the used loops, since we shallow-copied them to
         // ourself
     }

--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -232,8 +232,9 @@ void SBezierList::ScaleSelfBy(double s) {
 //-----------------------------------------------------------------------------
 // If our list contains multiple identical Beziers (in either forward or
 // reverse order), then cull them.
+// If both is false, only one of the beziers is removed.
 //-----------------------------------------------------------------------------
-void SBezierList::CullIdenticalBeziers() {
+void SBezierList::CullIdenticalBeziers(bool both) {
     int i, j;
 
     l.ClearTags();
@@ -247,7 +248,7 @@ void SBezierList::CullIdenticalBeziers() {
             if(bj->Equals(bi) ||
                bj->Equals(&bir))
             {
-                bi->tag = 1;
+                if (both) bi->tag = 1;
                 bj->tag = 1;
             }
         }

--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -231,8 +231,8 @@ void SBezierList::ScaleSelfBy(double s) {
 
 //-----------------------------------------------------------------------------
 // If our list contains multiple identical Beziers (in either forward or
-// reverse order), then cull them.
-// If both is false, only one of the beziers is removed.
+// reverse order), then cull them. If both is true, both beziers are removed.
+// Otherwise only one of them is removed.
 //-----------------------------------------------------------------------------
 void SBezierList::CullIdenticalBeziers(bool both) {
     int i, j;

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -156,7 +156,7 @@ public:
     static SBezierLoopSet From(SBezierList *spcl, SPolygon *poly,
                                double chordTol,
                                bool *allClosed, SEdge *errorAt,
-                               SBezierList *openContours);
+                               SBezierLoopSet *openContours);
 
     void GetBoundingProjd(Vector u, Vector orig, double *umin, double *umax) const;
     double SignedArea();
@@ -172,7 +172,7 @@ public:
                             double chordTol,
                             bool *allClosed, SEdge *notClosedAt,
                             bool *allCoplanar, Vector *notCoplanarAt,
-                            SBezierList *openContours);
+                            SBezierLoopSet *openContours);
     void AddOpenPath(SBezier *sb);
     void Clear();
 };

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -125,7 +125,7 @@ public:
 
     void Clear();
     void ScaleSelfBy(double s);
-    void CullIdenticalBeziers();
+    void CullIdenticalBeziers(bool both=true);
     void AllIntersectionsWith(SBezierList *sblb, SPointList *spl) const;
     bool GetPlaneContainingBeziers(Vector *p, Vector *u, Vector *v,
                                         Vector *notCoplanarAt) const;


### PR DESCRIPTION
I mostly use solvespace for designing stuff that I then cut out using a laser cutter. For that purpose I always use the section export function. In the past I used Inkscape to add text or line segments, but I would prefer to be able to model these in solvespace, especially when positioning is important. 

For custom line styles, there is an option "export these objects", which I hoped meant that these lines are included in the section export, but they aren't. This patch changes that, such that they are included. To get it to work properly I had to change some parts of the code for which I'm not sure whether I got them correct.

I don't know what "export these objects" is supposed to do, so I guess this is not entirely the right place for configuring a style for section export and that a new flag might be more appropriate.

Please let me know what you think of it.

P.S. I thought that it would be useful to add a way to disable the closed contour check for these custom line styles, but this is already possible by turning them into construction line segments (although those are visually indistinguishable). 