### PR TITLE
GTK: fix build on Ubuntu 18.04 by removing debug define

### DIFF
--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -15,7 +15,6 @@
 #include <gtkmm/cssprovider.h>
 #include <gtkmm/entry.h>
 #include <gtkmm/filechooserdialog.h>
-#define HAVE_GTK_FILECHOOSERNATIVE
 #if defined(HAVE_GTK_FILECHOOSERNATIVE)
 #   include <gtkmm/filechoosernative.h>
 #endif


### PR DESCRIPTION
Ubuntu 18.04 uses GTKMM 3.22.2-2, which doesn't support native file chooser.

Commit bc3e09edbfeb4859218bf51476e34635f45cf249 checks if native file chooser
is available, but the result is overridden with a hardcoded define,
probably for debugging.

Removing the debugging code fixes build on Ubuntu 18.04.