### PR TITLE
macOS Mojave: fix hang on launch

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -306,7 +306,8 @@ public:
     std::vector<std::shared_ptr<MenuImplCocoa>> subMenus;
 
     MenuBarImplCocoa() {
-        nsMenuBar = [NSApp mainMenu];
+        nsMenuBar = [[NSMenu alloc] initWithTitle:@"SolveSpace"];
+        [NSApp setMainMenu:nsMenuBar];
     }
 
     MenuRef AddSubMenu(const std::string &label) override {
@@ -321,7 +322,7 @@ public:
     }
 
     void Clear() override {
-        while([nsMenuBar numberOfItems] != 1) {
+        while([nsMenuBar numberOfItems] > 1) {
             [nsMenuBar removeItemAtIndex:1];
         }
         subMenus.clear();

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -639,6 +639,10 @@ public:
     }
 
     ~WindowImplWin32() {
+        // Make sure any of our child windows get destroyed before we call DestroyWindow, or their
+        // own destructors may fail.
+        // menuBar.reset();
+
         sscheck(DestroyWindow(hWindow));
 #if defined(HAVE_SPACEWARE)
         if(hSpaceWare != SI_NO_HANDLE) {


### PR DESCRIPTION
On Mojave, [NSApp menuBar] doesn't exist until after applicationDidFinishLaunching, causing `nsMenuBar` to be nil (and `Clear()` to never exit since `numberOfItems` is 0). Rather than restructuring the lifecycle of the app, just create our own menu bar and set it as the main menu.