### PR TITLE
Move two members of Vector to be inline.

### DIFF
--- a/src/dsc.h
+++ b/src/dsc.h
@@ -108,6 +108,25 @@ public:
     Vector4 Project4d() const;
 };
 
+inline double Vector::Element(int i) const {
+    switch (i) {
+    case 0: return x;
+    case 1: return y;
+    case 2: return z;
+    default: ssassert(false, "Unexpected vector element index");
+    }
+}
+
+inline bool Vector::Equals(Vector v, double tol) const {
+    // Quick axis-aligned tests before going further
+    const Vector dv = this->Minus(v);
+    if (fabs(dv.x) > tol) return false;
+    if (fabs(dv.y) > tol) return false;
+    if (fabs(dv.z) > tol) return false;
+
+    return dv.MagSquared() < tol*tol;
+}
+
 struct VectorHash {
     size_t operator()(const Vector &v) const;
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -430,25 +430,6 @@ Vector Vector::From(hParam x, hParam y, hParam z) {
     return v;
 }
 
-double Vector::Element(int i) const {
-    switch(i) {
-        case 0: return x;
-        case 1: return y;
-        case 2: return z;
-        default: ssassert(false, "Unexpected vector element index");
-    }
-}
-
-bool Vector::Equals(Vector v, double tol) const {
-    // Quick axis-aligned tests before going further
-    const Vector dv = this->Minus(v);
-    if (fabs(dv.x) > tol) return false;
-    if (fabs(dv.y) > tol) return false;
-    if (fabs(dv.z) > tol) return false;
-
-    return dv.MagSquared() < tol*tol;
-}
-
 bool Vector::EqualsExactly(Vector v) const {
     return EXACT(x == v.x &&
                  y == v.y &&


### PR DESCRIPTION
Performance change: moved since they show up disproportionately
in profiling. (or at least, they did in January of 2018. I'm nearly full-time linux now, and I'm strangely better at profiling on Windows, so I didn't re-profile yet.)