### PR TITLE
Fix tests by correcting detection of build path sep.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,10 @@ foreach(pkg_config_lib CAIRO)
     link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
 endforeach()
 
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+    add_definitions(-DTEST_BUILD_ON_WINDOWS)
+endif()
+
 # test suite
 
 set(testsuite_SOURCES

--- a/test/harness.cpp
+++ b/test/harness.cpp
@@ -21,9 +21,12 @@ namespace Platform {
 }
 }
 
-// The paths in __FILE__ are from the build system, but defined(WIN32) returns
-// the value for the host system.
-#define BUILD_PATH_SEP (__FILE__[0]=='/' ? '/' : '\\')
+
+#ifdef TEST_BUILD_ON_WINDOWS
+static char BUILD_PATH_SEP = '\\';
+#else
+static char BUILD_PATH_SEP = '/';
+#endif
 
 static std::string BuildRoot() {
     static std::string rootDir;


### PR DESCRIPTION
Before, would guess incorrectly if the CMake source tree was specified
via a relative path (since then the path would not start with /).
Now, checks for any backslashes, using them as an indicator that
the backslash is the separator.

Without this, I can't get the test suite to run on Linux, and I'm pretty sure I couldn't get it to run on Windows before.