### PR TITLE
Clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,43 @@
+---
+# Things explicitly enumerated in CONTRIBUTING.md
+IndentWidth: 4
+UseTab: Never
+SpaceBeforeParens: Never
+BreakBeforeBraces: Attach
+ColumnLimit: 100
+# Docs say 100, but some places look more like 80.
+#ColumnLimit: 80
+
+# Based on minimizing diff when applying clang-format
+AccessModifierOffset: -4
+DerivePointerAlignment: true
+AlignConsecutiveAssignments: true
+FixNamespaceComments: true
+NamespaceIndentation: Inner
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: Yes # MultiLine
+SpaceAfterTemplateKeyword: false
+MaxEmptyLinesToKeep: 2
+IndentPPDirectives: AfterHash
+AlignEscapedNewlines: DontAlign
+BreakConstructorInitializers: BeforeColon
+AllowShortCaseLabelsOnASingleLine: true
+
+# This one is mixed in its effect: it permits some single-line functions,
+# but also tends to put, e.g., enums on a single line.
+AllowShortBlocksOnASingleLine: true
+
+# No way to remove all space around operators as seen in much of the code I looked at.
+#SpaceBeforeAssignmentOperators: false
+
+# Only seen some of the time (mostly just variables, not functions)
+# but clang-format only has a true/false
+#AlignConsecutiveDeclarations: true
+
+
+# Would be nice to turn on eventually, maybe?
+SortIncludes: false
+SortUsingDeclarations: false
+
+# Hard to tell what the desired config here was.
+# AllowShortFunctionsOnASingleLine: Inline

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,22 @@
+---
+# clang-analyzer-optin turned off because of structure-padding warnings hiding other warnings
+# Eventually should add modernize-loop-convert.
+# readability-braces-around-statements is what the CONTRIBUTING.md file states, but code doesn't really follow.
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-optin-*,readability-braces-around-statements'
+WarningsAsErrors: ''
+HeaderFilterRegex: 'src/.*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:    
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  # - key:             modernize-replace-auto-ptr.IncludeStyle
+  #   value:           llvm
+  # - key:             modernize-use-nullptr.NullMacros
+  #   value:           'NULL'
+...
+


### PR DESCRIPTION
Follow-up from #414 - this is my best attempt at getting one using my typical approach of populating with the explicitly-stated preferences, then iterating through "apply to file" and "correct config causing most apparent spurious changes". There are substantial inconsistencies that mean that whatever decision I make for some of these, it will introduce changes if it were applied all-over, but since that's not on the table anyway, this should be at least something. There were also a few where clang-format couldn't quite express the subtle distinctions I saw in the existing formatting, so I picked the overall less-intrusive one.

The file is commented to help you modify it as desired.

I also added a clang-tidy config file because the contributing doc says "braces around all the things" and that's not something clang-format can do (for some reason), you have to use clang-tidy. Doing so exposed me to the reality that it's a guideline very rarely followed - but if you'd like to enforce it, that clang-tidy file is a good way to do so. Something like this, assuming you have a build tree in `build/`...

```sh
find src test \(-name "*.h" -o -name "*.cpp" \) -print0 | xargs --null clang-tidy-7 -p build -fix 
git add -u
git clang-format
```

(Can't use run-clang-tidy here because it will result in things getting multiple sets of brackets, etc. Sadly must do it single-threaded like this, or have it save out the fixes and manually choose the ones to apply.)