### PR TITLE
Automatically resize the Three.js view to fit window if the size was not forced

### DIFF
--- a/res/threejs/SolveSpaceControls.js
+++ b/res/threejs/SolveSpaceControls.js
@@ -330,15 +330,18 @@ solvespace = function(obj, params) {
     var geometry, controls, material, mesh, edges;
     var width, height, scale, offset, projRight, projUp;
     var directionalLightArray = [];
+    var inheritedWidth = false, inheritedHeight = false;
 
     if (typeof params === "undefined" || !("width" in params)) {
         width = window.innerWidth;
+        inheritedWidth = true;
     } else {
         width = params.width;
     }
 
     if (typeof params === "undefined" || !("height" in params)) {
         height = window.innerHeight;
+        inheritedHeight = true;
     } else {
         height = params.height;
     }
@@ -409,8 +412,29 @@ solvespace = function(obj, params) {
         controls.addEventListener("change", render);
         controls.addEventListener("change", lightUpdate);
 
+        if(inheritedWidth || inheritedHeight) {
+            window.addEventListener("resize", resize);
+        }
+
         animate();
         return renderer.domElement;
+    }
+
+    function resize() {
+        if(inheritedWidth)
+            width = window.innerWidth;
+        if(inheritedHeight)
+            height = window.innerHeight;
+
+        camera.renderWidth = width;
+        camera.renderHeight = height;
+
+        renderer.setSize(width * window.devicePixelRatio, height * window.devicePixelRatio);
+        renderer.domElement.style =
+            "width:  " + width  + "px;" +
+            "height: " + height + "px;";
+
+        render();
     }
 
     function animate() {

--- a/res/threejs/SolveSpaceControls.js
+++ b/res/threejs/SolveSpaceControls.js
@@ -421,13 +421,19 @@ solvespace = function(obj, params) {
     }
 
     function resize() {
-        if(inheritedWidth)
+        scale = camera.zoomScale;
+        if(inheritedWidth) {
+            scale *= window.innerWidth / width;
             width = window.innerWidth;
-        if(inheritedHeight)
+        }
+        if(inheritedHeight) {
+            scale *= window.innerHeight / height;
             height = window.innerHeight;
+        }
 
         camera.renderWidth = width;
         camera.renderHeight = height;
+        camera.zoomScale = scale;
 
         renderer.setSize(width * window.devicePixelRatio, height * window.devicePixelRatio);
         renderer.domElement.style =


### PR DESCRIPTION
Resizing the browser window had no effect, leading to requiring a reload. With this patch the view size follows the browser's, if not overridden in `params`.

I arrived at this code by blind-hacking at the export, so am not sure if all is up to standard (the `render()` call in particular).