### PR TITLE
Win32: Restore Windows XP Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,8 +259,8 @@ if(WIN32)
         -D_CRT_SECURE_NO_DEPRECATE
         -D_CRT_SECURE_NO_WARNINGS
         -D_SCL_SECURE_NO_WARNINGS
-        -DWINVER=0x0601
-        -D_WIN32_WINNT=0x0601
+        -DWINVER=0x0501
+        -D_WIN32_WINNT=0x0501
         -D_WIN32_IE=_WIN32_WINNT
         -DISOLATION_AWARE_ENABLED
         -DWIN32
@@ -285,7 +285,7 @@ if(MSVC)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(WARNING_FLAGS   "-Wall -Wextra -Wno-unused-parameter")
+    set(WARNING_FLAGS   "-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(WARNING_FLAGS "${WARNING_FLAGS} -Wfloat-conversion")
     endif()

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -12,6 +12,24 @@
 #include <commdlg.h>
 #include <shellapi.h>
 
+// Macros to compile under XP
+#if !defined(LSTATUS)
+#   define LSTATUS LONG
+#endif
+
+#if !defined(MAPVK_VK_TO_CHAR)
+#   define MAPVK_VK_TO_CHAR 2
+#endif
+
+#if !defined(USER_DEFAULT_SCREEN_DPI)
+#   define USER_DEFAULT_SCREEN_DPI 96
+#endif
+
+#if !defined(TTM_POPUP)
+#   define TTM_POPUP (WM_USER + 34)
+#endif
+// End macros to compile under XP
+
 #if !defined(WM_DPICHANGED)
 #   define WM_DPICHANGED 0x02E0
 #endif


### PR DESCRIPTION
By setting WINVER=0x0501 (Windows XP) in CMakeLists.txt and adding a few
missing defines in guiwin.cpp and configuring OPENGL=1 in CMake
Solvespace (3.0~25b6eba1) compiles and works perfectly on Windows XP.
Tested with MinGW GCC-6.3.0-1

[solvespace_WinXP_3.0_25b6eba1.zip](https://github.com/solvespace/solvespace/files/3210928/solvespace_WinXP_3.0_25b6eba1.zip)