### PR TITLE
WIP: Port both IdList and List to std::vector

### DIFF
--- a/src/dsc.h
+++ b/src/dsc.h
@@ -464,18 +464,16 @@ public:
         }
         const auto oldN = dest->n;
 
-        // Mainly ensures we have a vector allocated:
-        // the range insert would reserve as well.
+        // Mainly ensures we have a vector allocated, but also limits re-allocations to 1.
         dest->ReserveMore(n);
+        for(auto &elt : *this) { dest->vec->push_back(elt); }
 
-        dest->vec->insert(dest->end(), begin(), end());
+        dest->UpdateSize();
 
         // The items we just added are sorted, so merge
         std::inplace_merge(dest->begin(), dest->begin() + oldN, dest->end(), Compare());
 
         /// @todo Look to see if we already have something with the same handle value.
-
-        dest->UpdateSize();
 
         // Just drop, don't clear.
         vec.reset();

--- a/src/dsc.h
+++ b/src/dsc.h
@@ -420,6 +420,27 @@ public:
         std::inplace_merge(begin(), end() - 1, end(), Compare());
     }
 
+    void MergeInto(IdList *dest) {
+        dest->ReserveMore(n);
+
+        const auto oldEnd = dest->elem + dest->n;
+        auto outIter      = oldEnd;
+
+        for(auto &elt : *this) {
+            // Copy-construct at the end of the list.
+            new(outIter) T(elt);
+            ++outIter;
+        }
+
+        /// @todo Look to see if we already have something with the same handle value.
+
+        dest->n = dest->n + n;
+        Clear();
+
+        // The items we just added are sorted, so merge
+        std::inplace_merge(dest->begin(), oldEnd, dest->end(), Compare());
+    }
+
     T *FindById(H h) {
         T *t = FindByIdNoOops(h);
         ssassert(t != NULL, "Cannot find handle");

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -1196,7 +1196,7 @@ void SolveSpaceUI::ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, S
 
 
     std::map<std::uint8_t, std::vector<STriangleSpan>> opacities;
-    STriangle *start          = sm->l.begin();
+    STriangle *start          = &(*sm->l.begin());
     std::uint8_t last_opacity = start->meta.color.alpha;
     for(auto & tr : sm->l) {
         if(tr.meta.color.alpha != last_opacity) {
@@ -1205,7 +1205,7 @@ void SolveSpaceUI::ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, S
             last_opacity = start->meta.color.alpha;
         }
     }
-    opacities[last_opacity].push_back(STriangleSpan{start, sm->l.end()});
+    opacities[last_opacity].push_back(STriangleSpan{start, &(*sm->l.begin()) + sm->l.n});
 
     for(auto && op : opacities) {
         fprintf(f, "\n"

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -121,6 +121,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
             break;
     }
 
+    EntityList entityAdditions;
     Entity e = {};
     EntReqTable::GetRequestInfo(type, extraPoints, &et, &points, &hasNormal, &hasDistance);
 
@@ -158,7 +159,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
             p.param[0] = AddParam(param, h.param(16 + 3*i + 0));
             p.param[1] = AddParam(param, h.param(16 + 3*i + 1));
         }
-        entity->Add(&p);
+        entityAdditions.Add(&p);
         e.point[i] = p.h;
     }
     if(hasNormal) {
@@ -183,7 +184,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
         // The point determines where the normal gets displayed on-screen;
         // it's entirely cosmetic.
         n.point[0] = e.point[0];
-        entity->Add(&n);
+        entityAdditions.Add(&n);
         e.normal = n.h;
     }
     if(hasDistance) {
@@ -194,11 +195,13 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
         d.style = style;
         d.type = Entity::Type::DISTANCE;
         d.param[0] = AddParam(param, h.param(64));
-        entity->Add(&d);
+        entityAdditions.Add(&d);
         e.distance = d.h;
     }
 
-    if(et != (Entity::Type)0) entity->Add(&e);
+    if(et != (Entity::Type)0) entityAdditions.Add(&e);
+
+    entityAdditions.MergeInto(entity);
 }
 
 std::string Request::DescriptionString() const {

--- a/src/ttf.cpp
+++ b/src/ttf.cpp
@@ -91,8 +91,8 @@ TtfFont *TtfFontList::LoadFont(const std::string &font)
 {
     LoadAll();
 
-    TtfFont *tf = std::find_if(l.begin(), l.end(),
-        [&font](const TtfFont &tf) { return tf.FontFileBaseName() == font; });
+    auto tf = std::find_if(l.begin(), l.end(),
+                           [&font](const TtfFont &tf) { return tf.FontFileBaseName() == font; });
 
     if(tf != l.end()) {
         if(tf->fontFace == NULL) {
@@ -101,7 +101,7 @@ TtfFont *TtfFontList::LoadFont(const std::string &font)
             else
                 tf->LoadFromFile(fontLibrary, /*nameOnly=*/false);
         }
-        return tf;
+        return &(*tf);
     } else {
         return NULL;
     }


### PR DESCRIPTION
WIP because it doesn't pass the tests. (All but the last two commits pass - those passing commits are in other PRs) Current test results:

```
Missing (absent) translation for group-name'#references'
Missing (absent) translation for group-name'sketch-in-plane'
  OK   test constraint/length_difference/normal_migrate_from_v22
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_line_distance/test.cpp:21: FAILED: render doesn't match reference; 30 (0.01%) pixels differ
  NG   test constraint/pt_line_distance/free_in_3d_roundtrip
  OK   test core/path/from_raw
  OK   test constraint/proj_pt_distance/reference_migrate_from_v22
test/constraint/where_dragged/test.cpp:21: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test constraint/where_dragged/free_in_3d_roundtrip
  OK   test constraint/horizontal/line_migrate_from_v22
  OK   test core/path/extension
test/constraint/length_difference/test.cpp:5: FAILED: render doesn't match reference; 42 (0.01%) pixels differ
  NG   test constraint/length_difference/normal_roundtrip
  OK   test constraint/same_orientation/normal_migrate_from_v22
test/constraint/equal_angle/test.cpp:21: FAILED: render doesn't match reference; 59 (0.02%) pixels differ
  NG   test constraint/equal_angle/other_roundtrip
  OK   test constraint/symmetric/normal_migrate_from_v22
test/constraint/pt_pt_distance/test.cpp:37: FAILED: render doesn't match reference; 19 (0.01%) pixels differ
  NG   test constraint/pt_pt_distance/reference_roundtrip
test/constraint/equal_line_arc_len/test.cpp:26: FAILED: render doesn't match reference; 9 (0.00%) pixels differ
  NG   test constraint/equal_line_arc_len/tau
  OK   test core/expr/literal
  OK   test constraint/pt_on_line/normal_migrate_from_v22
  OK   test constraint/pt_line_distance/reference_migrate_from_v22
  OK   test constraint/pt_face_distance/normal_migrate_from_v20
test/constraint/angle/test.cpp:5: FAILED: render doesn't match reference; 25 (0.01%) pixels differ
  NG   test constraint/angle/normal_roundtrip
  OK   test constraint/diameter/normal_migrate_from_v20
test/constraint/symmetric/test.cpp:21: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test constraint/symmetric/free_in_3d_roundtrip
test/constraint/horizontal/test.cpp:21: FAILED: render doesn't match reference; 45 (0.01%) pixels differ
  NG   test constraint/horizontal/pt_pt_roundtrip
test/constraint/length_ratio/test.cpp:5: FAILED: render doesn't match reference; 37 (0.01%) pixels differ
  NG   test constraint/length_ratio/normal_roundtrip
test/constraint/pt_line_distance/test.cpp:53: FAILED: render doesn't match reference; 30 (0.01%) pixels differ
  NG   test constraint/pt_line_distance/extended_render
  OK   test constraint/at_midpoint/line_pt_free_in_3d_migrate_from_v22
test/constraint/angle/test.cpp:21: FAILED: render doesn't match reference; 25 (0.01%) pixels differ
  NG   test constraint/angle/free_in_3d_roundtrip
  OK   test constraint/cubic_line_tangent/normal_migrate_from_v20
test/constraint/points_coincident/test.cpp:5: FAILED: render doesn't match reference; 2 (0.00%) pixels differ
  NG   test constraint/points_coincident/normal_roundtrip
  OK   test constraint/at_midpoint/line_plane_normal_migrate_from_v22
test/constraint/equal_line_arc_len/test.cpp:5: FAILED: render doesn't match reference; 34 (0.01%) pixels differ
  NG   test constraint/equal_line_arc_len/normal_roundtrip
  OK   test constraint/comment/normal_migrate_from_v20
test/constraint/points_coincident/test.cpp:21: FAILED: render doesn't match reference; 2 (0.00%) pixels differ
  NG   test constraint/points_coincident/free_in_3d_roundtrip
  OK   test constraint/eq_pt_ln_distances/normal_migrate_from_v20
  OK   test core/path/is_absolute_unix
  OK   test constraint/proj_pt_distance/reference_migrate_from_v20
failed: I=8, avoid=870895808
print 870895840 edges
failed: I=9, avoid=870895808
print 870895840 edges
failed: I=10, avoid=870895808
print 870895840 edges
failed: I=11, avoid=870895808
print 870895840 edges
failed: I=8, avoid=870895808
print 870895840 edges
failed: I=9, avoid=870895808
print 870895840 edges
failed: I=10, avoid=870895808
print 870895840 edges
failed: I=11, avoid=870895808
print 870895840 edges
failed: I=14, avoid=870895808
print 870895840 edges
failed: I=15, avoid=870895808
print 870895840 edges
failed: I=16, avoid=870895808
print 870895840 edges
failed: I=17, avoid=870895808
print 870895840 edges
failed: I=20, avoid=870895808
print 870895840 edges
failed: I=21, avoid=870895808
print 870895840 edges
failed: I=22, avoid=870895808
print 870895840 edges
failed: I=23, avoid=870895808
print 870895840 edges
failed: I=8, avoid=870895808
print 870895840 edges
failed: I=9, avoid=870895808
print 870895840 edges
failed: I=10, avoid=870895808
print 870895840 edges
failed: I=11, avoid=870895808
print 870895840 edges
failed: I=14, avoid=870895808
print 870895840 edges
failed: I=15, avoid=870895808
print 870895840 edges
failed: I=16, avoid=870895808
print 870895840 edges
failed: I=17, avoid=870895808
print 870895840 edges
failed: I=20, avoid=870895808
print 870895840 edges
failed: I=21, avoid=870895808
print 870895840 edges
failed: I=22, avoid=870895808
print 870895840 edges
failed: I=23, avoid=870895808
print 870895840 edges
failed: I=26, avoid=870895808
print 870895840 edges
failed: I=27, avoid=870895808
print 870895840 edges
failed: I=28, avoid=870895808
print 870895840 edges
failed: I=29, avoid=870895808
print 870895840 edges
failed: I=32, avoid=870895808
print 870895840 edges
failed: I=33, avoid=870895808
print 870895840 edges
failed: I=34, avoid=870895808
print 870895840 edges
failed: I=35, avoid=870895808
print 870895840 edges
failed: I=38, avoid=870895808
print 870895840 edges
failed: I=39, avoid=870895808
print 870895840 edges
failed: I=40, avoid=870895808
print 870895840 edges
failed: I=41, avoid=870895808
print 870895840 edges
failed: I=44, avoid=870895808
print 870895840 edges
failed: I=45, avoid=870895808
print 870895840 edges
failed: I=46, avoid=870895808
print 870895840 edges
failed: I=47, avoid=870895808
print 870895840 edges
failed: I=50, avoid=870895808
print 870895840 edges
failed: I=51, avoid=870895808
print 870895840 edges
failed: I=52, avoid=870895808
print 870895840 edges
failed: I=53, avoid=870895808
print 870895840 edges
failed: I=56, avoid=870895808
print 870895840 edges
failed: I=57, avoid=870895808
print 870895840 edges
failed: I=58, avoid=870895808
print 870895840 edges
failed: I=59, avoid=870895808
print 870895840 edges
polygon has no top-level contours?
polygon has no top-level contours?
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
failed to assemble polygon to trim nurbs surface in uv space
test/group/translate_nd/test.cpp:5: FAILED: render doesn't match reference; 21683 (6.02%) pixels differ
  NG   test group/translate_nd/normal_roundtrip
  OK   test constraint/symmetric/normal_migrate_from_v20
  OK   test constraint/pt_in_plane/normal_migrate_from_v20
  OK   test constraint/equal_angle/other_migrate_from_v20
  OK   test constraint/curve_curve_tangent/arc_cubic_migrate_from_v20
  OK   test constraint/at_midpoint/line_plane_free_in_3d_migrate_from_v22
  OK   test constraint/proj_pt_distance/normal_migrate_from_v22
  OK   test request/cubic/normal_migrate_from_v20
test/request/cubic/test.cpp:5: FAILED: render doesn't match reference; 5 (0.00%) pixels differ
  NG   test request/cubic/normal_roundtrip
  OK   test constraint/pt_on_line/free_in_3d_migrate_from_v22
test/constraint/length_ratio/test.cpp:21: FAILED: render doesn't match reference; 37 (0.01%) pixels differ
  NG   test constraint/length_ratio/reference_roundtrip
  OK   test constraint/angle/reference_free_in_3d_migrate_from_v20
  OK   test constraint/equal_line_arc_len/normal_migrate_from_v22
test/analysis/contour_area/test.cpp:6: FAILED: render doesn't match reference; 68 (0.02%) pixels differ
  NG   test analysis/contour_area/normal_roundtrip
test/constraint/diameter/test.cpp:5: FAILED: render doesn't match reference; 22 (0.01%) pixels differ
  NG   test constraint/diameter/normal_roundtrip
  OK   test request/cubic_periodic/normal_migrate_from_v20
test/constraint/parallel/test.cpp:21: FAILED: render doesn't match reference; 29 (0.01%) pixels differ
  NG   test constraint/parallel/free_in_3d_roundtrip
test/constraint/same_orientation/test.cpp:21: FAILED: render doesn't match reference; 29 (0.01%) pixels differ
  NG   test constraint/same_orientation/same_group_roundtrip
  OK   test constraint/same_orientation/normal_migrate_from_v20
  OK   test constraint/pt_plane_distance/normal_migrate_from_v20
  OK   test core/path/file_stem
  OK   test constraint/curve_curve_tangent/arc_cubic_migrate_from_v22
  OK   test constraint/pt_line_distance/normal_migrate_from_v20
  OK   test constraint/equal_line_arc_len/normal_migrate_from_v20
test/constraint/vertical/test.cpp:21: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test constraint/vertical/pt_pt_roundtrip
  OK   test constraint/at_midpoint/line_pt_free_in_3d_migrate_from_v20
  OK   test constraint/angle/free_in_3d_migrate_from_v22
test/group/translate_asy/test.cpp:5: FAILED: render doesn't match reference; 1079 (0.30%) pixels differ
  NG   test group/translate_asy/normal_roundtrip
  OK   test constraint/horizontal/line_migrate_from_v20
test/request/line_segment/test.cpp:5: FAILED: render doesn't match reference; 27 (0.01%) pixels differ
  NG   test request/line_segment/normal_roundtrip
  OK   test constraint/pt_line_distance/free_in_3d_migrate_from_v22
  OK   test request/cubic/normal_migrate_from_v22
  OK   test core/expr/precedence
test/constraint/pt_pt_distance/test.cpp:5: FAILED: render doesn't match reference; 19 (0.01%) pixels differ
  NG   test constraint/pt_pt_distance/normal_roundtrip
  OK   test constraint/angle/normal_migrate_from_v22
  OK   test core/path/file_name
  OK   test core/path/from_portable
  OK   test constraint/angle/reference_free_in_3d_migrate_from_v22
  OK   test constraint/cubic_line_tangent/free_in_3d_migrate_from_v22
  OK   test constraint/points_coincident/free_in_3d_migrate_from_v20
  OK   test constraint/pt_on_face/normal_migrate_from_v22
test/constraint/comment/test.cpp:5: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test constraint/comment/normal_roundtrip
  OK   test group/link/normal_migrate_from_v20
  OK   test request/cubic_periodic/normal_migrate_from_v22
  OK   test constraint/length_ratio/reference_migrate_from_v20
  OK   test constraint/symmetric/free_in_3d_migrate_from_v20
  OK   test core/path/relative_to
test/constraint/symmetric_vert/test.cpp:5: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test constraint/symmetric_vert/normal_roundtrip
test/constraint/pt_on_line/test.cpp:27: FAILED: render doesn't match reference; 66 (0.02%) pixels differ
  NG   test constraint/pt_on_line/right_free_in_3d_roundtrip
  OK   test core/path/parent
  OK   test constraint/symmetric_line/normal_migrate_from_v20
  OK   test constraint/pt_plane_distance/normal_migrate_from_v22
  OK   test constraint/symmetric_horiz/normal_migrate_from_v20
test/constraint/at_midpoint/test.cpp:21: FAILED: render doesn't match reference; 66 (0.02%) pixels differ
  NG   test constraint/at_midpoint/line_pt_free_in_3d_roundtrip
test/constraint/cubic_line_tangent/test.cpp:21: FAILED: render doesn't match reference; 43 (0.01%) pixels differ
  NG   test constraint/cubic_line_tangent/free_in_3d_roundtrip
  OK   test core/expr/constant
  OK   test request/line_segment/normal_migrate_from_v20
test/constraint/eq_pt_ln_distances/test.cpp:5: FAILED: render doesn't match reference; 38 (0.01%) pixels differ
  NG   test constraint/eq_pt_ln_distances/normal_roundtrip
  OK   test core/expr/binary_ops
test/request/circle/test.cpp:5: FAILED: render doesn't match reference; 45 (0.01%) pixels differ
  NG   test request/circle/normal_roundtrip
  OK   test constraint/diameter/reference_migrate_from_v22
  OK   test core/expr/parentheses
test/request/circle/test.cpp:44: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test request/circle/free_in_3d_dof
  OK   test constraint/cubic_line_tangent/normal_migrate_from_v22
test/constraint/diameter/test.cpp:21: FAILED: render doesn't match reference; 22 (0.01%) pixels differ
  NG   test constraint/diameter/reference_roundtrip
test/constraint/parallel/test.cpp:5: FAILED: render doesn't match reference; 43 (0.01%) pixels differ
  NG   test constraint/parallel/normal_roundtrip
  OK   test core/expr/variable
test/request/datum_point/test.cpp:5: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test request/datum_point/normal_roundtrip
  OK   test constraint/parallel/normal_migrate_from_v20
  OK   test group/link/normal_migrate_from_v22
test/constraint/horizontal/test.cpp:5: FAILED: render doesn't match reference; 27 (0.01%) pixels differ
  NG   test constraint/horizontal/line_roundtrip
  OK   test group/translate_asy/normal_inters
test/constraint/arc_line_tangent/test.cpp:5: FAILED: render doesn't match reference; 48 (0.01%) pixels differ
  NG   test constraint/arc_line_tangent/normal_roundtrip
  OK   test core/locale/parseable
Missing (empty) translation for group-name'#references'
Missing (empty) translation for group-name'sketch-in-plane'
  OK   test request/circle/free_in_3d_migrate_from_v22
test/constraint/symmetric/test.cpp:5: FAILED: render doesn't match reference; 19 (0.01%) pixels differ
  NG   test constraint/symmetric/normal_roundtrip
test/constraint/eq_len_pt_line_d/test.cpp:5: FAILED: render doesn't match reference; 60 (0.02%) pixels differ
  NG   test constraint/eq_len_pt_line_d/normal_roundtrip
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_line_distance/test.cpp:5: FAILED: render doesn't match reference; 30 (0.01%) pixels differ
  NG   test constraint/pt_line_distance/normal_roundtrip
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_face_distance/test.cpp:21: FAILED: render doesn't match reference; 260 (0.07%) pixels differ
  NG   test constraint/pt_face_distance/reference_roundtrip
  OK   test constraint/symmetric_line/normal_migrate_from_v22
  OK   test constraint/arc_line_tangent/normal_migrate_from_v22
test/constraint/proj_pt_distance/test.cpp:21: FAILED: render doesn't match reference; 29 (0.01%) pixels differ
  NG   test constraint/proj_pt_distance/reference_roundtrip
  OK   test constraint/pt_pt_distance/reference_migrate_from_v20
  OK   test constraint/symmetric_vert/normal_migrate_from_v22
  OK   test constraint/pt_face_distance/reference_migrate_from_v22
test/request/workplane/test.cpp:5: FAILED: render doesn't match reference; 26 (0.01%) pixels differ
  NG   test request/workplane/normal_roundtrip
test/constraint/pt_on_circle/test.cpp:5: FAILED: render doesn't match reference; 32 (0.01%) pixels differ
  NG   test constraint/pt_on_circle/normal_roundtrip
  OK   test constraint/pt_on_circle/normal_migrate_from_v20
  OK   test constraint/pt_on_line/normal_migrate_from_v20
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_line_distance/test.cpp:37: FAILED: render doesn't match reference; 30 (0.01%) pixels differ
  NG   test constraint/pt_line_distance/reference_roundtrip
  OK   test constraint/vertical/pt_pt_migrate_from_v22
test/constraint/cubic_line_tangent/test.cpp:5: FAILED: render doesn't match reference; 52 (0.01%) pixels differ
  NG   test constraint/cubic_line_tangent/normal_roundtrip
test/constraint/curve_curve_tangent/test.cpp:21: FAILED: render doesn't match reference; 63 (0.02%) pixels differ
  NG   test constraint/curve_curve_tangent/arc_cubic_roundtrip
test/constraint/equal_radius/test.cpp:5: FAILED: render doesn't match reference; 29 (0.01%) pixels differ
  NG   test constraint/equal_radius/normal_roundtrip
  OK   test constraint/curve_curve_tangent/arc_arc_migrate_from_v22
  OK   test core/path/relative_to_unix
  OK   test core/expr/unary_ops
test/constraint/symmetric_line/test.cpp:5: FAILED: render doesn't match reference; 14 (0.00%) pixels differ
  NG   test constraint/symmetric_line/normal_roundtrip
test/group/link/test.cpp:5: FAILED: render doesn't match reference; 47 (0.01%) pixels differ
  NG   test group/link/normal_roundtrip
  OK   test constraint/equal_radius/normal_migrate_from_v20
  OK   test constraint/perpendicular/normal_migrate_from_v22
  OK   test constraint/pt_line_distance/normal_migrate_from_v22
  OK   test constraint/pt_face_distance/reference_migrate_from_v20
test/constraint/vertical/test.cpp:5: FAILED: render doesn't match reference; 35 (0.01%) pixels differ
  NG   test constraint/vertical/line_roundtrip
  OK   test request/workplane/normal_migrate_from_v20
  OK   test constraint/angle/free_in_3d_migrate_from_v20
  OK   test constraint/symmetric/free_in_3d_migrate_from_v22
  OK   test constraint/equal_radius/normal_migrate_from_v22
  OK   test constraint/parallel/normal_migrate_from_v22
  OK   test constraint/diameter/normal_migrate_from_v22
  OK   test constraint/pt_plane_distance/reference_migrate_from_v20
  OK   test core/path/equals_unix
  OK   test constraint/equal_angle/normal_migrate_from_v20
  OK   test request/image/linked_roundtrip
test/request/ttf_text/test.cpp:5: FAILED: render doesn't match reference; 12 (0.00%) pixels differ
  NG   test request/ttf_text/normal_roundtrip
  OK   test constraint/vertical/line_migrate_from_v20
  OK   test request/datum_point/normal_migrate_from_v20
test/constraint/angle/test.cpp:37: FAILED: render doesn't match reference; 23 (0.01%) pixels differ
  NG   test constraint/angle/reference_roundtrip
test/constraint/at_midpoint/test.cpp:37: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test constraint/at_midpoint/line_plane_normal_roundtrip
  OK   test constraint/points_coincident/free_in_3d_migrate_from_v22
  OK   test constraint/where_dragged/free_in_3d_migrate_from_v20
  OK   test constraint/pt_on_circle/negative_dia
  OK   test constraint/diameter/reference_migrate_from_v20
test/constraint/angle/test.cpp:69: FAILED: render doesn't match reference; 22 (0.01%) pixels differ
  NG   test constraint/angle/skew_render
test/request/circle/test.cpp:21: FAILED: render doesn't match reference; 45 (0.01%) pixels differ
  NG   test request/circle/free_in_3d_roundtrip
  OK   test constraint/pt_on_line/free_in_3d_migrate_from_v20
  OK   test constraint/equal_length_lines/normal_migrate_from_v22
  OK   test constraint/at_midpoint/line_plane_normal_migrate_from_v20
  OK   test constraint/horizontal/pt_pt_migrate_from_v22
  OK   test constraint/pt_line_distance/free_in_3d_migrate_from_v20
  OK   test constraint/where_dragged/free_in_3d_migrate_from_v22
  OK   test constraint/points_coincident/normal_migrate_from_v20
  OK   test core/path/with_extension
  OK   test constraint/pt_pt_distance/reference_migrate_from_v22
  OK   test constraint/pt_pt_distance/free_in_3d_migrate_from_v20
  OK   test core/path/has_extension
  OK   test core/path/expand_from_cwd
  OK   test constraint/points_coincident/normal_migrate_from_v22
  OK   test constraint/pt_pt_distance/normal_migrate_from_v20
test/constraint/perpendicular/test.cpp:5: FAILED: render doesn't match reference; 5 (0.00%) pixels differ
  NG   test constraint/perpendicular/normal_roundtrip
  OK   test group/translate_asy/normal_migrate_from_v22
test/constraint/pt_pt_distance/test.cpp:21: FAILED: render doesn't match reference; 19 (0.01%) pixels differ
  NG   test constraint/pt_pt_distance/free_in_3d_roundtrip
  OK   test constraint/pt_on_face/normal_migrate_from_v20
failed: I=8, avoid=870895808
print 870895840 edges
failed: I=9, avoid=870895808
print 870895840 edges
failed: I=10, avoid=870895808
print 870895840 edges
failed: I=11, avoid=870895808
print 870895840 edges
failed: I=8, avoid=870895808
print 870895840 edges
failed: I=9, avoid=870895808
print 870895840 edges
failed: I=10, avoid=870895808
print 870895840 edges
failed: I=11, avoid=870895808
print 870895840 edges
failed: I=14, avoid=870895808
print 870895840 edges
failed: I=15, avoid=870895808
print 870895840 edges
failed: I=16, avoid=870895808
print 870895840 edges
failed: I=17, avoid=870895808
print 870895840 edges
failed: I=20, avoid=870895808
print 870895840 edges
failed: I=21, avoid=870895808
print 870895840 edges
failed: I=22, avoid=870895808
print 870895840 edges
failed: I=23, avoid=870895808
print 870895840 edges
failed: I=8, avoid=870895808
print 870895840 edges
failed: I=9, avoid=870895808
print 870895840 edges
failed: I=10, avoid=870895808
print 870895840 edges
failed: I=11, avoid=870895808
print 870895840 edges
failed: I=14, avoid=870895808
print 870895840 edges
failed: I=15, avoid=870895808
print 870895840 edges
failed: I=16, avoid=870895808
print 870895840 edges
failed: I=17, avoid=870895808
print 870895840 edges
failed: I=20, avoid=870895808
print 870895840 edges
failed: I=21, avoid=870895808
print 870895840 edges
failed: I=22, avoid=870895808
print 870895840 edges
failed: I=23, avoid=870895808
print 870895840 edges
failed: I=26, avoid=870895808
print 870895840 edges
failed: I=27, avoid=870895808
print 870895840 edges
failed: I=28, avoid=870895808
print 870895840 edges
failed: I=29, avoid=870895808
print 870895840 edges
failed: I=32, avoid=870895808
print 870895840 edges
failed: I=33, avoid=870895808
print 870895840 edges
failed: I=34, avoid=870895808
print 870895840 edges
failed: I=35, avoid=870895808
print 870895840 edges
failed: I=38, avoid=870895808
print 870895840 edges
failed: I=39, avoid=870895808
print 870895840 edges
failed: I=40, avoid=870895808
print 870895840 edges
failed: I=41, avoid=870895808
print 870895840 edges
failed: I=44, avoid=870895808
print 870895840 edges
failed: I=45, avoid=870895808
print 870895840 edges
failed: I=46, avoid=870895808
print 870895840 edges
failed: I=47, avoid=870895808
print 870895840 edges
failed: I=50, avoid=870895808
print 870895840 edges
failed: I=51, avoid=870895808
print 870895840 edges
failed: I=52, avoid=870895808
print 870895840 edges
failed: I=53, avoid=870895808
print 870895840 edges
failed: I=56, avoid=870895808
print 870895840 edges
failed: I=57, avoid=870895808
print 870895840 edges
failed: I=58, avoid=870895808
print 870895840 edges
failed: I=59, avoid=870895808
print 870895840 edges
failed: I=8, avoid=870895456
print 870895488 edges
failed: I=9, avoid=870895456
print 870895488 edges
failed: I=10, avoid=870895456
print 870895488 edges
failed: I=11, avoid=870895456
print 870895488 edges
failed: I=8, avoid=870895456
print 870895488 edges
failed: I=9, avoid=870895456
print 870895488 edges
failed: I=10, avoid=870895456
print 870895488 edges
failed: I=11, avoid=870895456
print 870895488 edges
failed: I=14, avoid=870895456
print 870895488 edges
failed: I=15, avoid=870895456
print 870895488 edges
failed: I=16, avoid=870895456
print 870895488 edges
failed: I=17, avoid=870895456
print 870895488 edges
failed: I=20, avoid=870895456
print 870895488 edges
failed: I=21, avoid=870895456
print 870895488 edges
failed: I=22, avoid=870895456
print 870895488 edges
failed: I=23, avoid=870895456
print 870895488 edges
failed: I=8, avoid=870895456
print 870895488 edges
failed: I=9, avoid=870895456
print 870895488 edges
failed: I=10, avoid=870895456
print 870895488 edges
failed: I=11, avoid=870895456
print 870895488 edges
failed: I=14, avoid=870895456
print 870895488 edges
failed: I=15, avoid=870895456
print 870895488 edges
failed: I=16, avoid=870895456
print 870895488 edges
failed: I=17, avoid=870895456
print 870895488 edges
failed: I=20, avoid=870895456
print 870895488 edges
failed: I=21, avoid=870895456
print 870895488 edges
failed: I=22, avoid=870895456
print 870895488 edges
failed: I=23, avoid=870895456
print 870895488 edges
failed: I=26, avoid=870895456
print 870895488 edges
failed: I=27, avoid=870895456
print 870895488 edges
failed: I=28, avoid=870895456
print 870895488 edges
failed: I=29, avoid=870895456
print 870895488 edges
failed: I=32, avoid=870895456
print 870895488 edges
failed: I=33, avoid=870895456
print 870895488 edges
failed: I=34, avoid=870895456
print 870895488 edges
failed: I=35, avoid=870895456
print 870895488 edges
failed: I=38, avoid=870895456
print 870895488 edges
failed: I=39, avoid=870895456
print 870895488 edges
failed: I=40, avoid=870895456
print 870895488 edges
failed: I=41, avoid=870895456
print 870895488 edges
failed: I=44, avoid=870895456
print 870895488 edges
failed: I=45, avoid=870895456
print 870895488 edges
failed: I=46, avoid=870895456
print 870895488 edges
failed: I=47, avoid=870895456
print 870895488 edges
failed: I=50, avoid=870895456
print 870895488 edges
failed: I=51, avoid=870895456
print 870895488 edges
failed: I=52, avoid=870895456
print 870895488 edges
failed: I=53, avoid=870895456
print 870895488 edges
failed: I=56, avoid=870895456
print 870895488 edges
failed: I=57, avoid=870895456
print 870895488 edges
failed: I=58, avoid=870895456
print 870895488 edges
failed: I=59, avoid=870895456
print 870895488 edges
  OK   test group/translate_nd/normal_migrate_from_v22
  OK   test constraint/cubic_line_tangent/free_in_3d_migrate_from_v20
  OK   test constraint/horizontal/pt_pt_migrate_from_v20
test/constraint/proj_pt_distance/test.cpp:5: FAILED: render doesn't match reference; 29 (0.01%) pixels differ
  NG   test constraint/proj_pt_distance/normal_roundtrip
  OK   test request/image/normal_roundtrip
  OK   test constraint/length_ratio/normal_migrate_from_v22
  OK   test request/ttf_text/normal_migrate_from_v22
  OK   test request/arc_of_circle/normal_migrate_from_v22
  OK   test request/circle/normal_migrate_from_v22
  OK   test constraint/symmetric_horiz/normal_migrate_from_v22
  OK   test constraint/eq_len_pt_line_d/normal_migrate_from_v22
  OK   test request/line_segment/normal_migrate_from_v22
  OK   test core/path/join
  OK   test constraint/where_dragged/normal_migrate_from_v20
  OK   test constraint/symmetric_vert/normal_migrate_from_v20
  OK   test constraint/vertical/pt_pt_migrate_from_v20
  OK   test constraint/proj_pt_distance/normal_migrate_from_v20
  OK   test constraint/eq_pt_ln_distances/normal_migrate_from_v22
  OK   test constraint/where_dragged/normal_migrate_from_v22
  OK   test constraint/pt_in_plane/normal_roundtrip
  OK   test constraint/equal_length_lines/normal_migrate_from_v20
  OK   test constraint/perpendicular/normal_migrate_from_v20
  OK   test core/expr/functions
test/request/circle/test.cpp:38: FAILED: render doesn't match reference; 26 (0.01%) pixels differ
  NG   test request/circle/normal_dof
  OK   test core/expr/errors
  OK   test constraint/pt_face_distance/normal_migrate_from_v22
test/constraint/angle/test.cpp:53: FAILED: render doesn't match reference; 25 (0.01%) pixels differ
  NG   test constraint/angle/reference_free_in_3d_roundtrip
  OK   test constraint/same_orientation/normal_roundtrip
test/constraint/at_midpoint/test.cpp:5: FAILED: render doesn't match reference; 66 (0.02%) pixels differ
  NG   test constraint/at_midpoint/line_pt_normal_roundtrip
  OK   test constraint/at_midpoint/line_pt_normal_migrate_from_v20
  OK   test constraint/length_ratio/normal_migrate_from_v20
test/constraint/at_midpoint/test.cpp:53: FAILED: render doesn't match reference; 1 (0.00%) pixels differ
  NG   test constraint/at_midpoint/line_plane_free_in_3d_roundtrip
  OK   test request/datum_point/normal_migrate_from_v22
  OK   test constraint/length_ratio/reference_migrate_from_v22
  OK   test core/path/to_portable
  OK   test request/ttf_text/normal_migrate_from_v20
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_face_distance/test.cpp:5: FAILED: render doesn't match reference; 260 (0.07%) pixels differ
  NG   test constraint/pt_face_distance/normal_roundtrip
  OK   test request/workplane/normal_migrate_from_v22
  OK   test constraint/at_midpoint/line_plane_free_in_3d_migrate_from_v20
  OK   test constraint/pt_in_plane/normal_migrate_from_v22
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_plane_distance/test.cpp:21: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test constraint/pt_plane_distance/reference_roundtrip
  OK   test core/path/expand
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
Vector::WithMagnitude(1) of zero vector!
test/constraint/pt_plane_distance/test.cpp:5: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test constraint/pt_plane_distance/normal_roundtrip
  OK   test constraint/angle/reference_migrate_from_v20
  OK   test constraint/eq_len_pt_line_d/normal_migrate_from_v20
  OK   test constraint/pt_pt_distance/free_in_3d_migrate_from_v22
test/constraint/equal_length_lines/test.cpp:5: FAILED: render doesn't match reference; 21 (0.01%) pixels differ
  NG   test constraint/equal_length_lines/normal_roundtrip
  OK   test constraint/pt_on_circle/normal_migrate_from_v22
  OK   test constraint/curve_curve_tangent/arc_arc_migrate_from_v20
  OK   test constraint/equal_angle/other_migrate_from_v22
test/constraint/pt_on_face/test.cpp:5: FAILED: render doesn't match reference; 148 (0.04%) pixels differ
  NG   test constraint/pt_on_face/normal_roundtrip
test/constraint/pt_on_line/test.cpp:21: FAILED: render doesn't match reference; 39 (0.01%) pixels differ
  NG   test constraint/pt_on_line/left_free_in_3d_roundtrip
test/constraint/pt_on_line/test.cpp:5: FAILED: render doesn't match reference; 39 (0.01%) pixels differ
  NG   test constraint/pt_on_line/normal_roundtrip
  OK   test constraint/angle/normal_migrate_from_v20
test/constraint/equal_line_arc_len/test.cpp:21: FAILED: render doesn't match reference; 28 (0.01%) pixels differ
  NG   test constraint/equal_line_arc_len/pi
test/request/arc_of_circle/test.cpp:5: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test request/arc_of_circle/normal_roundtrip
  OK   test request/circle/normal_migrate_from_v20
test/constraint/symmetric_horiz/test.cpp:5: FAILED: render doesn't match reference; 19 (0.01%) pixels differ
  NG   test constraint/symmetric_horiz/normal_roundtrip
  OK   test constraint/pt_pt_distance/normal_migrate_from_v22
test/constraint/curve_curve_tangent/test.cpp:5: FAILED: render doesn't match reference; 14 (0.00%) pixels differ
  NG   test constraint/curve_curve_tangent/arc_arc_roundtrip
  OK   test constraint/parallel/free_in_3d_migrate_from_v22
  OK   test request/circle/free_in_3d_migrate_from_v20
  OK   test constraint/angle/reference_migrate_from_v22
  OK   test constraint/arc_line_tangent/normal_migrate_from_v20
  OK   test constraint/comment/normal_migrate_from_v22
  OK   test constraint/length_difference/reference_migrate_from_v22
test/constraint/where_dragged/test.cpp:5: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test constraint/where_dragged/normal_roundtrip
test/constraint/equal_angle/test.cpp:5: FAILED: render doesn't match reference; 70 (0.02%) pixels differ
  NG   test constraint/equal_angle/normal_roundtrip
  OK   test constraint/pt_plane_distance/reference_migrate_from_v22
  OK   test request/arc_of_circle/normal_migrate_from_v20
test/constraint/length_difference/test.cpp:16: FAILED: render doesn't match reference; 42 (0.01%) pixels differ
  NG   test constraint/length_difference/reference_roundtrip
  OK   test constraint/vertical/line_migrate_from_v22
  OK   test constraint/parallel/free_in_3d_migrate_from_v20
test/request/cubic_periodic/test.cpp:5: FAILED: render doesn't match reference; 46 (0.01%) pixels differ
  NG   test request/cubic_periodic/normal_roundtrip
  OK   test constraint/equal_angle/normal_migrate_from_v22
  OK   test constraint/at_midpoint/line_pt_normal_migrate_from_v22
  OK   test constraint/pt_line_distance/reference_migrate_from_v20
Failure! 80 checks failed
``