### PR TITLE
Linux: add support for building snap packages

### DIFF
--- a/pkg/snap/.gitignore
+++ b/pkg/snap/.gitignore
@@ -1,0 +1,3 @@
+*.snap
+solvespace-snap-src
+squashfs-root

--- a/pkg/snap/build.sh
+++ b/pkg/snap/build.sh
@@ -7,6 +7,6 @@ trap "rm -rf $solvespace_snap_src" EXIT
 cd "$dir"
 
 git_root="$(git rev-parse --show-toplevel)"
-rsync -r "$git_root"/ "$solvespace_snap_src"
+rsync --filter=":- .gitignore" -r "$git_root"/ "$solvespace_snap_src"
 
 snapcraft "$@"

--- a/pkg/snap/build.sh
+++ b/pkg/snap/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -xe
+
+dir="$(dirname "$(readlink -f "$0")")"
+solvespace_snap_src="$dir/solvespace-snap-src"
+trap "rm -rf $solvespace_snap_src" EXIT
+
+cd "$dir"
+
+git_root="$(git rev-parse --show-toplevel)"
+rsync -r "$git_root"/ "$solvespace_snap_src"
+
+snapcraft "$@"

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -12,7 +12,6 @@ description: |
   * mechanism design — use the constraint solver to simulate planar or spatial linkages, with pin, ball, or slide joints
   * plane and solid geometry — replace hand-solved trigonometry and spreadsheets with a live dimensioned drawing
 
-grade: stable
 confinement: strict
 
 layout:
@@ -40,6 +39,8 @@ parts:
       snapcraftctl pull
       version="3.0~$(git rev-parse --short=8 HEAD)"
       snapcraftctl set-version "$version"
+      git describe --exact-match HEAD && grade="stable" || grade="devel"
+      snapcraftctl set-grade "$grade"
       git submodule update --init extlib/libdxfrw extlib/flatbuffers extlib/q3d
     configflags:
       - -DCMAKE_INSTALL_PREFIX=/usr

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -38,7 +38,9 @@ parts:
     source-type: local
     override-pull: |
       snapcraftctl pull
-      version="3.0~$(git rev-parse --short=8 HEAD)"
+      version_major=$(grep "solvespace_VERSION_MAJOR" CMakeLists.txt | tr -d "()" | cut -d" " -f2)
+      version_minor=$(grep "solvespace_VERSION_MINOR" CMakeLists.txt | tr -d "()" | cut -d" " -f2)
+      version="$version_major.$version_minor~$(git rev-parse --short=8 HEAD)"
       snapcraftctl set-version "$version"
       git describe --exact-match HEAD && grade="stable" || grade="devel"
       snapcraftctl set-grade "$grade"

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -1,0 +1,72 @@
+name: solvespace
+base: core18
+summary: Parametric 2d/3d CAD
+adopt-info: solvespace
+description: |
+  SOLVESPACE is a free (GPLv3) parametric 3d CAD tool.
+  Applications include
+  * modeling 3d parts — draw with extrudes, revolves, and Boolean (union / difference) operations
+  * modeling 2d parts — draw the part as a single section, and export DXF, PDF, SVG; use 3d assembly to verify fit
+  * 3d-printed parts — export the STL or other triangle mesh expected by most 3d printers
+  * preparing CAM data — export 2d vector art for a waterjet machine or laser cutter; or generate STEP or STL, for import into third-party CAM software for machining
+  * mechanism design — use the constraint solver to simulate planar or spatial linkages, with pin, ball, or slide joints
+  * plane and solid geometry — replace hand-solved trigonometry and spreadsheets with a live dimensioned drawing
+
+grade: stable
+confinement: strict
+
+layout:
+  /usr/share/solvespace:
+    bind: $SNAP/usr/share/solvespace
+
+apps:
+  solvespace:
+    command: usr/bin/solvespace
+    desktop: solvespace.desktop
+    extensions: [gnome-3-28]
+    plugs: [opengl, unity7, home, removable-media, gsettings, network]
+    environment:
+      __EGL_VENDOR_LIBRARY_DIRS: $SNAP/usr/share/glvnd/egl_vendor.d
+  solvespace-cli:
+    command: usr/bin/solvespace-cli
+    plugs: [home, removable-media, network]
+
+parts:
+  solvespace:
+    plugin: cmake
+    source: ./solvespace-snap-src
+    source-type: local
+    override-pull: |
+      snapcraftctl pull
+      version="3.0~$(git rev-parse --short=8 HEAD)"
+      snapcraftctl set-version "$version"
+      git submodule update --init extlib/libdxfrw extlib/flatbuffers extlib/q3d
+    configflags:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_TESTS=OFF
+      - -DSNAP=ON
+    build-packages:
+      - zlib1g-dev
+      - libpng-dev
+      - libcairo2-dev
+      - libfreetype6-dev
+      - libjson-c-dev
+      - libfontconfig1-dev
+      - libgtkmm-3.0-dev
+      - libpangomm-1.4-dev
+      - libgl-dev
+      - libglu-dev
+      - libspnav-dev
+      - git
+    stage-packages:
+      - libspnav0
+      - libatkmm-1.6-1v5
+      - libcairomm-1.0-1v5
+      - libgtkmm-3.0-1v5
+      - libglibmm-2.4-1v5
+      - libpangomm-1.4-1v5
+      - libsigc++-2.0-0v5
+      - libglew2.0
+      - libegl-mesa0
+      - libdrm2

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ description: |
   * plane and solid geometry — replace hand-solved trigonometry and spreadsheets with a live dimensioned drawing
 
 confinement: strict
+license: GPL-3.0
 
 layout:
   /usr/share/solvespace:

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ apps:
     plugs: [opengl, unity7, home, removable-media, gsettings, network]
     environment:
       __EGL_VENDOR_LIBRARY_DIRS: $SNAP/usr/share/glvnd/egl_vendor.d
-  solvespace-cli:
+  cli:
     command: usr/bin/solvespace-cli
     plugs: [home, removable-media, network]
 

--- a/res/CMakeLists.txt
+++ b/res/CMakeLists.txt
@@ -153,6 +153,22 @@ else()
                 DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/${SIZE}/mimetypes
                 RENAME      com.solvespace.SolveSpace.png)
         endforeach()
+    elseif(SNAP)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/freedesktop/solvespace-snap.desktop
+            DESTINATION /
+            RENAME      solvespace.desktop)
+        
+        # snapd does not support registering new mime types
+
+        install(FILES freedesktop/solvespace-scalable.svg
+            DESTINATION /meta/icons/hicolor/scalable/apps
+            RENAME      snap.solvespace.svg)
+
+        foreach(SIZE 16x16 24x24 32x32 48x48)
+            install(FILES freedesktop/solvespace-${SIZE}.png
+                DESTINATION /meta/icons/hicolor/${SIZE}/apps
+                RENAME      snap.solvespace.png)
+        endforeach()
     else()
         configure_file(
             ${CMAKE_CURRENT_SOURCE_DIR}/freedesktop/solvespace.desktop.in

--- a/res/freedesktop/solvespace-snap.desktop
+++ b/res/freedesktop/solvespace-snap.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=SolveSpace
+Comment=A parametric 2d/3d CAD
+Exec=solvespace
+MimeType=application/x-solvespace
+Icon=${SNAP}/meta/icons/hicolor/scalable/apps/snap.solvespace.svg
+Type=Application
+Categories=Graphics
+Keywords=parametric;cad;2d;3d;


### PR DESCRIPTION
This is a "copy & paste" integration of the solvespace snap repo @ https://github.com/ppd1990/solvespace-snap as discussed in https://github.com/ppd1990/solvespace-snap/issues/2

## A few things left to discuss

1. ~~The integration resides in ```$ROOT/snap```. This is what build.snapcraft.io requires. If using the Ubuntu provided build server (and thus easy auto-build on commit) is not wanted, we could move it to mirror the flatpak integration~~

2. ~~The svg icon should probably find its place in ```res/freedesktop``` or we could just use a png icon. At the moment snap packages need an absolute path to an icon.~~
The svg icon was proposed for inclusion in #441 

3. ~~The snap is declared ```grade: stable```. Maybe that should only apply to tagged versions. Some extra logic would be required~~

## The next step

Publishing of the snap should be done under the flag of the upstream project. Therefore I propose a name transfer to a newly created "SolveSpace" publisher. This has to be requested on forum.snapcraft.io.

## Testing the build process
```
# optional for a faster build (adjust values for virtual build machine)
export SNAPCRAFT_BUILD_ENVIRONMENT_MEMORY=4G
export SNAPCRAFT_BUILD_ENVIRONMENT_CPU=6

snapcraft
...
snap install --dangerous solvespace_3.0~9ac55f39_amd64.snap 
```

