### PR TITLE
Handle operators

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -12,16 +12,16 @@ void SolveSpaceUI::Clipboard::Clear() {
 }
 
 bool SolveSpaceUI::Clipboard::ContainsEntity(hEntity he) {
-    if(he.v == Entity::NO_ENTITY.v)
+    if(he == Entity::NO_ENTITY)
         return true;
 
     ClipboardRequest *cr;
     for(cr = r.First(); cr; cr = r.NextAfter(cr)) {
-        if(cr->oldEnt.v == he.v)
+        if(cr->oldEnt == he)
             return true;
 
         for(int i = 0; i < MAX_POINTS_IN_ENTITY; i++) {
-            if(cr->oldPointEnt[i].v == he.v)
+            if(cr->oldPointEnt[i] == he)
                 return true;
         }
     }
@@ -29,16 +29,16 @@ bool SolveSpaceUI::Clipboard::ContainsEntity(hEntity he) {
 }
 
 hEntity SolveSpaceUI::Clipboard::NewEntityFor(hEntity he) {
-    if(he.v == Entity::NO_ENTITY.v)
+    if(he == Entity::NO_ENTITY)
         return Entity::NO_ENTITY;
 
     ClipboardRequest *cr;
     for(cr = r.First(); cr; cr = r.NextAfter(cr)) {
-        if(cr->oldEnt.v == he.v)
+        if(cr->oldEnt == he)
             return cr->newReq.entity(0);
 
         for(int i = 0; i < MAX_POINTS_IN_ENTITY; i++) {
-            if(cr->oldPointEnt[i].v == he.v)
+            if(cr->oldPointEnt[i] == he)
                 return cr->newReq.entity(1+i);
         }
     }
@@ -52,13 +52,13 @@ void GraphicsWindow::DeleteSelection() {
     List<Selection> *ls = &(selection);
     for(Selection *s = ls->First(); s; s = ls->NextAfter(s)) {
         hRequest r = { 0 };
-        if(s->entity.v && s->entity.isFromRequest()) {
+        if(s->entity && s->entity.isFromRequest()) {
             r = s->entity.request();
         }
-        if(r.v && !r.IsFromReferences()) {
+        if(r && !r.IsFromReferences()) {
             SK.request.Tag(r, 1);
         }
-        if(s->constraint.v) {
+        if(s->constraint) {
             SK.constraint.Tag(s->constraint, 1);
         }
     }
@@ -81,7 +81,7 @@ void GraphicsWindow::CopySelection() {
 
     List<Selection> *ls = &(selection);
     for(Selection *s = ls->First(); s; s = ls->NextAfter(s)) {
-        if(!s->entity.v) continue;
+        if(!s->entity) continue;
         // Work only on entities that have requests that will generate them.
         Entity *e = SK.GetEntity(s->entity);
         bool hasDistance;
@@ -130,7 +130,7 @@ void GraphicsWindow::CopySelection() {
     }
 
     for(Selection *s = ls->First(); s; s = ls->NextAfter(s)) {
-        if(!s->constraint.v) continue;
+        if(!s->constraint) continue;
 
         Constraint *c = SK.GetConstraint(s->constraint);
         if(c->type == Constraint::Type::COMMENT) {
@@ -164,15 +164,15 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
     // For arcs, reflection involves swapping the endpoints, or otherwise
     // the arc gets inverted.
     auto mapPoint = [scale](hEntity he) {
-        if(he.v == 0) return he;
+        if(!he) return he;
 
         if(scale < 0) {
             hRequest hr = he.request();
             Request *r = SK.GetRequest(hr);
             if(r->type == Request::Type::ARC_OF_CIRCLE) {
-                if(he.v == hr.entity(2).v) {
+                if(he == hr.entity(2)) {
                     return hr.entity(3);
-                } else if(he.v == hr.entity(3).v) {
+                } else if(he == hr.entity(3)) {
                     return hr.entity(2);
                 }
             }

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -63,8 +63,8 @@ void Constraint::DeleteAllConstraintsFor(Constraint::Type type, hEntity entityA,
         ConstraintBase *ct = &(SK.constraint.elem[i]);
         if(ct->type != type) continue;
 
-        if(ct->entityA.v != entityA.v) continue;
-        if(ct->ptA.v != ptA.v) continue;
+        if(ct->entityA != entityA) continue;
+        if(ct->ptA != ptA) continue;
         ct->tag = 1;
     }
     SK.constraint.RemoveTagged();
@@ -406,7 +406,7 @@ void Constraint::MenuConstrain(Command id) {
                 Entity *l0 = SK.GetEntity(gs.entity[0]),
                        *l1 = SK.GetEntity(gs.entity[1]);
 
-                if((l1->group.v != SS.GW.activeGroup.v) ||
+                if((l1->group != SS.GW.activeGroup) ||
                    (l1->construction && !(l0->construction)))
                 {
                     swap(l0, l1);
@@ -433,10 +433,10 @@ void Constraint::MenuConstrain(Command id) {
                             "(symmetric about workplane)\n"));
                 return;
             }
-            if(c.entityA.v == Entity::NO_ENTITY.v) {
+            if(c.entityA == Entity::NO_ENTITY) {
                 // Horizontal / vertical symmetry, implicit symmetry plane
                 // normal to the workplane
-                if(c.workplane.v == Entity::FREE_IN_3D.v) {
+                if(c.workplane == Entity::FREE_IN_3D) {
                     Error(_("A workplane must be active when constraining "
                             "symmetric without an explicit symmetry plane."));
                     return;
@@ -466,7 +466,7 @@ void Constraint::MenuConstrain(Command id) {
         case Command::VERTICAL:
         case Command::HORIZONTAL: {
             hEntity ha, hb;
-            if(c.workplane.v == Entity::FREE_IN_3D.v) {
+            if(c.workplane == Entity::FREE_IN_3D) {
                 Error(_("Activate a workplane (with Sketch -> In Workplane) before "
                         "applying a horizontal or vertical constraint."));
                 return;
@@ -510,12 +510,10 @@ void Constraint::MenuConstrain(Command id) {
 
             Entity *nfree = SK.GetEntity(c.entityA);
             Entity *nref  = SK.GetEntity(c.entityB);
-            if(nref->group.v == SS.GW.activeGroup.v) {
+            if(nref->group == SS.GW.activeGroup) {
                 swap(nref, nfree);
             }
-            if(nfree->group.v == SS.GW.activeGroup.v &&
-               nref ->group.v != SS.GW.activeGroup.v)
-            {
+            if(nfree->group == SS.GW.activeGroup && nref->group != SS.GW.activeGroup) {
                 // nfree is free, and nref is locked (since it came from a
                 // previous group); so let's force nfree aligned to nref,
                 // and make convergence easy
@@ -746,7 +744,7 @@ void Constraint::MenuConstrain(Command id) {
     }
 
     for(const Constraint &cc : SK.constraint) {
-        if(c.h.v != cc.h.v && c.Equals(cc)) {
+        if(c.h != cc.h && c.Equals(cc)) {
             // Oops, we already have this exact constraint. Remove the one we just added.
             SK.constraint.RemoveById(c.h);
             SS.GW.ClearSelection();

--- a/src/constrainteq.cpp
+++ b/src/constrainteq.cpp
@@ -40,7 +40,7 @@ Expr *ConstraintBase::PointLineDistance(hEntity wrkpl, hEntity hpt, hEntity hln)
 
     EntityBase *p = SK.GetEntity(hpt);
 
-    if(wrkpl.v == EntityBase::FREE_IN_3D.v) {
+    if(wrkpl == EntityBase::FREE_IN_3D) {
         ExprVector ep = p->PointGetExprs();
 
         ExprVector ea = a->PointGetExprs();
@@ -82,7 +82,7 @@ Expr *ConstraintBase::Distance(hEntity wrkpl, hEntity hpa, hEntity hpb) {
     ssassert(pa->IsPoint() && pb->IsPoint(),
              "Expected two points to measure projected distance between");
 
-    if(wrkpl.v == EntityBase::FREE_IN_3D.v) {
+    if(wrkpl == EntityBase::FREE_IN_3D) {
         // This is true distance
         ExprVector ea, eb, eab;
         ea = pa->PointGetExprs();
@@ -111,7 +111,7 @@ Expr *ConstraintBase::Distance(hEntity wrkpl, hEntity hpa, hEntity hpb) {
 Expr *ConstraintBase::DirectionCosine(hEntity wrkpl,
                                       ExprVector ae, ExprVector be)
 {
-    if(wrkpl.v == EntityBase::FREE_IN_3D.v) {
+    if(wrkpl == EntityBase::FREE_IN_3D) {
         Expr *mags = (ae.Magnitude())->Times(be.Magnitude());
         return (ae.Dot(be))->Div(mags);
     } else {
@@ -146,7 +146,7 @@ void ConstraintBase::ModifyToSatisfy() {
         Vector a = SK.GetEntity(entityA)->VectorGetNum();
         Vector b = SK.GetEntity(entityB)->VectorGetNum();
         if(other) a = a.ScaledBy(-1);
-        if(workplane.v != EntityBase::FREE_IN_3D.v) {
+        if(workplane != EntityBase::FREE_IN_3D) {
             a = a.ProjectVectorInto(workplane);
             b = b.ProjectVectorInto(workplane);
         }
@@ -190,7 +190,7 @@ void ConstraintBase::AddEq(IdList<Equation,hEquation> *l, const ExprVector &v,
                            int baseIndex) const {
     AddEq(l, v.x, baseIndex);
     AddEq(l, v.y, baseIndex + 1);
-    if(workplane.v == EntityBase::FREE_IN_3D.v) {
+    if(workplane == EntityBase::FREE_IN_3D) {
         AddEq(l, v.z, baseIndex + 2);
     }
 }
@@ -200,7 +200,7 @@ void ConstraintBase::Generate(IdList<Param,hParam> *l) {
         case Type::PARALLEL:
         case Type::CUBIC_LINE_TANGENT:
             // Add new parameter only when we operate in 3d space
-            if(workplane.v != EntityBase::FREE_IN_3D.v) break;
+            if(workplane != EntityBase::FREE_IN_3D) break;
             // fallthrough
         case Type::SAME_ORIENTATION:
         case Type::PT_ON_LINE: {
@@ -361,7 +361,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
         case Type::POINTS_COINCIDENT: {
             EntityBase *a = SK.GetEntity(ptA);
             EntityBase *b = SK.GetEntity(ptB);
-            if(workplane.v == EntityBase::FREE_IN_3D.v) {
+            if(workplane == EntityBase::FREE_IN_3D) {
                 ExprVector pa = a->PointGetExprs();
                 ExprVector pb = b->PointGetExprs();
                 AddEq(l, pa.x->Minus(pb.x), 0);
@@ -430,13 +430,13 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
         }
 
         case Type::AT_MIDPOINT:
-            if(workplane.v == EntityBase::FREE_IN_3D.v) {
+            if(workplane == EntityBase::FREE_IN_3D) {
                 EntityBase *ln = SK.GetEntity(entityA);
                 ExprVector a = SK.GetEntity(ln->point[0])->PointGetExprs();
                 ExprVector b = SK.GetEntity(ln->point[1])->PointGetExprs();
                 ExprVector m = (a.Plus(b)).ScaledBy(Expr::From(0.5));
 
-                if(ptA.v) {
+                if(ptA) {
                     ExprVector p = SK.GetEntity(ptA)->PointGetExprs();
                     AddEq(l, (m.x)->Minus(p.x), 0);
                     AddEq(l, (m.y)->Minus(p.y), 1);
@@ -455,7 +455,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
                 Expr *mu = Expr::From(0.5)->Times(au->Plus(bu));
                 Expr *mv = Expr::From(0.5)->Times(av->Plus(bv));
 
-                if(ptA.v) {
+                if(ptA) {
                     EntityBase *p = SK.GetEntity(ptA);
                     Expr *pu, *pv;
                     p->PointGetExprsInWorkplane(workplane, &pu, &pv);
@@ -469,7 +469,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
             return;
 
         case Type::SYMMETRIC:
-            if(workplane.v == EntityBase::FREE_IN_3D.v) {
+            if(workplane == EntityBase::FREE_IN_3D) {
                 EntityBase *plane = SK.GetEntity(entityA);
                 EntityBase *ea = SK.GetEntity(ptA);
                 EntityBase *eb = SK.GetEntity(ptB);
@@ -521,7 +521,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
 
         case Type::SYMMETRIC_HORIZ:
         case Type::SYMMETRIC_VERT: {
-            ssassert(workplane.v != Entity::FREE_IN_3D.v,
+            ssassert(workplane != Entity::FREE_IN_3D,
                      "Unexpected horizontal/vertical symmetric constraint in 3d");
 
             EntityBase *a = SK.GetEntity(ptA);
@@ -576,11 +576,11 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
 
         case Type::HORIZONTAL:
         case Type::VERTICAL: {
-            ssassert(workplane.v != Entity::FREE_IN_3D.v,
+            ssassert(workplane != Entity::FREE_IN_3D,
                      "Unexpected horizontal/vertical constraint in 3d");
 
             hEntity ha, hb;
-            if(entityA.v) {
+            if(entityA) {
                 EntityBase *e = SK.GetEntity(entityA);
                 ha = e->point[0];
                 hb = e->point[1];
@@ -701,7 +701,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
 
             ExprVector b = line->VectorGetExprs();
 
-            if(workplane.v == EntityBase::FREE_IN_3D.v) {
+            if(workplane == EntityBase::FREE_IN_3D) {
                 ExprVector eq = VectorsParallel3d(a, b, valP);
                 AddEq(l, eq);
             } else {
@@ -755,7 +755,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
             ExprVector a = ea->VectorGetExprsInWorkplane(workplane);
             ExprVector b = eb->VectorGetExprsInWorkplane(workplane);
 
-            if(workplane.v == EntityBase::FREE_IN_3D.v) {
+            if(workplane == EntityBase::FREE_IN_3D) {
                 ExprVector eq = VectorsParallel3d(a, b, valP);
                 AddEq(l, eq);
             } else {
@@ -775,7 +775,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
 
         case Type::WHERE_DRAGGED: {
             EntityBase *ep = SK.GetEntity(ptA);
-            if(workplane.v == EntityBase::FREE_IN_3D.v) {
+            if(workplane == EntityBase::FREE_IN_3D) {
                 ExprVector ev = ep->PointGetExprs();
                 Vector v = ep->PointGetNum();
 

--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -214,13 +214,13 @@ void TextWindow::DescribeSelection() {
         Group *g = SK.GetGroup(e->group);
         Printf(false, "");
         Printf(false, "%FtIN GROUP%E      %s", g->DescriptionString().c_str());
-        if(e->workplane.v == Entity::FREE_IN_3D.v) {
+        if(e->workplane == Entity::FREE_IN_3D) {
             Printf(false, "%FtNOT LOCKED IN WORKPLANE%E");
         } else {
             Entity *w = SK.GetEntity(e->workplane);
             Printf(false, "%FtIN WORKPLANE%E  %s", w->DescriptionString().c_str());
         }
-        if(e->style.v) {
+        if(e->style) {
             Style *s = Style::Get(e->style);
             Printf(false, "%FtIN STYLE%E      %s", s->DescriptionString().c_str());
         } else {
@@ -232,12 +232,13 @@ void TextWindow::DescribeSelection() {
 
         std::vector<hConstraint> lhc = {};
         for(const Constraint &c : SK.constraint) {
-            if(!(c.ptA.v == e->h.v ||
-                 c.ptB.v == e->h.v ||
-                 c.entityA.v == e->h.v ||
-                 c.entityB.v == e->h.v ||
-                 c.entityC.v == e->h.v ||
-                 c.entityD.v == e->h.v)) continue;
+            if(!(c.ptA == e->h ||
+                 c.ptB == e->h ||
+                 c.entityA == e->h ||
+                 c.entityB == e->h ||
+                 c.entityC == e->h ||
+                 c.entityD == e->h))
+                continue;
             lhc.push_back(c.h);
         }
 
@@ -314,8 +315,7 @@ void TextWindow::DescribeSelection() {
         Printf(true,  " pt-ln distance = %Fi%s%E",
             SS.MmToString(pp.DistanceToLine(lp0, lp1.Minus(lp0))).c_str());
         hEntity wrkpl = SS.GW.ActiveWorkplane();
-        if(wrkpl.v != Entity::FREE_IN_3D.v &&
-                !(p->workplane.v == wrkpl.v && ln->workplane.v == wrkpl.v)) {
+        if(wrkpl != Entity::FREE_IN_3D && !(p->workplane == wrkpl && ln->workplane == wrkpl)) {
             Vector ppw  = pp.ProjectInto(wrkpl);
             Vector lp0w = lp0.ProjectInto(wrkpl);
             Vector lp1w = lp1.ProjectInto(wrkpl);
@@ -385,10 +385,9 @@ void TextWindow::DescribeSelection() {
         lhe.push_back(c->entityC);
         lhe.push_back(c->entityD);
 
-        auto it = std::remove_if(lhe.begin(), lhe.end(),
-            [](hEntity he) {
-                return he.v == Entity::NO_ENTITY.v || !he.isFromRequest();
-            });
+        auto it = std::remove_if(lhe.begin(), lhe.end(), [](hEntity he) {
+            return he == Entity::NO_ENTITY || !he.isFromRequest();
+        });
         lhe.erase(it, lhe.end());
 
         if(!lhe.empty()) {
@@ -426,13 +425,13 @@ void TextWindow::DescribeSelection() {
     bool styleAssigned = false;
     for(int i = 0; i < gs.entities; i++) {
         Entity *e = SK.GetEntity(gs.entity[i]);
-        if(e->style.v != 0) {
+        if(e->style) {
             styleAssigned = true;
         }
     }
     for(int i = 0; i < gs.constraints; i++) {
         Constraint *c = SK.GetConstraint(gs.constraint[i]);
-        if(c->type == Constraint::Type::COMMENT && c->disp.style.v != 0) {
+        if(c->type == Constraint::Type::COMMENT && c->disp.style) {
             styleAssigned = true;
         }
     }

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -60,7 +60,7 @@ void Constraint::DoLabel(Canvas *canvas, Canvas::hStroke hcs,
     // By default, the reference is from the center; but the style could
     // specify otherwise if one is present, and it could also specify a
     // rotation.
-    if(type == Type::COMMENT && disp.style.v) {
+    if(type == Type::COMMENT && disp.style) {
         Style *st = Style::Get(disp.style);
         // rotation first
         double rads = st->textAngle*PI/180;
@@ -298,7 +298,7 @@ void Constraint::DoArcForAngle(Canvas *canvas, Canvas::hStroke hcs,
     Vector gr = camera.projRight.ScaledBy(1.0);
     Vector gu = camera.projUp.ScaledBy(1.0);
 
-    if(workplane.v != Entity::FREE_IN_3D.v) {
+    if(workplane != Entity::FREE_IN_3D) {
         a0 = a0.ProjectInto(workplane);
         b0 = b0.ProjectInto(workplane);
         da = da.ProjectVectorInto(workplane);
@@ -452,10 +452,10 @@ bool Constraint::IsVisible() const {
     if(!(g->visible)) return false;
     // And likewise if the group is not the active group; except for comments
     // with an assigned style.
-    if(g->h.v != SS.GW.activeGroup.v && !(type == Type::COMMENT && disp.style.v)) {
+    if(g->h != SS.GW.activeGroup && !(type == Type::COMMENT && disp.style)) {
         return false;
     }
-    if(disp.style.v) {
+    if(disp.style) {
         Style *s = Style::Get(disp.style);
         if(!s->visible) return false;
     }
@@ -529,7 +529,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             Vector ap = SK.GetEntity(ptA)->PointGetNum();
             Vector bp = SK.GetEntity(ptB)->PointGetNum();
 
-            if(workplane.v != Entity::FREE_IN_3D.v) {
+            if(workplane != Entity::FREE_IN_3D) {
                 DoProjectedPoint(canvas, hcs, &ap);
                 DoProjectedPoint(canvas, hcs, &bp);
             }
@@ -596,7 +596,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             Vector lB = SK.GetEntity(line->point[1])->PointGetNum();
             Vector dl = lB.Minus(lA);
 
-            if(workplane.v != Entity::FREE_IN_3D.v) {
+            if(workplane != Entity::FREE_IN_3D) {
                 lA = lA.ProjectInto(workplane);
                 lB = lB.ProjectInto(workplane);
                 DoProjectedPoint(canvas, hcs, &pt);
@@ -638,7 +638,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 }
             }
 
-            if(workplane.v != Entity::FREE_IN_3D.v) {
+            if(workplane != Entity::FREE_IN_3D) {
                 // Draw the projection marker from the closest point on the
                 // projected line to the projected point on the real line.
                 Vector lAB = (lA.Minus(lB));
@@ -829,7 +829,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
         case Type::PERPENDICULAR: {
             Vector u = Vector::From(0, 0, 0), v = Vector::From(0, 0, 0);
             Vector rn, ru;
-            if(workplane.v == Entity::FREE_IN_3D.v) {
+            if(workplane == Entity::FREE_IN_3D) {
                 rn = gn;
                 ru = gu;
             } else {
@@ -882,7 +882,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 v = norm->NormalV();
             } else if(type == Type::CUBIC_LINE_TANGENT) {
                 Vector n;
-                if(workplane.v == Entity::FREE_IN_3D.v) {
+                if(workplane == Entity::FREE_IN_3D) {
                     u = gr;
                     v = gu;
                     n = gn;
@@ -985,7 +985,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 a = SK.GetEntity(e->point[0])->PointGetNum();
                 b = SK.GetEntity(e->point[1])->PointGetNum();
 
-                if(workplane.v != Entity::FREE_IN_3D.v) {
+                if(workplane != Entity::FREE_IN_3D) {
                     DoProjectedPoint(canvas, hcs, &a);
                     DoProjectedPoint(canvas, hcs, &b);
                 }
@@ -1005,7 +1005,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             Entity *forLen = SK.GetEntity(entityA);
             Vector a = SK.GetEntity(forLen->point[0])->PointGetNum(),
                    b = SK.GetEntity(forLen->point[1])->PointGetNum();
-            if(workplane.v != Entity::FREE_IN_3D.v) {
+            if(workplane != Entity::FREE_IN_3D) {
                 DoProjectedPoint(canvas, hcs, &a);
                 DoProjectedPoint(canvas, hcs, &b);
             }
@@ -1017,7 +1017,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             Vector la = SK.GetEntity(ln->point[0])->PointGetNum(),
                    lb = SK.GetEntity(ln->point[1])->PointGetNum();
             Vector pt = SK.GetEntity(ptA)->PointGetNum();
-            if(workplane.v != Entity::FREE_IN_3D.v) {
+            if(workplane != Entity::FREE_IN_3D) {
                 DoProjectedPoint(canvas, hcs, &pt);
                 la = la.ProjectInto(workplane);
                 lb = lb.ProjectInto(workplane);
@@ -1039,7 +1039,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 Entity *pte = SK.GetEntity(i == 0 ? ptA : ptB);
                 Vector pt = pte->PointGetNum();
 
-                if(workplane.v != Entity::FREE_IN_3D.v) {
+                if(workplane != Entity::FREE_IN_3D) {
                     DoProjectedPoint(canvas, hcs, &pt);
                     la = la.ProjectInto(workplane);
                     lb = lb.ProjectInto(workplane);
@@ -1102,9 +1102,9 @@ s:
         case Type::AT_MIDPOINT:
         case Type::HORIZONTAL:
         case Type::VERTICAL:
-            if(entityA.v) {
+            if(entityA) {
                 Vector r, u, n;
-                if(workplane.v == Entity::FREE_IN_3D.v) {
+                if(workplane == Entity::FREE_IN_3D) {
                     r = gr; u = gu; n = gn;
                 } else {
                     r = SK.GetEntity(workplane)->Normal()->NormalU();
@@ -1171,7 +1171,7 @@ s:
 
         case Type::COMMENT: {
             Vector u, v;
-            if(workplane.v == Entity::FREE_IN_3D.v) {
+            if(workplane == Entity::FREE_IN_3D) {
                 u = gr;
                 v = gu;
             } else {
@@ -1180,7 +1180,7 @@ s:
                 v = norm->NormalV();
             }
 
-            if(disp.style.v != 0) {
+            if(disp.style) {
                 RgbaColor color = stroke.color;
                 stroke = Style::Stroke(disp.style);
                 stroke.layer = Canvas::Layer::FRONT;
@@ -1225,7 +1225,7 @@ bool Constraint::IsStylable() const {
 }
 
 hStyle Constraint::GetStyle() const {
-    if(disp.style.v != 0) return disp.style;
+    if(disp.style) return disp.style;
     return { Style::CONSTRAINT };
 }
 

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -150,7 +150,7 @@ bool Entity::IsStylable() const {
 bool Entity::IsVisible() const {
     Group *g = SK.GetGroup(group);
 
-    if(g->h.v == Group::HGROUP_REFERENCES.v && IsNormal()) {
+    if(g->h == Group::HGROUP_REFERENCES && IsNormal()) {
         // The reference normals are always shown
         return true;
     }
@@ -162,7 +162,7 @@ bool Entity::IsVisible() const {
 
     if(!SS.GW.showWorkplanes) {
         if(IsWorkplane() && !h.isFromRequest()) {
-            if(g->h.v != SS.GW.activeGroup.v) {
+            if(g->h != SS.GW.activeGroup) {
                 // The group-associated workplanes are hidden outside
                 // their group.
                 return false;
@@ -170,7 +170,7 @@ bool Entity::IsVisible() const {
         }
     }
 
-    if(style.v) {
+    if(style) {
         Style *s = Style::Get(style);
         if(!s->visible) return false;
     }
@@ -453,7 +453,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         zIndex = 5;
     } else if(how == DrawAs::HIDDEN) {
         zIndex = 2;
-    } else if(group.v != SS.GW.activeGroup.v) {
+    } else if(group != SS.GW.activeGroup) {
         zIndex = 3;
     } else {
         zIndex = 4;
@@ -568,11 +568,11 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
                     // dimmer for the ones at the model origin.
                     hRequest hr   = h.request();
                     uint8_t  luma = (asReference) ? 255 : 100;
-                    if(hr.v == Request::HREQUEST_REFERENCE_XY.v) {
+                    if(hr == Request::HREQUEST_REFERENCE_XY) {
                         stroke.color = RgbaColor::From(0, 0, luma);
-                    } else if(hr.v == Request::HREQUEST_REFERENCE_YZ.v) {
+                    } else if(hr == Request::HREQUEST_REFERENCE_YZ) {
                         stroke.color = RgbaColor::From(luma, 0, 0);
-                    } else if(hr.v == Request::HREQUEST_REFERENCE_ZX.v) {
+                    } else if(hr == Request::HREQUEST_REFERENCE_ZX) {
                         stroke.color = RgbaColor::From(0, luma, 0);
                     }
                 }

--- a/src/dsc.h
+++ b/src/dsc.h
@@ -309,6 +309,12 @@ static inline bool operator!=(HandleBase<Derived> const &lhs, HandleBase<Derived
     return !(lhs == rhs);
 }
 
+// Less-than-compare any two instances of a handle type.
+template<typename Derived>
+static inline bool operator<(HandleBase<Derived> const &lhs, HandleBase<Derived> const &rhs) {
+    return lhs.v < rhs.v;
+}
+
 // A list, where each element has an integer identifier. The list is kept
 // sorted by that identifier, and items can be looked up in log n time by
 // id.

--- a/src/dsc.h
+++ b/src/dsc.h
@@ -285,6 +285,30 @@ public:
     }
 };
 
+/// CRTP base for handle classes, to automatically provide functionality.
+/// Derived classes should include "using HandleBase::HandleBase" in their body to inherit constructors.
+template<typename Derived>
+class HandleBase {
+public:
+    HandleBase(uint32_t val) : v(val) {}
+    HandleBase() : v(0) {}
+    // In a boolean context, a handle is "true" if it is non-zero.
+    explicit operator bool() const { return v != 0; }
+    uint32_t v;
+};
+
+// Equality-compare any two instances of a handle type.
+template<typename Derived>
+static inline bool operator==(HandleBase<Derived> const &lhs, HandleBase<Derived> const &rhs) {
+    return lhs.v == rhs.v;
+}
+
+// Inequality-compare any two instances of a handle type.
+template<typename Derived>
+static inline bool operator!=(HandleBase<Derived> const &lhs, HandleBase<Derived> const &rhs) {
+    return !(lhs == rhs);
+}
+
 // A list, where each element has an integer identifier. The list is kept
 // sorted by that identifier, and items can be looked up in log n time by
 // id.

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -37,7 +37,7 @@ ExprVector EntityBase::VectorGetExprsInWorkplane(hEntity wrkpl) const {
         case Type::NORMAL_N_ROT:
         case Type::NORMAL_N_ROT_AA: {
             ExprVector ev = NormalExprsN();
-            if(wrkpl.v == EntityBase::FREE_IN_3D.v) {
+            if(wrkpl == EntityBase::FREE_IN_3D) {
                 return ev;
             }
             // Get the offset and basis vectors for this weird exotic csys.
@@ -565,7 +565,7 @@ ExprVector EntityBase::PointGetExprs() const {
 }
 
 void EntityBase::PointGetExprsInWorkplane(hEntity wrkpl, Expr **u, Expr **v) const {
-    if(type == Type::POINT_IN_2D && workplane.v == wrkpl.v) {
+    if(type == Type::POINT_IN_2D && workplane == wrkpl) {
         // They want our coordinates in the form that we've written them,
         // very nice.
         *u = Expr::From(param[0]);
@@ -587,7 +587,7 @@ void EntityBase::PointGetExprsInWorkplane(hEntity wrkpl, Expr **u, Expr **v) con
 }
 
 ExprVector EntityBase::PointGetExprsInWorkplane(hEntity wrkpl) const {
-    if(wrkpl.v == Entity::FREE_IN_3D.v) {
+    if(wrkpl == Entity::FREE_IN_3D) {
         return PointGetExprs();
     }
 
@@ -873,11 +873,11 @@ void EntityBase::GenerateEquations(IdList<Equation,hEquation> *l) const {
             int i;
             for(i = 0; i < SK.constraint.n; i++) {
                 ConstraintBase *c = &(SK.constraint.elem[i]);
-                if(c->group.v != group.v) continue;
+                if(c->group != group) continue;
                 if(c->type != Constraint::Type::POINTS_COINCIDENT) continue;
 
-                if((c->ptA.v == point[1].v && c->ptB.v == point[2].v) ||
-                   (c->ptA.v == point[2].v && c->ptB.v == point[1].v))
+                if((c->ptA == point[1] && c->ptB == point[2]) ||
+                   (c->ptA == point[2] && c->ptB == point[1]))
                 {
                     break;
                 }

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -28,7 +28,7 @@ void SolveSpaceUI::ExportSectionTo(const Platform::Path &filename) {
 
     SS.GW.GroupSelection();
     auto const &gs = SS.GW.gs;
-    if((gs.n == 0 && g->activeWorkplane.v != Entity::FREE_IN_3D.v)) {
+    if((gs.n == 0 && g->activeWorkplane != Entity::FREE_IN_3D)) {
         Entity *wrkpl = SK.GetEntity(g->activeWorkplane);
         origin = wrkpl->WorkplaneGetOffset();
         n = wrkpl->Normal()->NormalN();

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -361,8 +361,8 @@ Expr *Expr::PartialWrt(hParam p) const {
     Expr *da, *db;
 
     switch(op) {
-        case Op::PARAM_PTR: return From(p.v == parp->h.v ? 1 : 0);
-        case Op::PARAM:     return From(p.v == parh.v ? 1 : 0);
+        case Op::PARAM_PTR: return From(p == parp->h ? 1 : 0);
+        case Op::PARAM:     return From(p == parh ? 1 : 0);
 
         case Op::CONSTANT:  return From(0.0);
         case Op::VARIABLE:  ssassert(false, "Not supported yet");
@@ -412,8 +412,8 @@ uint64_t Expr::ParamsUsed() const {
 }
 
 bool Expr::DependsOn(hParam p) const {
-    if(op == Op::PARAM)     return (parh.v    == p.v);
-    if(op == Op::PARAM_PTR) return (parp->h.v == p.v);
+    if(op == Op::PARAM)     return (parh    == p);
+    if(op == Op::PARAM_PTR) return (parp->h == p);
 
     int c = Children();
     if(c == 1)          return a->DependsOn(p);
@@ -494,7 +494,7 @@ Expr *Expr::FoldConstants() {
 void Expr::Substitute(hParam oldh, hParam newh) {
     ssassert(op != Op::PARAM_PTR, "Expected an expression that refer to params via handles");
 
-    if(op == Op::PARAM && parh.v == oldh.v) {
+    if(op == Op::PARAM && parh == oldh) {
         parh = newh;
     }
     int c = Children();
@@ -528,11 +528,11 @@ hParam Expr::ReferencedParams(ParamList *pl) const {
         hParam pa, pb;
         pa = a->ReferencedParams(pl);
         pb = b->ReferencedParams(pl);
-        if(pa.v == NO_PARAMS.v) {
+        if(pa == NO_PARAMS) {
             return pb;
-        } else if(pb.v == NO_PARAMS.v) {
+        } else if(pb == NO_PARAMS) {
             return pa;
-        } else if(pa.v == pb.v) {
+        } else if(pa == pb) {
             return pa; // either, doesn't matter
         } else {
             return MULTIPLE_PARAMS;

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -18,7 +18,7 @@ void SolveSpaceUI::MarkGroupDirty(hGroup hg, bool onlyThis) {
     bool go = false;
     for(i = 0; i < SK.groupOrder.n; i++) {
         Group *g = SK.GetGroup(SK.groupOrder.elem[i]);
-        if(g->h.v == hg.v) {
+        if(g->h == hg) {
             go = true;
         }
         if(go) {
@@ -55,8 +55,8 @@ bool SolveSpaceUI::PruneOrphans() {
 }
 
 bool SolveSpaceUI::GroupsInOrder(hGroup before, hGroup after) {
-    if(before.v == 0) return true;
-    if(after.v  == 0) return true;
+    if(!before) return true;
+    if(!after) return true;
     if(!GroupExists(before)) return false;
     if(!GroupExists(after)) return false;
     int beforep = SK.GetGroup(before)->order;
@@ -72,7 +72,7 @@ bool SolveSpaceUI::GroupExists(hGroup hg) {
 bool SolveSpaceUI::EntityExists(hEntity he) {
     // A nonexstient entity is acceptable, though, usually just means it
     // doesn't apply.
-    if(he.v == Entity::NO_ENTITY.v) return true;
+    if(he == Entity::NO_ENTITY) return true;
     return SK.entity.FindByIdNoOops(he) ? true : false;
 }
 
@@ -94,7 +94,7 @@ bool SolveSpaceUI::PruneRequests(hGroup hg) {
     int i;
     for(i = 0; i < SK.entity.n; i++) {
         Entity *e = &(SK.entity.elem[i]);
-        if(e->group.v != hg.v) continue;
+        if(e->group != hg) continue;
 
         if(EntityExists(e->workplane)) continue;
 
@@ -111,7 +111,7 @@ bool SolveSpaceUI::PruneConstraints(hGroup hg) {
     int i;
     for(i = 0; i < SK.constraint.n; i++) {
         Constraint *c = &(SK.constraint.elem[i]);
-        if(c->group.v != hg.v) continue;
+        if(c->group != hg) continue;
 
         if(EntityExists(c->workplane) &&
            EntityExists(c->ptA) &&
@@ -164,7 +164,7 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
                 if((!g->clean) || !g->IsSolvedOkay()) {
                     first = min(first, i);
                 }
-                if(g->h.v == SS.GW.activeGroup.v) {
+                if(g->h == SS.GW.activeGroup) {
                     last = i;
                 }
             }
@@ -190,7 +190,7 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
 
         case Generate::UNTIL_ACTIVE: {
             for(i = 0; i < SK.groupOrder.n; i++) {
-                if(SK.groupOrder.elem[i].v == SS.GW.activeGroup.v)
+                if(SK.groupOrder.elem[i] == SS.GW.activeGroup)
                     break;
             }
 
@@ -235,13 +235,13 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
 
         for(j = 0; j < SK.request.n; j++) {
             Request *r = &(SK.request.elem[j]);
-            if(r->group.v != g->h.v) continue;
+            if(r->group != g->h) continue;
 
             r->Generate(&(SK.entity), &(SK.param));
         }
         for(j = 0; j < SK.constraint.n; j++) {
             Constraint *c = &SK.constraint.elem[j];
-            if(c->group.v != g->h.v) continue;
+            if(c->group != g->h) continue;
 
             c->Generate(&(SK.param));
         }
@@ -265,7 +265,7 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
             }
         }
 
-        if(g->h.v == Group::HGROUP_REFERENCES.v) {
+        if(g->h == Group::HGROUP_REFERENCES) {
             ForceReferences();
             g->solved.how = SolveResult::OKAY;
             g->clean = true;
@@ -303,11 +303,11 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
     }
 
     // Make sure the point that we're tracing exists.
-    if(traced.point.v && !SK.entity.FindByIdNoOops(traced.point)) {
+    if(traced.point && !SK.entity.FindByIdNoOops(traced.point)) {
         traced.point = Entity::NO_ENTITY;
     }
     // And if we're tracing a point, add its new value to the path
-    if(traced.point.v) {
+    if(traced.point) {
         Entity *pt = SK.GetEntity(traced.point);
         traced.path.AddPoint(pt->PointGetNum());
     }
@@ -435,7 +435,7 @@ void SolveSpaceUI::MarkDraggedParams() {
         } else {
             hp = SS.GW.pending.points.elem[i];
         }
-        if(!hp.v) continue;
+        if(!hp) continue;
 
         // The pending point could be one in a group that has not yet
         // been processed, in which case the lookup will fail; but
@@ -460,7 +460,7 @@ void SolveSpaceUI::MarkDraggedParams() {
             }
         }
     }
-    if(SS.GW.pending.circle.v) {
+    if(SS.GW.pending.circle) {
         Entity *circ = SK.entity.FindByIdNoOops(SS.GW.pending.circle);
         if(circ) {
             Entity *dist = SK.GetEntity(circ->distance);
@@ -474,7 +474,7 @@ void SolveSpaceUI::MarkDraggedParams() {
             }
         }
     }
-    if(SS.GW.pending.normal.v) {
+    if(SS.GW.pending.normal) {
         Entity *norm = SK.entity.FindByIdNoOops(SS.GW.pending.normal);
         if(norm) {
             switch(norm->type) {
@@ -512,13 +512,13 @@ void SolveSpaceUI::WriteEqSystemForGroup(hGroup hg) {
     // And generate all the params for requests in this group
     for(i = 0; i < SK.request.n; i++) {
         Request *r = &(SK.request.elem[i]);
-        if(r->group.v != hg.v) continue;
+        if(r->group != hg) continue;
 
         r->Generate(&(sys.entity), &(sys.param));
     }
     for(i = 0; i < SK.constraint.n; i++) {
         Constraint *c = &SK.constraint.elem[i];
-        if(c->group.v != hg.v) continue;
+        if(c->group != hg) continue;
 
         c->Generate(&(sys.param));
     }
@@ -565,7 +565,7 @@ bool SolveSpaceUI::ActiveGroupsOkay() {
         Group *g = SK.GetGroup(SK.groupOrder.elem[i]);
         if(!g->IsSolvedOkay())
             return false;
-        if(g->h.v == SS.GW.activeGroup.v)
+        if(g->h == SS.GW.activeGroup)
             break;
     }
     return true;

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -552,7 +552,7 @@ void GraphicsWindow::LoopOverPoints(const std::vector<Entity *> &entities,
         } else {
             // We have to iterate children points, because we can select entities without points
             for(int i = 0; i < MAX_POINTS_IN_ENTITY; i++) {
-                if(e->point[i].v == 0) break;
+                if(!e->point[i]) break;
                 Vector p = SK.GetEntity(e->point[i])->PointGetNum();
                 HandlePointForZoomToFit(p, pmax, pmin, wmin, usePerspective, camera);
             }
@@ -608,7 +608,7 @@ double GraphicsWindow::ZoomToFit(const Camera &camera,
     if(useSelection) {
         for(int i = 0; i < selection.n; i++) {
             Selection *s = &selection.elem[i];
-            if(s->entity.v != 0) {
+            if(s->entity) {
                 Entity *e = SK.entity.FindById(s->entity);
                 if(e->IsFace()) {
                     faces.push_back(e->h);
@@ -616,7 +616,7 @@ double GraphicsWindow::ZoomToFit(const Camera &camera,
                 }
                 entities.push_back(e);
             }
-            if(s->constraint.v != 0) {
+            if(s->constraint) {
                 Constraint *c = SK.constraint.FindById(s->constraint);
                 constraints.push_back(c);
             }
@@ -845,10 +845,10 @@ void GraphicsWindow::EnsureValidActives() {
     bool change = false;
     // The active group must exist, and not be the references.
     Group *g = SK.group.FindByIdNoOops(activeGroup);
-    if((!g) || (g->h.v == Group::HGROUP_REFERENCES.v)) {
+    if((!g) || (g->h == Group::HGROUP_REFERENCES)) {
         int i;
         for(i = 0; i < SK.groupOrder.n; i++) {
-            if(SK.groupOrder.elem[i].v != Group::HGROUP_REFERENCES.v) {
+            if(SK.groupOrder.elem[i] != Group::HGROUP_REFERENCES) {
                 break;
             }
         }
@@ -875,7 +875,7 @@ void GraphicsWindow::EnsureValidActives() {
         Entity *e = SK.entity.FindByIdNoOops(ActiveWorkplane());
         if(e) {
             hGroup hgw = e->group;
-            if(hgw.v != activeGroup.v && SS.GroupsInOrder(activeGroup, hgw)) {
+            if(hgw != activeGroup && SS.GroupsInOrder(activeGroup, hgw)) {
                 // The active workplane is in a group that comes after the
                 // active group; so any request or constraint will fail.
                 SetWorkplaneFreeIn3d();
@@ -932,7 +932,7 @@ hEntity GraphicsWindow::ActiveWorkplane() {
     }
 }
 bool GraphicsWindow::LockedInWorkplane() {
-    return (SS.GW.ActiveWorkplane().v != Entity::FREE_IN_3D.v);
+    return (SS.GW.ActiveWorkplane() != Entity::FREE_IN_3D);
 }
 
 void GraphicsWindow::ForceTextWindowShown() {
@@ -1027,7 +1027,7 @@ void GraphicsWindow::MenuEdit(Command id) {
         case Command::SELECT_ALL: {
             Entity *e;
             for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {
-                if(e->group.v != SS.GW.activeGroup.v) continue;
+                if(e->group != SS.GW.activeGroup) continue;
                 if(e->IsFace() || e->IsDistance()) continue;
                 if(!e->IsVisible()) continue;
 
@@ -1045,7 +1045,7 @@ void GraphicsWindow::MenuEdit(Command id) {
             do {
                 didSomething = false;
                 for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {
-                    if(e->group.v != SS.GW.activeGroup.v) continue;
+                    if(e->group != SS.GW.activeGroup) continue;
                     if(!e->HasEndpoints()) continue;
                     if(!e->IsVisible()) continue;
 
@@ -1055,8 +1055,8 @@ void GraphicsWindow::MenuEdit(Command id) {
                     bool onChain = false, alreadySelected = false;
                     List<Selection> *ls = &(SS.GW.selection);
                     for(Selection *s = ls->First(); s; s = ls->NextAfter(s)) {
-                        if(!s->entity.v) continue;
-                        if(s->entity.v == e->h.v) {
+                        if(!s->entity) continue;
+                        if(s->entity == e->h) {
                             alreadySelected = true;
                             continue;
                         }
@@ -1139,7 +1139,7 @@ void GraphicsWindow::MenuEdit(Command id) {
 
             List<Selection> *ls = &(SS.GW.selection);
             for(Selection *s = ls->First(); s; s = ls->NextAfter(s)) {
-                if(s->entity.v) {
+                if(s->entity) {
                     hEntity hp = s->entity;
                     Entity *ep = SK.GetEntity(hp);
                     if(!ep->IsPoint()) continue;
@@ -1148,7 +1148,7 @@ void GraphicsWindow::MenuEdit(Command id) {
                     ep->PointForceTo(SS.GW.SnapToGrid(p));
                     SS.GW.pending.points.Add(&hp);
                     SS.MarkGroupDirty(ep->group);
-                } else if(s->constraint.v) {
+                } else if(s->constraint) {
                     Constraint *c = SK.GetConstraint(s->constraint);
                     std::vector<Vector> refs;
                     c->GetReferencePoints(SS.GW.GetCamera(), &refs);

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -50,7 +50,7 @@ bool Group::IsVisible() {
 }
 
 size_t Group::GetNumConstraints(void) {
-    return SK.constraint.CountIf([&](Constraint const & c) { return c.group.v == h.v; });
+    return SK.constraint.CountIf([&](Constraint const & c) { return c.group == h; });
 }
 
 Vector Group::ExtrusionGetVector() {
@@ -288,7 +288,7 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
         Group *gi = SK.GetGroup(SK.groupOrder.elem[i]);
         if(afterActive)
             gi->order += 1;
-        if(gi->h.v == SS.GW.activeGroup.v) {
+        if(gi->h == SS.GW.activeGroup) {
             g.order = gi->order + 1;
             afterActive = true;
         }
@@ -450,7 +450,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             hEntity pt = { 0 };
             for(i = 0; i < entity->n; i++) {
                 Entity *e = &(entity->elem[i]);
-                if(e->group.v != opA.v) continue;
+                if(e->group != opA) continue;
 
                 if(e->IsPoint()) pt = e->h;
 
@@ -483,7 +483,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
 
             for(i = 0; i < entity->n; i++) {
                 Entity *e = &(entity->elem[i]);
-                if(e->group.v != opA.v) continue;
+                if(e->group != opA) continue;
 
                 e->CalculateNumerical(/*forExport=*/false);
                 hEntity he = e->h;
@@ -532,7 +532,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
 
             for(i = 0; i < entity->n; i++) {
                 Entity *e = &(entity->elem[i]);
-                if(e->group.v != opA.v)
+                if(e->group != opA)
                     continue;
 
                 e->CalculateNumerical(/*forExport=*/false);
@@ -542,7 +542,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                            NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, CopyAs::NUMERIC);
 
                 for(a = 0; a < 2; a++) {
-                    if(e->group.v != opA.v)
+                    if(e->group != opA)
                         continue;
 
                     e->CalculateNumerical(false);
@@ -578,7 +578,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             for(a = a0; a < n; a++) {
                 for(i = 0; i < entity->n; i++) {
                     Entity *e = &(entity->elem[i]);
-                    if(e->group.v != opA.v) continue;
+                    if(e->group != opA) continue;
 
                     e->CalculateNumerical(/*forExport=*/false);
                     CopyEntity(entity, e,
@@ -613,7 +613,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             for(a = a0; a < n; a++) {
                 for(i = 0; i < entity->n; i++) {
                     Entity *e = &(entity->elem[i]);
-                    if(e->group.v != opA.v) continue;
+                    if(e->group != opA) continue;
 
                     e->CalculateNumerical(/*forExport=*/false);
                     CopyEntity(entity, e,
@@ -687,7 +687,7 @@ void Group::GenerateEquations(IdList<Equation,hEquation> *l) {
 #undef EC
 #undef EP
     } else if(type == Type::EXTRUDE) {
-        if(predef.entityB.v != Entity::FREE_IN_3D.v) {
+        if(predef.entityB != Entity::FREE_IN_3D) {
             // The extrusion path is locked along a line, normal to the
             // specified workplane.
             Entity *w = SK.GetEntity(predef.entityB);
@@ -702,7 +702,7 @@ void Group::GenerateEquations(IdList<Equation,hEquation> *l) {
             AddEq(l, v.Dot(extruden), 1);
         }
     } else if(type == Type::TRANSLATE) {
-        if(predef.entityB.v != Entity::FREE_IN_3D.v) {
+        if(predef.entityB != Entity::FREE_IN_3D) {
             Entity *w = SK.GetEntity(predef.entityB);
             ExprVector n = w->Normal()->NormalExprsN();
             ExprVector trans;
@@ -840,7 +840,7 @@ void Group::MakeLatheSurfacesSelectable(IdList<Entity, hEntity> *el, hEntity in,
 
 void Group::MakeExtrusionTopBottomFaces(IdList<Entity,hEntity> *el, hEntity pt)
 {
-    if(pt.v == 0) return;
+    if(!pt) return;
     Group *src = SK.GetGroup(opA);
     Vector n = src->polyLoops.normal;
 

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -16,7 +16,7 @@ void Group::AssembleLoops(bool *allClosed,
     int i;
     for(i = 0; i < SK.entity.n; i++) {
         Entity *e = &(SK.entity.elem[i]);
-        if(e->group.v != h.v) continue;
+        if(e->group != h) continue;
         if(e->construction) continue;
         if(e->forceHidden) continue;
 
@@ -84,7 +84,7 @@ void SShell::RemapFaces(Group *g, int remap) {
     SSurface *ss;
     for(ss = surface.First(); ss; ss = surface.NextAfter(ss)){
         hEntity face = { ss->face };
-        if(face.v == Entity::NO_ENTITY.v) continue;
+        if(face == Entity::NO_ENTITY) continue;
 
         face = g->Remap(face, remap);
         ss->face = face.v;
@@ -95,7 +95,7 @@ void SMesh::RemapFaces(Group *g, int remap) {
     STriangle *tr;
     for(tr = l.First(); tr; tr = l.NextAfter(tr)) {
         hEntity face = { tr->meta.face };
-        if(face.v == Entity::NO_ENTITY.v) continue;
+        if(face == Entity::NO_ENTITY) continue;
 
         face = g->Remap(face, remap);
         tr->meta.face = face.v;
@@ -261,7 +261,7 @@ void Group::GenerateShellAndMesh() {
 
                 Entity *e;
                 for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {
-                    if(e->group.v != opA.v) continue;
+                    if(e->group != opA) continue;
                     if(e->type != Entity::Type::LINE_SEGMENT) continue;
 
                     Vector a = SK.GetEntity(e->point[0])->PointGetNum(),
@@ -458,7 +458,7 @@ void Group::GenerateDisplayItems() {
         displayMesh.PrecomputeTransparency();
 
         // Recalculate mass center if needed
-        if(SS.centerOfMass.draw && SS.centerOfMass.dirty && h.v == SS.GW.activeGroup.v) {
+        if(SS.centerOfMass.draw && SS.centerOfMass.dirty && h == SS.GW.activeGroup) {
             SS.UpdateCenterOfMass();
         }
         displayDirty = false;
@@ -469,7 +469,7 @@ Group *Group::PreviousGroup() const {
     int i;
     for(i = 0; i < SK.groupOrder.n; i++) {
         Group *g = SK.GetGroup(SK.groupOrder.elem[i]);
-        if(g->h.v == h.v) break;
+        if(g->h == h) break;
     }
     if(i == 0 || i >= SK.groupOrder.n) return NULL;
     return SK.GetGroup(SK.groupOrder.elem[i - 1]);
@@ -559,7 +559,7 @@ void Group::DrawMesh(DrawMeshAs how, Canvas *canvas) {
 
             std::vector<uint32_t> faces;
             hEntity he = SS.GW.hover.entity;
-            if(he.v != 0 && SK.GetEntity(he)->IsFace()) {
+            if(he && SK.GetEntity(he)->IsFace()) {
                 faces.push_back(he.v);
             }
             canvas->DrawFaces(displayMesh, faces, hcf);
@@ -687,7 +687,7 @@ void Group::DrawFilledPaths(Canvas *canvas) {
         if(s->filled) {
             // This is a filled loop, where the user specified a fill color.
             fill.color = s->fillColor;
-        } else if(h.v == SS.GW.activeGroup.v && SS.checkClosedContour &&
+        } else if(h == SS.GW.activeGroup && SS.checkClosedContour &&
                     polyError.how == PolyError::GOOD) {
             // If this is the active group, and we are supposed to check
             // for closed contours, and we do indeed have a closed and

--- a/src/importdxf.cpp
+++ b/src/importdxf.cpp
@@ -455,8 +455,8 @@ public:
         Entity *e = SK.GetEntity(he);
         Vector pos = e->PointGetNum();
         hEntity p = findPoint(pos);
-        if(p.v == he.v) return;
-        if(p.v != Entity::NO_ENTITY.v) {
+        if(p == he) return;
+        if(p != Entity::NO_ENTITY) {
             if(constrain) {
                 Constraint::ConstrainCoincident(he, p);
             }
@@ -475,7 +475,7 @@ public:
 
     hEntity createOrGetPoint(const Vector &p) {
         hEntity he = findPoint(p);
-        if(he.v != Entity::NO_ENTITY.v) return he;
+        if(he != Entity::NO_ENTITY) return he;
 
         hRequest hr = SS.GW.AddRequest(Request::Type::DATUM_POINT, /*rememberForUndo=*/false);
         he = hr.entity(0);

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -15,8 +15,8 @@ void GraphicsWindow::ReplacePointInConstraints(hEntity oldpt, hEntity newpt) {
     int i;
     for(i = 0; i < SK.constraint.n; i++) {
         Constraint *c = &(SK.constraint.elem[i]);
-        if(c->ptA.v == oldpt.v) c->ptA = newpt;
-        if(c->ptB.v == oldpt.v) c->ptB = newpt;
+        if(c->ptA == oldpt) c->ptA = newpt;
+        if(c->ptB == oldpt) c->ptB = newpt;
     }
 }
 
@@ -27,7 +27,7 @@ void GraphicsWindow::RemoveConstraintsForPointBeingDeleted(hEntity hpt) {
     SK.constraint.ClearTags();
     for(int i = 0; i < SK.constraint.n; i++) {
         Constraint *c = &(SK.constraint.elem[i]);
-        if(c->ptA.v == hpt.v || c->ptB.v == hpt.v) {
+        if(c->ptA == hpt || c->ptB == hpt) {
             c->tag = 1;
             (SS.deleted.constraints)++;
             if(c->type != Constraint::Type::POINTS_COINCIDENT &&
@@ -49,12 +49,12 @@ void GraphicsWindow::RemoveConstraintsForPointBeingDeleted(hEntity hpt) {
 //-----------------------------------------------------------------------------
 void GraphicsWindow::FixConstraintsForRequestBeingDeleted(hRequest hr) {
     Request *r = SK.GetRequest(hr);
-    if(r->group.v != SS.GW.activeGroup.v) return;
+    if(r->group != SS.GW.activeGroup) return;
 
     Entity *e;
     for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {
         if(!(e->h.isFromRequest())) continue;
-        if(e->h.request().v != hr.v) continue;
+        if(e->h.request() != hr) continue;
 
         if(e->type != Entity::Type::POINT_IN_2D &&
            e->type != Entity::Type::POINT_IN_3D)
@@ -74,13 +74,13 @@ void GraphicsWindow::FixConstraintsForPointBeingDeleted(hEntity hpt) {
     SK.constraint.ClearTags();
     for(c = SK.constraint.First(); c; c = SK.constraint.NextAfter(c)) {
         if(c->type != Constraint::Type::POINTS_COINCIDENT) continue;
-        if(c->group.v != SS.GW.activeGroup.v) continue;
+        if(c->group != SS.GW.activeGroup) continue;
 
-        if(c->ptA.v == hpt.v) {
+        if(c->ptA == hpt) {
             ld.Add(&(c->ptB));
             c->tag = 1;
         }
-        if(c->ptB.v == hpt.v) {
+        if(c->ptB == hpt) {
             ld.Add(&(c->ptA));
             c->tag = 1;
         }
@@ -233,10 +233,10 @@ void GraphicsWindow::ParametricCurve::ConstrainPointIfCoincident(hEntity hpt) {
     ptv = pt->PointGetNum();
 
     for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {
-        if(e->h.v == pt->h.v) continue;
+        if(e->h == pt->h) continue;
         if(!e->IsPoint()) continue;
-        if(e->group.v != pt->group.v) continue;
-        if(e->workplane.v != pt->workplane.v) continue;
+        if(e->group != pt->group) continue;
+        if(e->workplane != pt->workplane) continue;
 
         ev = e->PointGetNum();
         if(!ev.Equals(ptv)) continue;
@@ -272,8 +272,8 @@ void GraphicsWindow::MakeTangentArc() {
     bool pointf[2];
     for(i = 0; i < SK.request.n; i++) {
         Request *r = &(SK.request.elem[i]);
-        if(r->group.v != activeGroup.v) continue;
-        if(r->workplane.v != ActiveWorkplane().v) continue;
+        if(r->group != activeGroup) continue;
+        if(r->workplane != ActiveWorkplane()) continue;
         if(r->construction) continue;
         if(r->type != Request::Type::LINE_SEGMENT &&
            r->type != Request::Type::ARC_OF_CIRCLE)
@@ -412,8 +412,8 @@ void GraphicsWindow::MakeTangentArc() {
         SK.constraint.ClearTags();
         for(i = 0; i < SK.constraint.n; i++) {
             Constraint *cs = &(SK.constraint.elem[i]);
-            if(cs->group.v != activeGroup.v) continue;
-            if(cs->workplane.v != ActiveWorkplane().v) continue;
+            if(cs->group != activeGroup) continue;
+            if(cs->workplane != ActiveWorkplane()) continue;
             if(cs->type != Constraint::Type::POINTS_COINCIDENT) continue;
             if (SK.GetEntity(cs->ptA)->PointGetNum().Equals(pshared)) {
             cs->tag = 1;
@@ -605,12 +605,12 @@ hEntity GraphicsWindow::SplitEntity(hEntity he, Vector pinter) {
     SK.request.ClearTags();
     for(int i = 0; i < SK.request.n; i++) {
         Request *r = &(SK.request.elem[i]);
-        if(r->group.v != activeGroup.v) continue;
+        if(r->group != activeGroup) continue;
         if(r->type != reqType) continue;
 
         // If the user wants to keep the old entities around, they can just
         // mark them construction first.
-        if(he.v == r->h.entity(0).v && !r->construction) {
+        if(he == r->h.entity(0) && !r->construction) {
             r->tag = 1;
             break;
         }
@@ -659,8 +659,8 @@ void GraphicsWindow::SplitLinesOrCurves() {
         }
 
         for(Constraint &c : SK.constraint) {
-            if(c.ptA.request().v == hb.request().v &&
-               c.entityA.request().v == ha.request().v) {
+            if(c.ptA.request() == hb.request() &&
+               c.entityA.request() == ha.request()) {
                 pi = SK.GetEntity(c.ptA)->PointGetNum();
 
                 if(ea->type == Entity::Type::LINE_SEGMENT && !pi.OnLineSegment(p0, p1)) {
@@ -713,7 +713,7 @@ void GraphicsWindow::SplitLinesOrCurves() {
             // Remove datum point, as it has now been superseded by the split point.
             SK.request.ClearTags();
             for(Request &r : SK.request) {
-                if(r.h.v == hb.request().v) {
+                if(r.h == hb.request()) {
                     if(r.type == Request::Type::DATUM_POINT) {
                         // Delete datum point.
                         r.tag = 1;
@@ -729,7 +729,7 @@ void GraphicsWindow::SplitLinesOrCurves() {
         } else {
             // Split second non-point entity and add constraint.
             hib = SplitEntity(hb, pi);
-            if(hia.v && hib.v) {
+            if(hia && hib) {
                 Constraint::ConstrainCoincident(hia, hib);
             }
         }

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -59,14 +59,14 @@ class Canvas {
 public:
     // Stroke and fill styles are addressed with handles to be able to quickly
     // group geometry into indexed draw calls.
-    class hStroke {
+    class hStroke : public HandleBase<Canvas::hStroke> {
     public:
-        uint32_t v;
+        using HandleBase::HandleBase;
     };
 
-    class hFill {
+    class hFill : public HandleBase<Canvas::hFill> {
     public:
-        uint32_t v;
+        using HandleBase::HandleBase;
     };
 
     // The layer of a geometry describes how it occludes other geometry.

--- a/src/render/rendercairo.cpp
+++ b/src/render/rendercairo.cpp
@@ -58,7 +58,7 @@ void CairoRenderer::OutputEnd() {
 }
 
 void CairoRenderer::SelectStroke(hStroke hcs) {
-    if(current.hcs.v == hcs.v) return;
+    if(current.hcs == hcs) return;
     FinishPath();
 
     Stroke *stroke = strokes.FindById(hcs);

--- a/src/render/rendergl1.cpp
+++ b/src/render/rendergl1.cpp
@@ -249,7 +249,7 @@ void OpenGl1Renderer::UnSelectPrimitive() {
 }
 
 Canvas::Stroke *OpenGl1Renderer::SelectStroke(hStroke hcs) {
-    if(current.hcs.v == hcs.v) return current.stroke;
+    if(current.hcs == hcs) return current.stroke;
 
     Stroke *stroke = strokes.FindById(hcs);
     UnSelectPrimitive();
@@ -270,7 +270,7 @@ Canvas::Stroke *OpenGl1Renderer::SelectStroke(hStroke hcs) {
 }
 
 Canvas::Fill *OpenGl1Renderer::SelectFill(hFill hcf) {
-    if(current.hcf.v == hcf.v) return current.fill;
+    if(current.hcf == hcf) return current.fill;
 
     Fill *fill = fills.FindById(hcf);
     UnSelectPrimitive();
@@ -607,7 +607,7 @@ void OpenGl1Renderer::DrawMesh(const SMesh &m, hFill hcfFront, hFill hcfBack) {
     frontColor = frontFill->color;
 
     ssglMaterialRGBA(GL_FRONT, frontFill->color);
-    if(hcfBack.v != 0) {
+    if(hcfBack) {
         Fill *backFill = fills.FindById(hcfBack);
         backColor = backFill->color;
         ssassert(frontFill->layer  == backFill->layer &&

--- a/src/render/rendergl3.cpp
+++ b/src/render/rendergl3.cpp
@@ -195,7 +195,7 @@ static void ssglDepthRange(Canvas::Layer layer, int zIndex) {
 //-----------------------------------------------------------------------------
 
 Canvas::Stroke *OpenGl3Renderer::SelectStroke(hStroke hcs) {
-    if(current.hcs.v == hcs.v) return current.stroke;
+    if(current.hcs == hcs) return current.stroke;
 
     Stroke *stroke = strokes.FindById(hcs);
     ssglDepthRange(stroke->layer, stroke->zIndex);
@@ -241,7 +241,7 @@ void OpenGl3Renderer::SelectMask(FillPattern pattern) {
 }
 
 Canvas::Fill *OpenGl3Renderer::SelectFill(hFill hcf) {
-    if(current.hcf.v == hcf.v) return current.fill;
+    if(current.hcf == hcf) return current.fill;
 
     Fill *fill = fills.FindById(hcf);
     ssglDepthRange(fill->layer, fill->zIndex);

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -146,7 +146,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
         p.group = group;
         p.style = style;
         p.construction = e.construction;
-        if(workplane.v == Entity::FREE_IN_3D.v) {
+        if(workplane == Entity::FREE_IN_3D) {
             p.type = Entity::Type::POINT_IN_3D;
             // params for x y z
             p.param[0] = AddParam(param, h.param(16 + 3*i + 0));
@@ -168,7 +168,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
         n.group = group;
         n.style = style;
         n.construction = e.construction;
-        if(workplane.v == Entity::FREE_IN_3D.v) {
+        if(workplane == Entity::FREE_IN_3D) {
             n.type = Entity::Type::NORMAL_IN_3D;
             n.param[0] = AddParam(param, h.param(32+0));
             n.param[1] = AddParam(param, h.param(32+1));
@@ -203,11 +203,11 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
 
 std::string Request::DescriptionString() const {
     const char *s = "";
-    if(h.v == Request::HREQUEST_REFERENCE_XY.v) {
+    if(h == Request::HREQUEST_REFERENCE_XY) {
         s = "#XY";
-    } else if(h.v == Request::HREQUEST_REFERENCE_YZ.v) {
+    } else if(h == Request::HREQUEST_REFERENCE_YZ) {
         s = "#YZ";
-    } else if(h.v == Request::HREQUEST_REFERENCE_ZX.v) {
+    } else if(h == Request::HREQUEST_REFERENCE_ZX) {
         s = "#ZX";
     } else {
         switch(type) {
@@ -228,10 +228,10 @@ std::string Request::DescriptionString() const {
 
 int Request::IndexOfPoint(hEntity he) const {
     if(type == Type::DATUM_POINT) {
-        return (he.v == h.entity(0).v) ? 0 : -1;
+        return (he == h.entity(0)) ? 0 : -1;
     }
     for(int i = 0; i < MAX_POINTS_IN_ENTITY; i++) {
-        if(he.v == h.entity(i + 1).v) {
+        if(he == h.entity(i + 1)) {
             return i;
         }
     }

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -50,53 +50,58 @@ enum class Command : uint32_t;
 
 // All of the hWhatever handles are a 32-bit ID, that is used to represent
 // some data structure in the sketch.
-class hGroup {
+class hGroup : public HandleBase<hGroup> {
 public:
     // bits 15: 0   -- group index
-    uint32_t v;
+    using HandleBase::HandleBase;
 
     inline hEntity entity(int i) const;
     inline hParam param(int i) const;
     inline hEquation equation(int i) const;
 };
-class hRequest {
+
+class hRequest: public HandleBase<hRequest> {
 public:
     // bits 15: 0   -- request index
-    uint32_t v;
+    using HandleBase::HandleBase;
 
     inline hEntity entity(int i) const;
     inline hParam param(int i) const;
 
     inline bool IsFromReferences() const;
 };
-class hEntity {
+
+class hEntity : public HandleBase<hEntity>{
 public:
     // bits 15: 0   -- entity index
     //      31:16   -- request index
-    uint32_t v;
+    using HandleBase::HandleBase;
 
     inline bool isFromRequest() const;
     inline hRequest request() const;
     inline hGroup group() const;
     inline hEquation equation(int i) const;
 };
-class hParam {
+
+class hParam : public HandleBase<hParam>{
 public:
     // bits 15: 0   -- param index
     //      31:16   -- request index
-    uint32_t v;
+    using HandleBase::HandleBase;
 
     inline hRequest request() const;
 };
 
-class hStyle {
+class hStyle : public HandleBase<hStyle>{
 public:
-    uint32_t v;
+    using HandleBase::HandleBase;
 };
 
-struct EntityId {
-    uint32_t v;     // entity ID, starting from 0
+struct EntityId : public HandleBase<EntityId> {
+    using HandleBase::HandleBase;
+         // entity ID, starting from 0
 };
+
 struct EntityKey {
     hEntity     input;
     int         copyNumber;
@@ -587,9 +592,9 @@ public:
 };
 
 
-class hConstraint {
+class hConstraint : public HandleBase<hConstraint>{
 public:
-    uint32_t v;
+    using HandleBase::HandleBase;
 
     inline hEquation equation(int i) const;
     inline hParam param(int i) const;
@@ -662,10 +667,10 @@ public:
     std::string comment;    // since comments are represented as constraints
 
     bool Equals(const ConstraintBase &c) const {
-        return type == c.type && group.v == c.group.v && workplane.v == c.workplane.v &&
-            valA == c.valA && valP.v == c.valP.v && ptA.v == c.ptA.v && ptB.v == c.ptB.v &&
-            entityA.v == c.entityA.v && entityB.v == c.entityB.v &&
-            entityC.v == c.entityC.v && entityD.v == c.entityD.v &&
+        return type == c.type && group == c.group && workplane == c.workplane &&
+            valA == c.valA && valP == c.valP && ptA == c.ptA && ptB == c.ptB &&
+            entityA == c.entityA && entityB == c.entityB &&
+            entityC == c.entityC && entityD == c.entityD &&
             other == c.other && other2 == c.other2 && reference == c.reference &&
             comment == c.comment;
     }
@@ -755,9 +760,9 @@ public:
                                     bool other = false, bool other2 = false);
 };
 
-class hEquation {
+class hEquation : public HandleBase<hEquation> {
 public:
-    uint32_t v;
+    using HandleBase::HandleBase;
 
     inline bool isFromConstraint() const;
     inline hConstraint constraint() const;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -116,7 +116,7 @@ struct EntityKeyHash {
 };
 struct EntityKeyEqual {
     bool operator()(const EntityKey &a, const EntityKey &b) const {
-        return std::tie(a.input.v, a.copyNumber) == std::tie(b.input.v, b.copyNumber);
+        return std::tie(a.input, a.copyNumber) == std::tie(b.input, b.copyNumber);
     }
 };
 typedef std::unordered_map<EntityKey, EntityId, EntityKeyHash, EntityKeyEqual> EntityMap;
@@ -894,9 +894,9 @@ inline hEquation hGroup::equation(int i) const
     { hEquation r; r.v = (v << 16) | 0x80000000 | (uint32_t)i; return r; }
 
 inline bool hRequest::IsFromReferences() const {
-    if(v == Request::HREQUEST_REFERENCE_XY.v) return true;
-    if(v == Request::HREQUEST_REFERENCE_YZ.v) return true;
-    if(v == Request::HREQUEST_REFERENCE_ZX.v) return true;
+    if(*this == Request::HREQUEST_REFERENCE_XY) return true;
+    if(*this == Request::HREQUEST_REFERENCE_YZ) return true;
+    if(*this == Request::HREQUEST_REFERENCE_ZX) return true;
     return false;
 }
 inline hEntity hRequest::entity(int i) const

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -1045,7 +1045,7 @@ BBox Sketch::CalculateEntityBBox(bool includingInvisible) {
         // arc center point shouldn't be included in bounding box calculation
         if(e.IsPoint() && e.h.isFromRequest()) {
             Request *r = SK.GetRequest(e.h.request());
-            if(r->type == Request::Type::ARC_OF_CIRCLE && e.h.v == r->h.entity(1).v) {
+            if(r->type == Request::Type::ARC_OF_CIRCLE && e.h == r->h.entity(1)) {
                 continue;
             }
         }

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -165,13 +165,8 @@ enum class Unit : uint32_t {
     METERS
 };
 
-template<class T>
-struct CompareHandle {
-    bool operator()(T lhs, T rhs) const { return lhs.v < rhs.v; }
-};
-
 template<class Key, class T>
-using handle_map = std::map<Key, T, CompareHandle<Key>>;
+using handle_map = std::map<Key, T>;
 
 class Group;
 class SSurface;

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -444,9 +444,9 @@ SSurface SSurface::MakeCopyTrimAgainst(SShell *parent,
         for(sc = into->curve.First(); sc; sc = into->curve.NextAfter(sc)) {
             if(sc->source != SCurve::Source::INTERSECTION) continue;
             if(opA) {
-                if(sc->surfA.v != h.v || sc->surfB.v != ss->h.v) continue;
+                if(sc->surfA != h || sc->surfB != ss->h) continue;
             } else {
-                if(sc->surfB.v != h.v || sc->surfA.v != ss->h.v) continue;
+                if(sc->surfB != h || sc->surfA != ss->h) continue;
             }
 
             int i;

--- a/src/srf/merge.cpp
+++ b/src/srf/merge.cpp
@@ -59,8 +59,8 @@ void SShell::MergeCoincidentSurfaces() {
                 // new srf
                 SCurve *sc;
                 for(sc = curve.First(); sc; sc = curve.NextAfter(sc)) {
-                    if(sc->surfA.v == sj->h.v) sc->surfA = si->h;
-                    if(sc->surfB.v == sj->h.v) sc->surfB = si->h;
+                    if(sc->surfA == sj->h) sc->surfA = si->h;
+                    if(sc->surfB == sj->h) sc->surfB = si->h;
                 }
             }
 

--- a/src/srf/surface.cpp
+++ b/src/srf/surface.cpp
@@ -742,7 +742,7 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
 
                 // If this input curve generated a surface, then trim that
                 // surface with the rotated version of the input curve.
-                if(revs.d[0].v) { // not d[j] because crash on j==sections
+                if(revs.d[0]) { // not d[j] because crash on j==sections
                     sc         = {};
                     sc.isExact = true;
                     sc.exact   = sb->TransformedBy(ts, qs, 1.0);
@@ -786,7 +786,7 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
                 // And if this input curve and the one after it both generated
                 // surfaces, then trim both of those by the appropriate
                 // curve based on the control points.
-                if((j < sections) && revs.d[j].v && revsp.d[j].v) {
+                if((j < sections) && revs.d[j] && revsp.d[j]) {
                     SSurface *ss = surface.FindById(revs.d[j]);
 
                     sc         = {};
@@ -873,7 +873,7 @@ void SShell::MakeFromRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector axis, 
 
                 // If this input curve generate a surface, then trim that
                 // surface with the rotated version of the input curve.
-                if(revs.d[j].v) {
+                if(revs.d[j]) {
                     sc = {};
                     sc.isExact = true;
                     sc.exact = sb->TransformedBy(ts, qs, 1.0);
@@ -893,7 +893,7 @@ void SShell::MakeFromRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector axis, 
                 // And if this input curve and the one after it both generated
                 // surfaces, then trim both of those by the appropriate
                 // circle.
-                if(revs.d[j].v && revsp.d[j].v) {
+                if(revs.d[j] && revsp.d[j]) {
                     SSurface *ss = surface.FindById(revs.d[j]);
 
                     sc = {};

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -58,14 +58,14 @@ public:
 
 class SShell;
 
-class hSSurface {
+class hSSurface : public HandleBase<hSSurface> {
 public:
-    uint32_t v;
+    using HandleBase::HandleBase;
 };
 
-class hSCurve {
+class hSCurve : public HandleBase<hSCurve> {
 public:
-    uint32_t v;
+    using HandleBase::HandleBase;
 };
 
 // Stuff for rational polynomial curves, of degree one to three. These are

--- a/src/srf/surfinter.cpp
+++ b/src/srf/surfinter.cpp
@@ -331,7 +331,7 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
                 // Find the other surface that this curve trims.
                 hSCurve hsc = { (uint32_t)se->auxA };
                 SCurve *sc = shA->curve.FindById(hsc);
-                hSSurface hother = (sc->surfA.v == srfA->h.v) ?
+                hSSurface hother = (sc->surfA == srfA->h) ?
                                                     sc->surfB : sc->surfA;
                 SSurface *other = shA->surface.FindById(hother);
 

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -50,7 +50,7 @@ std::string Style::CnfPrefixToName(const std::string &prefix) {
 
 void Style::CreateAllDefaultStyles() {
     const Default *d;
-    for(d = &(Defaults[0]); d->h.v; d++) {
+    for(d = &(Defaults[0]); d->h; d++) {
         (void)Get(d->h);
     }
 }
@@ -58,10 +58,10 @@ void Style::CreateAllDefaultStyles() {
 void Style::CreateDefaultStyle(hStyle h) {
     bool isDefaultStyle = true;
     const Default *d;
-    for(d = &(Defaults[0]); d->h.v; d++) {
-        if(d->h.v == h.v) break;
+    for(d = &(Defaults[0]); d->h; d++) {
+        if(d->h == h) break;
     }
-    if(!d->h.v) {
+    if(!d->h) {
         // Not a default style; so just create it the same as our default
         // active group entity style.
         d = &(Defaults[0]);
@@ -108,7 +108,7 @@ void Style::FillDefaultStyle(Style *s, const Default *d, bool factory) {
 
 void Style::LoadFactoryDefaults() {
     const Default *d;
-    for(d = &(Defaults[0]); d->h.v; d++) {
+    for(d = &(Defaults[0]); d->h; d++) {
         Style *s = Get(d->h);
         FillDefaultStyle(s, d, /*factory=*/true);
     }
@@ -117,7 +117,7 @@ void Style::LoadFactoryDefaults() {
 
 void Style::FreezeDefaultStyles(Platform::SettingsRef settings) {
     const Default *d;
-    for(d = &(Defaults[0]); d->h.v; d++) {
+    for(d = &(Defaults[0]); d->h; d++) {
         settings->FreezeColor(CnfColor(d->cnfPrefix), Color(d->h));
         settings->FreezeFloat(CnfWidth(d->cnfPrefix), (float)Width(d->h));
         settings->FreezeFloat(CnfTextHeight(d->cnfPrefix), (float)TextHeight(d->h));
@@ -181,7 +181,7 @@ void Style::AssignSelectionToStyle(uint32_t v) {
 // the style, according to our table of default styles.
 //-----------------------------------------------------------------------------
 Style *Style::Get(hStyle h) {
-    if(h.v == 0) h.v = ACTIVE_GRP;
+    if(!h) h.v = ACTIVE_GRP;
 
     Style *s = SK.style.FindByIdNoOops(h);
     if(s) {
@@ -331,13 +331,13 @@ hStyle Style::ForEntity(hEntity he) {
     Entity *e = SK.GetEntity(he);
     // If the entity has a special style, use that. If that style doesn't
     // exist yet, then it will get created automatically later.
-    if(e->style.v != 0) {
+    if(e->style) {
         return e->style;
     }
 
     // Otherwise, we use the default rules.
     hStyle hs;
-    if(e->group.v != SS.GW.activeGroup.v) {
+    if(e->group != SS.GW.activeGroup) {
         hs.v = INACTIVE_GRP;
     } else if(e->construction) {
         hs.v = CONSTRUCTION;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -79,7 +79,7 @@ void System::EvalJacobian() {
 bool System::IsDragged(hParam p) {
     hParam *pp;
     for(pp = dragged.First(); pp; pp = dragged.NextAfter(pp)) {
-        if(p.v == pp->v) return true;
+        if(p == *pp) return true;
     }
     return false;
 }
@@ -115,7 +115,7 @@ void System::SolveBySubstitution() {
             }
             for(j = 0; j < param.n; j++) {
                 Param *rp = &(param.elem[j]);
-                if(rp->substd.v == a.v) {
+                if(rp->substd == a) {
                     rp->substd = b;
                 }
             }
@@ -328,8 +328,8 @@ void System::WriteEquationsExceptFor(hConstraint hc, Group *g) {
     // Generate all the equations from constraints in this group
     for(i = 0; i < SK.constraint.n; i++) {
         ConstraintBase *c = &(SK.constraint.elem[i]);
-        if(c->group.v != g->h.v) continue;
-        if(c->h.v == hc.v) continue;
+        if(c->group != g->h) continue;
+        if(c->h == hc) continue;
 
         if(c->HasLabel() && c->type != Constraint::Type::COMMENT &&
                 g->allDimsReference)
@@ -351,7 +351,7 @@ void System::WriteEquationsExceptFor(hConstraint hc, Group *g) {
     // And the equations from entities
     for(i = 0; i < SK.entity.n; i++) {
         EntityBase *e = &(SK.entity.elem[i]);
-        if(e->group.v != g->h.v) continue;
+        if(e->group != g->h) continue;
 
         e->GenerateEquations(&eq);
     }
@@ -365,7 +365,7 @@ void System::FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad, bo
     for(a = 0; a < 2; a++) {
         for(i = 0; i < SK.constraint.n; i++) {
             ConstraintBase *c = &(SK.constraint.elem[i]);
-            if(c->group.v != g->h.v) continue;
+            if(c->group != g->h) continue;
             if((c->type == Constraint::Type::POINTS_COINCIDENT && a == 0) ||
                (c->type != Constraint::Type::POINTS_COINCIDENT && a == 1))
             {
@@ -436,8 +436,8 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
         if(e->tag != 0) continue;
 
         hParam hp = e->e->ReferencedParams(&param);
-        if(hp.v == Expr::NO_PARAMS.v) continue;
-        if(hp.v == Expr::MULTIPLE_PARAMS.v) continue;
+        if(hp == Expr::NO_PARAMS) continue;
+        if(hp == Expr::MULTIPLE_PARAMS) continue;
 
         Param *p = param.FindById(hp);
         if(p->tag != 0) continue; // let rank test catch inconsistency

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -71,7 +71,7 @@ void TextWindow::ScreenActivateGroup(int link, uint32_t v) {
 void TextWindow::ReportHowGroupSolved(hGroup hg) {
     SS.GW.ClearSuper();
     SS.TW.GoToScreen(Screen::GROUP_SOLVE_INFO);
-    SS.TW.shown.group.v = hg.v;
+    SS.TW.shown.group = hg;
     SS.ScheduleShowTW();
 }
 void TextWindow::ScreenHowGroupSolved(int link, uint32_t v) {
@@ -103,7 +103,7 @@ void TextWindow::ShowListOfGroups() {
     for(i = 0; i < SK.groupOrder.n; i++) {
         Group *g = SK.GetGroup(SK.groupOrder.elem[i]);
         std::string s = g->DescriptionString();
-        bool active = (g->h.v == SS.GW.activeGroup.v);
+        bool active = (g->h == SS.GW.activeGroup);
         bool shown = g->visible;
         bool ok = g->IsSolvedOkay();
         bool warn = (g->type == Group::Type::DRAWING_WORKPLANE &&
@@ -120,7 +120,7 @@ void TextWindow::ShowListOfGroups() {
               sprintf(sdof, "%-3d", dof);
             }
         }
-        bool ref = (g->h.v == Group::HGROUP_REFERENCES.v);
+        bool ref = (g->h == Group::HGROUP_REFERENCES);
         Printf(false, "%Bp%Fd "
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
@@ -245,7 +245,7 @@ void TextWindow::ScreenOpacity(int link, uint32_t v) {
 
     SS.TW.ShowEditControl(11, ssprintf("%.2f", g->color.alphaF()));
     SS.TW.edit.meaning = Edit::GROUP_OPACITY;
-    SS.TW.edit.group.v = g->h.v;
+    SS.TW.edit.group = g->h;
 }
 void TextWindow::ScreenChangeExprA(int link, uint32_t v) {
     Group *g = SK.GetGroup(SS.TW.shown.group);
@@ -271,7 +271,7 @@ void TextWindow::ScreenDeleteGroup(int link, uint32_t v) {
     SS.UndoRemember();
 
     hGroup hg = SS.TW.shown.group;
-    if(hg.v == SS.GW.activeGroup.v) {
+    if(hg == SS.GW.activeGroup) {
         SS.GW.activeGroup = SK.GetGroup(SS.GW.activeGroup)->PreviousGroup()->h;
     }
 
@@ -291,7 +291,7 @@ void TextWindow::ShowGroupInfo() {
     Group *g = SK.GetGroup(shown.group);
     const char *s = "???";
 
-    if(shown.group.v == Group::HGROUP_REFERENCES.v) {
+    if(shown.group == Group::HGROUP_REFERENCES) {
         Printf(true, "%FtGROUP  %E%s", g->DescriptionString().c_str());
         goto list_items;
     } else {
@@ -444,7 +444,7 @@ list_items:
     for(i = 0; i < SK.request.n; i++) {
         Request *r = &(SK.request.elem[i]);
 
-        if(r->group.v == shown.group.v) {
+        if(r->group == shown.group) {
             std::string s = r->DescriptionString();
             Printf(false, "%Bp   %Fl%Ll%D%f%h%s%E",
                 (a & 1) ? 'd' : 'a',
@@ -461,7 +461,7 @@ list_items:
     for(i = 0; i < SK.constraint.n; i++) {
         Constraint *c = &(SK.constraint.elem[i]);
 
-        if(c->group.v == shown.group.v) {
+        if(c->group == shown.group) {
             std::string s = c->DescriptionString();
             Printf(false, "%Bp   %Fl%Ll%D%f%h%s%E %s",
                 (a & 1) ? 'd' : 'a',


### PR DESCRIPTION
Handles seem like the kind of thing you should be able to compare, and the .v scattered throughout the codebase was an impediment to me learning it. Finally did a little modification I meant to do for a while: provide `==`, `!=`, `<` and `explicit operator bool` (aka "use in `if` statements") operators for all the handle types. Easiest, least messy way was with a curiously-recurring-template-pattern base class so there is only one implementation of the operators, yet the handles are still type-safe (can't compare across handle types without using `.v` to get the uint32_t).

If it seems useless to you, no hard feelings if you just reject this (or drop parts of it, like the operator bool perhaps, since that seems less obviously-useful than the comparison operators).  FWIW, I also have a version of this based on #428 (actually I devved it there first then rebased it onto master), at https://github.com/rpavlik/solvespace/tree/handle-operators-after-simplify

Could revise to not use CRTP, but would then need a "tag type" for each handle type to keep them distinct, so this seemed simplest.