### PR TITLE
VRML/WRL mesh export

### DIFF
--- a/src/export.cpp
+++ b/src/export.cpp
@@ -1217,53 +1217,35 @@ void SolveSpaceUI::ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, S
     }
 
     // Output all the vertices.
-    bool first = true;
     for(auto sp : spl.l) {
-        if(!first) {
-            fputs(",\n", f);
-        }
-        first = false;
-
-        fprintf(f, "          %f %f %f",
+        fprintf(f, "          %f %f %f,\n",
                 sp.p.x / SS.exportScale,
                 sp.p.y / SS.exportScale,
                 sp.p.z / SS.exportScale);
     }
 
-    fputs(" ] }\n"
+    fputs("        ] }\n"
           "        coordIndex [\n", f);
     // And now all the triangular faces, in terms of those vertices.
-    first = true;
     for(const auto & tr : sm->l) {
-        if(!first) {
-            fputs(",\n", f);
-        }
-        first = false;
-
-        fprintf(f, "          %d, %d, %d, -1",
+        fprintf(f, "          %d, %d, %d, -1,\n",
                 spl.IndexForPoint(tr.a),
                 spl.IndexForPoint(tr.b),
                 spl.IndexForPoint(tr.c));
     }
 
-    fputs(" ]\n"
+    fputs("        ]\n"
           "        color Color { color [\n", f);
     // Output triangle colors.
     std::vector<int> triangle_colour_ids;
     std::vector<RgbaColor> colours_present;
-    first = true;
     for(const auto & tr : sm->l) {
         const auto colour_itr = std::find_if(colours_present.begin(), colours_present.end(),
                                              [&](const RgbaColor & c) {
                                                  return c.Equals(tr.meta.color);
                                              });
         if(colour_itr == colours_present.end()) {
-            if(!first) {
-                fputs(",\n", f);
-            }
-            first = false;
-
-            fprintf(f, "          %.10f %.10f %.10f",
+            fprintf(f, "          %.10f %.10f %.10f,\n",
                     tr.meta.color.redF(),
                     tr.meta.color.greenF(),
                     tr.meta.color.blueF());
@@ -1274,20 +1256,14 @@ void SolveSpaceUI::ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, S
         }
     }
 
-    fputs(" ] }\n"
+    fputs("        ] }\n"
           "        colorIndex [\n", f);
 
-    first = true;
     for(auto colour_idx : triangle_colour_ids) {
-        if(!first) {
-            fputs(",\n", f);
-        }
-        first = false;
-
-        fprintf(f, "          %d, %d, %d, -1", colour_idx, colour_idx, colour_idx);
+        fprintf(f, "          %d, %d, %d, -1,\n", colour_idx, colour_idx, colour_idx);
     }
 
-    fputs(" ]\n"
+    fputs("        ]\n"
           "      }\n"
           "    }\n"
           "  ]\n"

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -1174,12 +1174,6 @@ void SolveSpaceUI::ExportMeshAsThreeJsTo(FILE *f, const Platform::Path &filename
 // Export the mesh as a VRML text file / WRL.
 //-----------------------------------------------------------------------------
 void SolveSpaceUI::ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, SMesh *sm) {
-    SPointList spl = {};
-
-    fprintf(f, "#VRML V2.0 utf8\n"
-               "#Exported from SolveSpace %s\n\n",
-            PACKAGE_VERSION);
-
     std::string basename = filename.FileStem();
     for(auto & c : basename) {
         if(!(isalnum(c) || ((unsigned)c >= 0x80))) {
@@ -1187,28 +1181,31 @@ void SolveSpaceUI::ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, S
         }
     }
 
-    // Material values below are magic copied from
-    // the "Buzzer_12x9.5RM7.6.wrl" model shipped with KiCad.
-    fprintf(f, "DEF %s Transform {\n"
+    fprintf(f, "#VRML V2.0 utf8\n"
+               "#Exported from SolveSpace %s\n"
+               "\n"
+               "DEF %s Transform {\n"
                "  children [\n"
                "    Shape {\n"
                "      appearance Appearance {\n"
                "        material DEF %s_material Material {\n"
-               "          diffuseColor"
-                        " 0.17333333333333334 0.17333333333333334 0.17333333333333334\n"
-               "          emissiveColor 0.0 0.0 0.0\n"
-               "          specularColor 1.0 1.0 1.0\n"
+               "          diffuseColor %f %f %f\n"
                "          ambientIntensity %f\n"
                "          transparency 0.0\n"
-               "          shininess 1.0\n"
                "        }\n"
                "      }\n"
                "      geometry IndexedFaceSet {\n"
                "        colorPerVertex TRUE\n"
                "        coord Coordinate { point [\n",
+            PACKAGE_VERSION,
             basename.c_str(),
             basename.c_str(),
+            SS.ambientIntensity,
+            SS.ambientIntensity,
+            SS.ambientIntensity,
             SS.ambientIntensity);
+
+    SPointList spl = {};
 
     for(const auto & tr : sm->l) {
         spl.IncrementTagFor(tr.a);

--- a/src/platform/gui.cpp
+++ b/src/platform/gui.cpp
@@ -95,6 +95,7 @@ std::vector<FileFilter> MeshFileFilters = {
     { CN_("file-type", "Three.js-compatible mesh, with viewer"), { "html" } },
     { CN_("file-type", "Three.js-compatible mesh, mesh only"), { "js" } },
     { CN_("file-type", "Q3D Object file"), { "q3do" } },
+    { CN_("file-type", "VRML text file"), { "wrl" } },
 };
 
 std::vector<FileFilter> SurfaceFileFilters = {

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -698,6 +698,7 @@ public:
     void ExportMeshAsObjTo(FILE *fObj, FILE *fMtl, SMesh *sm);
     void ExportMeshAsThreeJsTo(FILE *f, const Platform::Path &filename,
                                SMesh *sm, SOutlineList *sol);
+    void ExportMeshAsVrmlTo(FILE *f, const Platform::Path &filename, SMesh *sm);
     void ExportViewOrWireframeTo(const Platform::Path &filename, bool exportWireframe);
     void ExportSectionTo(const Platform::Path &filename);
     void ExportWireframeCurves(SEdgeList *sel, SBezierList *sbl,


### PR DESCRIPTION
As-is, any transparency is ignored, as it'd require emitting a `Shape` per transparency value (I think), so I'd like your opinion on the code as it currently stands before implementing that.

I'm not sure if you have any particular preferences regarding the `std::vector<>` usage for colour (and, later, transparency) buffering?

As for the material values, I present these four renders, identical, but for the material:

Just `ambientIntensity 1`:
![ai1](https://user-images.githubusercontent.com/6709544/62806329-d5016080-baf2-11e9-925f-001ae5d2f1ab.png)

Just `ambientIntensity 0.3`, as returned by `SS.ambientIntensity`:
![ai.3](https://user-images.githubusercontent.com/6709544/62806357-eea2a800-baf2-11e9-9fd6-fd75456f92bc.png)

Material values copied from "Buzzer_12x9.5RM7.6.wrl" (which includes `ambientIntensity 1`):
![a-ai1](https://user-images.githubusercontent.com/6709544/62806441-23aefa80-baf3-11e9-8e64-42f0eafd6613.png)

Material values copied from "Buzzer_12x9.5RM7.6.wrl", but with `ambientIntensity 0.3`, as returned by `SS.ambientIntensity`:
![a-ai.3](https://user-images.githubusercontent.com/6709544/62806468-375a6100-baf3-11e9-8b8b-38b3720bb6c1.png)

I can't speak for everyone, or for all renderers, but, to me, the last one both looks the best and truest to what I saw in SolveSpace, so that's what I've gone with.