### PR TITLE
Add proxy/iterator to iterate groups in order.

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -653,8 +653,7 @@ void GraphicsWindow::DrawPersistent(Canvas *canvas) {
     // specially by assigning a style with a fill color, or when the filled
     // paths are just being filled by default. This should go last, to make
     // the transparency work.
-    for(hGroup hg : SK.groupOrder) {
-        Group *g = SK.GetGroup(hg);
+    for(Group *g : SK.OrderedGroups()) {
         if(!(g->IsVisible())) continue;
         g->DrawFilledPaths(canvas);
     }
@@ -701,9 +700,8 @@ void GraphicsWindow::Draw(Canvas *canvas) {
 
     // Draw areas
     if(SS.showContourAreas) {
-        for(hGroup hg : SK.groupOrder) {
-            Group *g = SK.GetGroup(hg);
-            if(g->h != activeGroup) continue;
+        for(Group *g : SK.OrderedGroups()) {
+            if(g->h.v != activeGroup.v) continue;
             if(!(g->IsVisible())) continue;
             g->DrawContourAreaLabels(canvas);
         }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -20,10 +20,7 @@ void SolveSpaceUI::ClearExisting() {
     UndoClearStack(&redo);
     UndoClearStack(&undo);
 
-    for(hGroup hg : SK.groupOrder) {
-        Group *g = SK.GetGroup(hg);
-        g->Clear();
-    }
+    for(Group *g : SK.OrderedGroups()) { g->Clear(); }
 
     SK.constraint.Clear();
     SK.request.Clear();

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -15,8 +15,7 @@ void SolveSpaceUI::MarkGroupDirtyByEntity(hEntity he) {
 
 void SolveSpaceUI::MarkGroupDirty(hGroup hg, bool onlyThis) {
     bool go = false;
-    for(auto const &gh : SK.groupOrder) {
-        Group *g = SK.GetGroup(gh);
+    for(Group *g : SK.OrderedGroups()) {
         if(g->h == hg) {
             go = true;
         }
@@ -551,8 +550,7 @@ SolveResult SolveSpaceUI::TestRankForGroup(hGroup hg, int *rank) {
 }
 
 bool SolveSpaceUI::ActiveGroupsOkay() {
-    for(int i = 0; i < SK.groupOrder.n; i++) {
-        Group *g = SK.GetGroup(SK.groupOrder[i]);
+    for(Group *g : SK.OrderedGroups()) {
         if(!g->IsSolvedOkay())
             return false;
         if(g->h == SS.GW.activeGroup)

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -308,8 +308,7 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
     SS.UndoRemember();
 
     bool afterActive = false;
-    for(hGroup hg : SK.groupOrder) {
-        Group *gi = SK.GetGroup(hg);
+    for(Group *gi : SK.OrderedGroups()) {
         if(afterActive)
             gi->order += 1;
         if(gi->h == SS.GW.activeGroup) {

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -495,8 +495,7 @@ void Group::GenerateDisplayItems() {
 
 Group *Group::PreviousGroup() const {
     Group *prev = nullptr;
-    for(auto const &gh : SK.groupOrder) {
-        Group *g = SK.GetGroup(gh);
+    for(Group *g : SK.OrderedGroups()) {
         if(g->h == h) {
             return prev;
         }

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -57,11 +57,8 @@ void TextWindow::ScreenToggleGroupShown(int link, uint32_t v) {
 }
 void TextWindow::ScreenShowGroupsSpecial(int link, uint32_t v) {
     bool state = link == 's';
-    for(hGroup hg : SK.groupOrder) {
-        Group *g = SK.GetGroup(hg);
+    for(Group *g : SK.OrderedGroups()) { g->visible = state; }
 
-        g->visible = state;
-    }
     SS.GW.persistentDirty = true;
 }
 void TextWindow::ScreenActivateGroup(int link, uint32_t v) {
@@ -101,8 +98,7 @@ void TextWindow::ShowListOfGroups() {
     Printf(false, "%Ft    shown dof group-name%E");
     bool afterActive = false;
     bool backgroundParity = false;
-    for(hGroup hg : SK.groupOrder) {
-        Group *g = SK.GetGroup(hg);
+    for(Group *g : SK.OrderedGroups()) {
 
         std::string s = g->DescriptionString();
         bool active = (g->h == SS.GW.activeGroup);

--- a/src/undoredo.cpp
+++ b/src/undoredo.cpp
@@ -97,10 +97,7 @@ void SolveSpaceUI::PopOntoCurrentFrom(UndoStack *uk) {
     UndoState *ut = &(uk->d[uk->write]);
 
     // Free everything in the main copy of the program before replacing it
-    for(hGroup hg : SK.groupOrder) {
-        Group *g = SK.GetGroup(hg);
-        g->Clear();
-    }
+    for(Group *g : SK.OrderedGroups()) { g->Clear(); }
     SK.group.Clear();
     SK.groupOrder.Clear();
     SK.request.Clear();


### PR DESCRIPTION
Simplifies an idiom seen all over the codebase, of iterating
thru groupOrder then using it to look up a group.