### PR TITLE
Add the ability to merge IdLists, and use to banish more non-range-for.

### DIFF
--- a/src/dsc.h
+++ b/src/dsc.h
@@ -420,6 +420,27 @@ public:
         std::inplace_merge(begin(), end() - 1, end(), Compare());
     }
 
+    void MergeInto(IdList *dest) {
+        dest->ReserveMore(n);
+
+        const auto oldEnd = dest->elem + dest->n;
+        auto outIter      = oldEnd;
+
+        for(auto &elt : *this) {
+            // Copy-construct at the end of the list.
+            new(outIter) T(elt);
+            ++outIter;
+        }
+
+        /// @todo Look to see if we already have something with the same handle value.
+
+        dest->n = dest->n + n;
+        Clear();
+
+        // The items we just added are sorted, so merge
+        std::inplace_merge(dest->begin(), oldEnd, dest->end(), Compare());
+    }
+
     T *FindById(H h) {
         T *t = FindByIdNoOops(h);
         ssassert(t != NULL, "Cannot find handle");

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -121,6 +121,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
             break;
     }
 
+    EntityList entityAdditions;
     Entity e = {};
     EntReqTable::GetRequestInfo(type, extraPoints, &et, &points, &hasNormal, &hasDistance);
 
@@ -158,7 +159,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
             p.param[0] = AddParam(param, h.param(16 + 3*i + 0));
             p.param[1] = AddParam(param, h.param(16 + 3*i + 1));
         }
-        entity->Add(&p);
+        entityAdditions.Add(&p);
         e.point[i] = p.h;
     }
     if(hasNormal) {
@@ -183,7 +184,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
         // The point determines where the normal gets displayed on-screen;
         // it's entirely cosmetic.
         n.point[0] = e.point[0];
-        entity->Add(&n);
+        entityAdditions.Add(&n);
         e.normal = n.h;
     }
     if(hasDistance) {
@@ -194,11 +195,13 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
         d.style = style;
         d.type = Entity::Type::DISTANCE;
         d.param[0] = AddParam(param, h.param(64));
-        entity->Add(&d);
+        entityAdditions.Add(&d);
         e.distance = d.h;
     }
 
-    if(et != (Entity::Type)0) entity->Add(&e);
+    if(et != (Entity::Type)0) entityAdditions.Add(&e);
+
+    entityAdditions.MergeInto(entity);
 }
 
 std::string Request::DescriptionString() const {


### PR DESCRIPTION
Eliminates a class of reasons for not using range-for: Adding
during iteration. Instead, just add to a new IdList that you
merge in after iteration is complete.

In general I didn't convert the new types of solids to use this, just because I'm still new at using them so I couldn't tell for sure if it worked right. But, all tests pass.