### PR TITLE
Revert "IdList::RemoveTagged switch to std::remove_if from iteration.…

### DIFF
--- a/src/dsc.h
+++ b/src/dsc.h
@@ -493,22 +493,24 @@ public:
     }
 
     void RemoveTagged() {
-        auto newEnd = std::remove_if(this->begin(), this->end(), [](T &t) {
-            if(t.tag) {
-                t.Clear();
-                return true;
-            }
-            return false;
-        });
-        if(newEnd != this->end()) {
-            while (newEnd != this->end()) {
-                newEnd->~T();
-                ++newEnd;
+        int src, dest;
+        dest = 0;
+        for(src = 0; src < n; src++) {
+            if(elem[src].tag) {
+                // this item should be deleted
+                elem[src].Clear();
+            } else {
+                if(src != dest) {
+                    elem[dest] = elem[src];
+                }
+                dest++;
             }
         }
-        n = newEnd - begin();
+        for(int i = dest; i < n; i++)
+            elem[i].~T();
+        n = dest;
+        // and elemsAllocated is untouched, because we didn't resize
     }
-
     void RemoveById(H h) {
         ClearTags();
         FindById(h)->tag = 1;


### PR DESCRIPTION
… NFC."

This reverts commit 0bb6a348e393f460c0b1bf6ab04b4bae41102688.

Fixes #462 