### PR TITLE
Fix 468

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -566,27 +566,26 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             AddParam(param, h.param(6), axis_dir.z);
 
             int ai = 1;
+            EntityList& ent = *entity;
 
             // Not using range-for here because we're changing the size of entity in the loop.
             for(i = 0; i < entity->n; i++) {
-                Entity *e = &(entity->Get(i));
-                if(e->group != opA)
+                if(ent[i].group != opA)
                     continue;
 
-                e->CalculateNumerical(/*forExport=*/false);
-                hEntity he = e->h;
+                ent[i].CalculateNumerical(/*forExport=*/false);
+                hEntity he = ent[i].h;
 
                 CopyEntity(entity, SK.GetEntity(predef.origin), 0, ai, NO_PARAM, NO_PARAM,
                            NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, CopyAs::NUMERIC);
 
                 for(a = 0; a < 2; a++) {
                     //! @todo is this check redundant?
-                    Entity *e = &(entity->Get(i));
-                    if(e->group != opA)
+                    if(ent[i].group != opA)
                         continue;
 
-                    e->CalculateNumerical(false);
-                    CopyEntity(entity, e, a * 2 - (subtype == Subtype::ONE_SIDED ? 0 : 1),
+                    ent[i].CalculateNumerical(false);
+                    CopyEntity(entity, &(ent[i]), a * 2 - (subtype == Subtype::ONE_SIDED ? 0 : 1),
                            (a == 1) ? REMAP_LATHE_END : REMAP_LATHE_START, h.param(0),
                            h.param(1), h.param(2), h.param(3), h.param(4), h.param(5),
                            h.param(6), NO_PARAM, CopyAs::N_ROT_AA);
@@ -618,33 +617,32 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             AddParam(param, h.param(7), 20);
 
             int ai = 1;
+            EntityList& ent = *entity;
 
             // Not using range-for here because we're changing the size of entity in the loop.
             for(i = 0; i < entity->n; i++) {
-                Entity *e = &(entity->Get(i));
-                if(e->group.v != opA.v)
+                if(ent[i].group.v != opA.v)
                     continue;
 
-                e->CalculateNumerical(/*forExport=*/false);
+                ent[i].CalculateNumerical(/*forExport=*/false);
 
                 CopyEntity(entity, SK.GetEntity(predef.origin), 0, ai, NO_PARAM, NO_PARAM,
                            NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, CopyAs::NUMERIC);
 
                 for(a = 0; a < 2; a++) {
                     Entity *e = &(entity->Get(i));
-                    e->CalculateNumerical(false);
-                    CopyEntity(entity, e, a * 2 - (subtype == Subtype::ONE_SIDED ? 0 : 1),
+                    ent[i].CalculateNumerical(false);
+                    CopyEntity(entity, &(ent[i]), a * 2 - (subtype == Subtype::ONE_SIDED ? 0 : 1),
                                (a == 1) ? REMAP_LATHE_END : REMAP_LATHE_START, h.param(0),
                                h.param(1), h.param(2), h.param(3), h.param(4), h.param(5),
                                h.param(6), h.param(7), CopyAs::N_ROT_AXIS_TRANS);
                 }
                 // For point entities on the axis, create a construction line
-                e = &(entity->Get(i));
-                if(e->IsPoint()) {
-                    Vector check = e->PointGetNum().Minus(axis_pos).Cross(axis_dir);
+                if(ent[i].IsPoint()) {
+                    Vector check = ent[i].PointGetNum().Minus(axis_pos).Cross(axis_dir);
                     if (check.Dot(check) < LENGTH_EPS) {
                         //! @todo isn't this the same as &(ent[i])?
-                        Entity *ep = SK.GetEntity(e->h);
+                        Entity *ep = SK.GetEntity(ent[i].h);
                         Entity en = {};
                         // A point gets extruded to form a line segment
                         en.point[0] = Remap(ep->h, REMAP_LATHE_START);

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -568,7 +568,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             int ai = 1;
 
             for(i = 0; i < entity->n; i++) {
-                Entity *e = &((*entity)[i]);
+                Entity *e = &(entity->Get(i));
                 if(e->group != opA)
                     continue;
 
@@ -579,6 +579,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                            NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, CopyAs::NUMERIC);
 
                 for(a = 0; a < 2; a++) {
+                    Entity *e = &(entity->Get(i));
                     if(e->group != opA)
                         continue;
 
@@ -627,13 +628,15 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                            NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, CopyAs::NUMERIC);
 
                 for(a = 0; a < 2; a++) {
+                    Entity *e = &(entity->Get(i));
                     e->CalculateNumerical(false);
-		    CopyEntity(entity, e, a * 2 - (subtype == Subtype::ONE_SIDED ? 0 : 1),
-                           (a == 1) ? REMAP_LATHE_END : REMAP_LATHE_START, h.param(0),
-                           h.param(1), h.param(2), h.param(3), h.param(4), h.param(5),
-                           h.param(6), h.param(7), CopyAs::N_ROT_AXIS_TRANS);
+                    CopyEntity(entity, e, a * 2 - (subtype == Subtype::ONE_SIDED ? 0 : 1),
+                               (a == 1) ? REMAP_LATHE_END : REMAP_LATHE_START, h.param(0),
+                               h.param(1), h.param(2), h.param(3), h.param(4), h.param(5),
+                               h.param(6), h.param(7), CopyAs::N_ROT_AXIS_TRANS);
                 }
                 // For point entities on the axis, create a construction line
+                e = &(entity->Get(i));
                 if(e->IsPoint()) {
                     Vector check = e->PointGetNum().Minus(axis_pos).Cross(axis_dir);
                     if (check.Dot(check) < LENGTH_EPS) {
@@ -649,7 +652,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                         en.type = Entity::Type::LINE_SEGMENT;
                         entity->Add(&en);
                     }
-		}
+                }
                 ai++;
             }
             return;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -567,6 +567,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
 
             int ai = 1;
 
+            // Not using range-for here because we're changing the size of entity in the loop.
             for(i = 0; i < entity->n; i++) {
                 Entity *e = &(entity->Get(i));
                 if(e->group != opA)
@@ -579,6 +580,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                            NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM, CopyAs::NUMERIC);
 
                 for(a = 0; a < 2; a++) {
+                    //! @todo is this check redundant?
                     Entity *e = &(entity->Get(i));
                     if(e->group != opA)
                         continue;
@@ -617,6 +619,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
 
             int ai = 1;
 
+            // Not using range-for here because we're changing the size of entity in the loop.
             for(i = 0; i < entity->n; i++) {
                 Entity *e = &(entity->Get(i));
                 if(e->group.v != opA.v)
@@ -640,6 +643,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                 if(e->IsPoint()) {
                     Vector check = e->PointGetNum().Minus(axis_pos).Cross(axis_dir);
                     if (check.Dot(check) < LENGTH_EPS) {
+                        //! @todo isn't this the same as &(ent[i])?
                         Entity *ep = SK.GetEntity(e->h);
                         Entity en = {};
                         // A point gets extruded to form a line segment


### PR DESCRIPTION
Fixes #468 by removing use of pointers after an invalidation-causing action (CopyEntity).

I briefly reviewed the other code in this massive switch, and the rest (besides helix and revolve) appears to be safe: there are a few other places where the address of a list element is taken, but it's either done in the tightest loop and not used after the invalidation, and/or something like `hEntity he = e->h; e = NULL;` is done, where then `SK.GetEntity(he)` is used after in place of `e`.  This seems sufficient, if a bit overkill: it's putting in a log(n) lookup by handle where there's already a good-enough index available (good enough that it's being used to control iteration, anyway.)

The last commit here is a matter of style preference: can't use an invalidated pointer if you don't take one in the first place. :) Take or leave, no worries.

The middle commit highlights some things I got confused about when reading the code, as well as adds the comments that got missed due to the feature being in-flight when I added them.