### PR TITLE
Fix CLI/Testsuite crash on assert

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -143,7 +143,17 @@ static void MessageBox(const char *fmt, va_list va, bool error,
     description = description.substr(it - description.begin());
 
     Platform::MessageDialogRef dialog = CreateMessageDialog(SS.GW.window);
-
+    if (!dialog) {
+        if (error) {
+            fprintf(stderr, "Error: %s\n", message.c_str());
+        } else {
+            fprintf(stderr, "Message: %s\n", message.c_str());
+        }
+        if(onDismiss) {
+            onDismiss();
+        }
+        return;
+    }
     using Platform::MessageDialog;
     if(error) {
         dialog->SetType(MessageDialog::Type::ERROR);


### PR DESCRIPTION
If an assert triggered in the test suite, it would segfault. This trivially avoids that, letting it do the normal assert things.