### PR TITLE
Fix warning about destructor

### DIFF
--- a/src/render/render.h
+++ b/src/render/render.h
@@ -360,7 +360,7 @@ public:
     void OutputEnd() override;
 };
 
-class CairoPixmapRenderer : public CairoRenderer {
+class CairoPixmapRenderer final : public CairoRenderer {
 public:
     std::shared_ptr<Pixmap>  pixmap;
 


### PR DESCRIPTION
It was griping in shared_ptr code about there being virtual functions without a virtual destructor and creating a non-final class. Easiest way to fix it was to make this a final class.