### PR TITLE
Simplify UNION and DIFFERENCE boolean operations.

### DIFF
--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -195,7 +195,6 @@ static bool KeepRegion(SSurface::CombineAs type, bool opA, SShell::Class shell, 
     bool inShell = (shell == SShell::Class::INSIDE),
          outSide = (shell == SShell::Class::OUTSIDE),
          inSame  = (shell == SShell::Class::COINC_SAME),
-//         inOpp   = (shell == SShell::Class::COINC_OPP),
          inOrig  = (orig == SShell::Class::INSIDE);
 
     if(!inOrig) return false;

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -193,28 +193,25 @@ void SSurface::TrimFromEdgeList(SEdgeList *el, bool asUv) {
 static bool KeepRegion(SSurface::CombineAs type, bool opA, SShell::Class shell, SShell::Class orig)
 {
     bool inShell = (shell == SShell::Class::INSIDE),
+         outSide = (shell == SShell::Class::OUTSIDE),
          inSame  = (shell == SShell::Class::COINC_SAME),
-         inOpp   = (shell == SShell::Class::COINC_OPP),
+//         inOpp   = (shell == SShell::Class::COINC_OPP),
          inOrig  = (orig == SShell::Class::INSIDE);
 
-    bool inFace = inSame || inOpp;
-
-    // If these are correct, then they should be independent of inShell
-    // if inFace is true.
     if(!inOrig) return false;
     switch(type) {
         case SSurface::CombineAs::UNION:
             if(opA) {
-                return (!inShell && !inFace);
+                return outSide;
             } else {
-                return (!inShell && !inFace) || inSame;
+                return outSide || inSame;
             }
 
         case SSurface::CombineAs::DIFFERENCE:
             if(opA) {
-                return (!inShell && !inFace);
+                return outSide;
             } else {
-                return (inShell && !inFace) || inSame;
+                return inShell || inSame;
             }
 
         default: ssassert(false, "Unexpected combine type");


### PR DESCRIPTION
Union and difference are optimized by replacing the expression
  `(!inShell && !inFace)`
which is equivqlent to
  `(!inShell && !inSame && !inOpp)`
with
  `outSide`
which is qeuivalent, since `SShell::Class::OUTSIDE` is the only remaining possibility.