### PR TITLE
Got the basic tool -> select workflow working (#121)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,3 +329,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebI
 else()
     message(STATUS "Benchmarking disabled in debug builds.")
 endif()
+
+# Dump project structure for static analysis
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ set(libslvs_SOURCES
     util.cpp
     entity.cpp
     expr.cpp
-    constraint.cpp
+    constraintdesc.cpp
     constrainteq.cpp
     system.cpp
     platform/platform.cpp)
@@ -61,7 +61,9 @@ add_library(slvs SHARED
     lib.cpp)
 
 target_compile_definitions(slvs
-    PRIVATE -DLIBRARY)
+    PRIVATE
+        -DLIBRARY
+        )
 
 target_include_directories(slvs
     PUBLIC ${CMAKE_SOURCE_DIR}/include)
@@ -168,6 +170,7 @@ set(solvespace_core_SOURCES
     clipboard.cpp
     confscreen.cpp
     constraint.cpp
+    constraintdesc.cpp
     constrainteq.cpp
     describescreen.cpp
     draw.cpp
@@ -211,7 +214,7 @@ set(solvespace_core_SOURCES
     srf/raycast.cpp
     srf/surface.cpp
     srf/surfinter.cpp
-    srf/triangulate.cpp)
+    srf/triangulate.cpp constraintmenu.h constraintmenu.cpp)
 
 set(solvespace_core_gl_SOURCES
     solvespace.cpp)

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -6,52 +6,6 @@
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
 
-std::string Constraint::DescriptionString() const {
-    std::string s;
-    switch(type) {
-        case Type::POINTS_COINCIDENT:   s = C_("constr-name", "pts-coincident"); break;
-        case Type::PT_PT_DISTANCE:      s = C_("constr-name", "pt-pt-distance"); break;
-        case Type::PT_LINE_DISTANCE:    s = C_("constr-name", "pt-line-distance"); break;
-        case Type::PT_PLANE_DISTANCE:   s = C_("constr-name", "pt-plane-distance"); break;
-        case Type::PT_FACE_DISTANCE:    s = C_("constr-name", "pt-face-distance"); break;
-        case Type::PROJ_PT_DISTANCE:    s = C_("constr-name", "proj-pt-pt-distance"); break;
-        case Type::PT_IN_PLANE:         s = C_("constr-name", "pt-in-plane"); break;
-        case Type::PT_ON_LINE:          s = C_("constr-name", "pt-on-line"); break;
-        case Type::PT_ON_FACE:          s = C_("constr-name", "pt-on-face"); break;
-        case Type::EQUAL_LENGTH_LINES:  s = C_("constr-name", "eq-length"); break;
-        case Type::EQ_LEN_PT_LINE_D:    s = C_("constr-name", "eq-length-and-pt-ln-dist"); break;
-        case Type::EQ_PT_LN_DISTANCES:  s = C_("constr-name", "eq-pt-line-distances"); break;
-        case Type::LENGTH_RATIO:        s = C_("constr-name", "length-ratio"); break;
-        case Type::LENGTH_DIFFERENCE:   s = C_("constr-name", "length-difference"); break;
-        case Type::SYMMETRIC:           s = C_("constr-name", "symmetric"); break;
-        case Type::SYMMETRIC_HORIZ:     s = C_("constr-name", "symmetric-h"); break;
-        case Type::SYMMETRIC_VERT:      s = C_("constr-name", "symmetric-v"); break;
-        case Type::SYMMETRIC_LINE:      s = C_("constr-name", "symmetric-line"); break;
-        case Type::AT_MIDPOINT:         s = C_("constr-name", "at-midpoint"); break;
-        case Type::HORIZONTAL:          s = C_("constr-name", "horizontal"); break;
-        case Type::VERTICAL:            s = C_("constr-name", "vertical"); break;
-        case Type::DIAMETER:            s = C_("constr-name", "diameter"); break;
-        case Type::PT_ON_CIRCLE:        s = C_("constr-name", "pt-on-circle"); break;
-        case Type::SAME_ORIENTATION:    s = C_("constr-name", "same-orientation"); break;
-        case Type::ANGLE:               s = C_("constr-name", "angle"); break;
-        case Type::PARALLEL:            s = C_("constr-name", "parallel"); break;
-        case Type::ARC_LINE_TANGENT:    s = C_("constr-name", "arc-line-tangent"); break;
-        case Type::CUBIC_LINE_TANGENT:  s = C_("constr-name", "cubic-line-tangent"); break;
-        case Type::CURVE_CURVE_TANGENT: s = C_("constr-name", "curve-curve-tangent"); break;
-        case Type::PERPENDICULAR:       s = C_("constr-name", "perpendicular"); break;
-        case Type::EQUAL_RADIUS:        s = C_("constr-name", "eq-radius"); break;
-        case Type::EQUAL_ANGLE:         s = C_("constr-name", "eq-angle"); break;
-        case Type::EQUAL_LINE_ARC_LEN:  s = C_("constr-name", "eq-line-len-arc-len"); break;
-        case Type::WHERE_DRAGGED:       s = C_("constr-name", "lock-where-dragged"); break;
-        case Type::COMMENT:             s = C_("constr-name", "comment"); break;
-        default:                        s = "???"; break;
-    }
-
-    return ssprintf("c%03x-%s", h.v, s.c_str());
-}
-
-#ifndef LIBRARY
-
 //-----------------------------------------------------------------------------
 // Delete all constraints with the specified type, entityA, ptA. We use this
 // when auto-removing constraints that would become redundant.
@@ -231,6 +185,11 @@ void Constraint::MenuConstrain(Command id) {
                 return;
             }
             AddConstraint(&c);
+            break;
+
+        case Command::SELECT_ON:
+            SS.GW.selectionCommand = Command::SELECT_ON;
+            return;  // Return instantly so selection is not cleared further down this function.
             break;
 
         case Command::EQUAL:
@@ -765,5 +724,3 @@ void Constraint::MenuConstrain(Command id) {
 
     SS.GW.ClearSelection();
 }
-
-#endif /* ! LIBRARY */

--- a/src/constraintdesc.cpp
+++ b/src/constraintdesc.cpp
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------------
+// Implementation of the Constraint menu, to create new constraints in
+// the sketch.
+//
+// Copyright 2008-2013 Jonathan Westhues.
+//-----------------------------------------------------------------------------
+#include "solvespace.h"
+
+std::string Constraint::DescriptionString() const {
+    std::string s;
+    switch(type) {
+        case Type::POINTS_COINCIDENT:   s = C_("constr-name", "pts-coincident"); break;
+        case Type::PT_PT_DISTANCE:      s = C_("constr-name", "pt-pt-distance"); break;
+        case Type::PT_LINE_DISTANCE:    s = C_("constr-name", "pt-line-distance"); break;
+        case Type::PT_PLANE_DISTANCE:   s = C_("constr-name", "pt-plane-distance"); break;
+        case Type::PT_FACE_DISTANCE:    s = C_("constr-name", "pt-face-distance"); break;
+        case Type::PROJ_PT_DISTANCE:    s = C_("constr-name", "proj-pt-pt-distance"); break;
+        case Type::PT_IN_PLANE:         s = C_("constr-name", "pt-in-plane"); break;
+        case Type::PT_ON_LINE:          s = C_("constr-name", "pt-on-line"); break;
+        case Type::PT_ON_FACE:          s = C_("constr-name", "pt-on-face"); break;
+        case Type::EQUAL_LENGTH_LINES:  s = C_("constr-name", "eq-length"); break;
+        case Type::EQ_LEN_PT_LINE_D:    s = C_("constr-name", "eq-length-and-pt-ln-dist"); break;
+        case Type::EQ_PT_LN_DISTANCES:  s = C_("constr-name", "eq-pt-line-distances"); break;
+        case Type::LENGTH_RATIO:        s = C_("constr-name", "length-ratio"); break;
+        case Type::LENGTH_DIFFERENCE:   s = C_("constr-name", "length-difference"); break;
+        case Type::SYMMETRIC:           s = C_("constr-name", "symmetric"); break;
+        case Type::SYMMETRIC_HORIZ:     s = C_("constr-name", "symmetric-h"); break;
+        case Type::SYMMETRIC_VERT:      s = C_("constr-name", "symmetric-v"); break;
+        case Type::SYMMETRIC_LINE:      s = C_("constr-name", "symmetric-line"); break;
+        case Type::AT_MIDPOINT:         s = C_("constr-name", "at-midpoint"); break;
+        case Type::HORIZONTAL:          s = C_("constr-name", "horizontal"); break;
+        case Type::VERTICAL:            s = C_("constr-name", "vertical"); break;
+        case Type::DIAMETER:            s = C_("constr-name", "diameter"); break;
+        case Type::PT_ON_CIRCLE:        s = C_("constr-name", "pt-on-circle"); break;
+        case Type::SAME_ORIENTATION:    s = C_("constr-name", "same-orientation"); break;
+        case Type::ANGLE:               s = C_("constr-name", "angle"); break;
+        case Type::PARALLEL:            s = C_("constr-name", "parallel"); break;
+        case Type::ARC_LINE_TANGENT:    s = C_("constr-name", "arc-line-tangent"); break;
+        case Type::CUBIC_LINE_TANGENT:  s = C_("constr-name", "cubic-line-tangent"); break;
+        case Type::CURVE_CURVE_TANGENT: s = C_("constr-name", "curve-curve-tangent"); break;
+        case Type::PERPENDICULAR:       s = C_("constr-name", "perpendicular"); break;
+        case Type::EQUAL_RADIUS:        s = C_("constr-name", "eq-radius"); break;
+        case Type::EQUAL_ANGLE:         s = C_("constr-name", "eq-angle"); break;
+        case Type::EQUAL_LINE_ARC_LEN:  s = C_("constr-name", "eq-line-len-arc-len"); break;
+        case Type::WHERE_DRAGGED:       s = C_("constr-name", "lock-where-dragged"); break;
+        case Type::COMMENT:             s = C_("constr-name", "comment"); break;
+        default:                        s = "???"; break;
+    }
+
+    return ssprintf("c%03x-%s", h.v, s.c_str());
+}
+

--- a/src/constraintmenu.cpp
+++ b/src/constraintmenu.cpp
@@ -1,0 +1,159 @@
+//
+// Created by benjamin on 10/3/19.
+//
+
+#include "solvespace.h"
+
+#include <vector>
+#include "ui.h"
+#include "constraintmenu.h"
+
+
+struct ConstraintConditions {
+    Command command;
+    GraphicsWindow::GroupSelections valid_selection;  // TODO: make this some kind of iterable
+    // TODO: add the applying logic in here
+};
+// static initialization should zero anything that we don't declare.
+static ConstraintConditions Conditions[] = {
+    {Command::SELECT_ON, {.points = 2, .n = 2}}
+};
+
+
+std::vector<GraphicsWindow::GroupSelections> getConditions(Command command) {
+
+    std::vector<GraphicsWindow::GroupSelections> conditions;
+    for(const auto condition: Conditions){
+        if(condition.command == command) {
+            conditions.push_back(condition.valid_selection);
+        }
+    }
+
+    return conditions;
+}
+
+bool selectCountEqual(const GraphicsWindow::GroupSelections a, const GraphicsWindow::GroupSelections b) {
+    return a.points == b.points &&
+            a.entities == b.entities &&
+            a.workplanes == b.workplanes &&
+            a.faces == b.faces &&
+            a.lineSegments == b.lineSegments &&
+            a.circlesOrArcs == b.circlesOrArcs &&
+            a.arcs == b.arcs &&
+            a.cubics == b.cubics &&
+            a.periodicCubics == b.periodicCubics &&
+            a.anyNormals == b.anyNormals &&
+            a.vectors == b.vectors &&
+            a.constraints == b.constraints &&
+            a.stylables == b.stylables &&
+            a.constraintLabels == b.constraintLabels &&
+            a.withEndpoints == b.withEndpoints &&
+            a.n == b.n;
+}
+
+bool selectCountGreater(const GraphicsWindow::GroupSelections a, const GraphicsWindow::GroupSelections b) {
+    return a.points >= b.points &&
+           a.entities >= b.entities &&
+           a.workplanes >= b.workplanes &&
+           a.faces >= b.faces &&
+           a.lineSegments >= b.lineSegments &&
+           a.circlesOrArcs >= b.circlesOrArcs &&
+           a.arcs >= b.arcs &&
+           a.cubics >= b.cubics &&
+           a.periodicCubics >= b.periodicCubics &&
+           a.anyNormals >= b.anyNormals &&
+           a.vectors >= b.vectors &&
+           a.constraints >= b.constraints &&
+           a.stylables >= b.stylables &&
+           a.constraintLabels >= b.constraintLabels &&
+           a.withEndpoints >= b.withEndpoints &&
+           a.n >= b.n;
+}
+
+/**
+ * A selection for a command is complete if the selection has the exact number of components that
+ * the command might desire.
+ */
+bool TestSelectionComplete(Command command, const GraphicsWindow::GroupSelections toTest) {
+    // get the command's target selections
+    auto conditions = getConditions(command);
+    // if any of the target selections have all the same counts as the selection to test, return true
+    for(auto condition: conditions) {
+        if (selectCountEqual(condition, toTest)){
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+/**
+ * A selection for a command can possibly be valid if the selection has less items selected than
+ * a command might desire.
+ */
+bool TestSelectionPossiblyValid(Command command, const GraphicsWindow::GroupSelections toTest) {
+    // get the command's target selections
+    auto conditions = getConditions(command);
+    // if any of the target selections have more counts than the selection to test, return true
+    for(auto condition: conditions) {
+        if (selectCountGreater(condition, toTest)){
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// TODO: Make this unique for each command/condition
+bool ApplyCommandToSelection(Command command, const GraphicsWindow::GroupSelections selection) {
+
+    Constraint c = {};
+    c.group = SS.GW.activeGroup;
+    c.workplane = SS.GW.ActiveWorkplane();
+    bool constraintValid = true;
+    if(selection.points == 2 && selection.n == 2) {
+        c.type = SolveSpace::Constraint::Type::POINTS_COINCIDENT;
+        c.ptA = selection.point[0];
+        c.ptB = selection.point[1];
+    } else {
+        // set to false in else so if there are multiple, you only set it in a single place and
+        // don't have to copy it.
+        constraintValid = false;
+    }
+
+    if(constraintValid) {
+        SolveSpace::Constraint::AddConstraint(&c);
+    }
+    return constraintValid;
+}
+
+bool doCommandSelectionTest(Command command) {
+    SS.GW.GroupSelection();
+    auto const &gs = SS.GW.gs;
+
+    // do we still have the chance to fulfill a valid selection?
+    bool valid = TestSelectionPossiblyValid(command, gs);
+    // do we fulfill any of the possible ones?
+    bool fulfills = TestSelectionComplete(command, gs);
+    bool success = false;
+    if(fulfills) {
+        // if we do, then does it meet the extra requirements?
+        success = ApplyCommandToSelection(command, gs);
+        if(!success) {
+            // TODO: should this be a real error, or should we continue?
+            printf("Could not apply constraint to selection\n");
+        }
+    }
+    if(!valid) {
+        // TODO display real error here - look it up from a table?
+        Error("Ya done goofed");
+    }
+    // If we are finished handling the selection (whether due to success or failure), clear
+    // the current command and selection.
+    if(!valid || success){
+        SS.GW.selectionCommand = Command::NONE;
+        SS.GW.ClearSelection();
+    }
+}
+
+

--- a/src/constraintmenu.h
+++ b/src/constraintmenu.h
@@ -1,0 +1,16 @@
+//
+// Created by benjamin on 10/3/19.
+//
+
+#ifndef SOLVESPACE_CONSTRAINTMENU_H
+#define SOLVESPACE_CONSTRAINTMENU_H
+
+#include "solvespace.h"
+#include "ui.h"
+
+bool TestSelectionComplete(Command command, GraphicsWindow::GroupSelections toTest);
+bool TestSelectionPossiblyValid(Command command, GraphicsWindow::GroupSelections toTest);
+bool ApplyCommandToSelection(Command command, const GraphicsWindow::GroupSelections selection);
+bool doCommandSelectionTest(Command command);
+
+#endif //SOLVESPACE_CONSTRAINTMENU_H

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -6,6 +6,7 @@
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
+#include "constraintmenu.h"
 
 bool GraphicsWindow::Selection::Equals(Selection *b) {
     if(entity     != b->entity)     return false;
@@ -200,6 +201,11 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
     }
 
     selection.Add(stog);
+
+    // TODO: insert command selection handler
+    if(selectionCommand != Command::NONE) {
+        doCommandSelectionTest(selectionCommand);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -140,6 +140,7 @@ const MenuEntry Menu[] = {
 { 1, N_("Reference An&gle"),            Command::REF_ANGLE,        S|'n',   KN, mCon   },
 { 1, N_("Other S&upplementary Angle"),  Command::OTHER_ANGLE,      'u',     KN, mCon   },
 { 1, N_("Toggle R&eference Dim"),       Command::REFERENCE,        'e',     KN, mCon   },
+{ 1, N_("Constrain Coincident Point by selection"),       Command::SELECT_ON,        'e',     KN, mCon   },
 { 1, NULL,                              Command::NONE,             0,       KN, NULL   },
 { 1, N_("&Horizontal"),                 Command::HORIZONTAL,       'h',     KN, mCon   },
 { 1, N_("&Vertical"),                   Command::VERTICAL,         'v',     KN, mCon   },
@@ -402,6 +403,7 @@ void GraphicsWindow::Init() {
     showSnapGrid = false;
     context.active = false;
     toolbarHovered = Command::NONE;
+    selectionCommand = Command::NONE;
 
     if(!window) {
         window = Platform::CreateWindow();

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -781,6 +781,7 @@ public:
     static hConstraint TryConstrain(Constraint::Type type, hEntity ptA, hEntity ptB,
                                     hEntity entityA, hEntity entityB = Entity::NO_ENTITY,
                                     bool other = false, bool other2 = false);
+
 };
 
 class hEquation {

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -30,6 +30,9 @@
 #include <unordered_set>
 #include <vector>
 
+// For development in CLion
+//#undef LIBRARY
+
 // We declare these in advance instead of simply using FT_Library
 // (defined as typedef FT_LibraryRec_* FT_Library) because including
 // freetype.h invokes indescribable horrors and we would like to avoid

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -62,6 +62,10 @@ static ToolIcon Toolbar[] = {
       N_("Other supplementary angle"),                        {} },
     { "ref",             Command::REFERENCE,
       N_("Toggle reference dimension"),                       {} },
+
+    { "ref",             Command::SELECT_ON,
+      N_("Constrain Coincident Point by selection"),                       {} },
+
     { "",                Command::NONE, "",                   {} },
 
     { "extrude",         Command::GROUP_EXTRUDE,

--- a/src/ui.h
+++ b/src/ui.h
@@ -8,6 +8,9 @@
 #ifndef SOLVESPACE_UI_H
 #define SOLVESPACE_UI_H
 
+#include <stdint.h>
+#include <string>
+
 class Locale {
 public:
     std::string language;
@@ -36,6 +39,7 @@ const std::string &Translate(const char *msgctxt, const char *msgid);
 const std::string &TranslatePlural(const char *msgid, unsigned n);
 const std::string &TranslatePlural(const char *msgctxt, const char *msgid, unsigned n);
 
+// Translation support
 inline const char *N_(const char *msgid) {
     return msgid;
 }
@@ -152,6 +156,7 @@ enum class Command : uint32_t {
     ORIENTED_SAME,
     WHERE_DRAGGED,
     COMMENT,
+    SELECT_ON,
     // Analyze
     VOLUME,
     AREA,
@@ -720,13 +725,15 @@ public:
     bool hoverWasSelectedOnMousedown;
     List<Selection> selection;
 
+    Command selectionCommand;
+
     Selection ChooseFromHoverToSelect();
     Selection ChooseFromHoverToDrag();
     void HitTestMakeSelection(Point2d mp);
     void ClearSelection();
     void ClearNonexistentSelectionItems();
     /// This structure is filled by a call to GroupSelection().
-    struct {
+    struct GroupSelections {
         std::vector<hEntity>     point;
         std::vector<hEntity>     entity;
         std::vector<hEntity>     anyNormal;


### PR DESCRIPTION
As a first stab at #121, I've implemented a prototype of the tool -> select workflow. I'm uploading it now for feedback, even though just the one command works. I duplicated the reference button, then changed that duplicate to set a command flag in the graphics window, then wait for a valid selection. When that occurs, I attempt to create the constraint. I have only implemented the 2 points coincident at the moment, because I'm sure I'm doing something wrong and want some feedback before I do anything else. I'm not too sure about the naming, or how to display what the currently selected command is, or how to use a key binding, or if I'm even approaching this problem the right way.

I also broke out the part of constraint.cpp that wasn't `#ifdef LIBRARY` guarded into its own file; the guards made my IDE (CLion) really confused. 

Things I Need to add:
- display of current selection command
- clear current selection command on esc
- the rest of the commands (only works on 2 points coincident)
- add confirm with enter (if desired, it was in the original issue)
- clean up leftover dev detritus, like commented out stuff and the cmakelists files