### PR TITLE
Skip temporary copying to framebuffer.

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -225,9 +225,9 @@ public:
 
         NSUInteger modifierMask = 0;
         if(accel.shiftDown)
-            modifierMask |= NSShiftKeyMask;
+            modifierMask |= NSEventModifierFlagShift;
         if(accel.controlDown)
-            modifierMask |= NSCommandKeyMask;
+            modifierMask |= NSEventModifierFlagCommand;
         nsMenuItem.keyEquivalentModifierMask = modifierMask;
     }
 
@@ -236,7 +236,7 @@ public:
     }
 
     void SetActive(bool active) override {
-        nsMenuItem.state = active ? NSOnState : NSOffState;
+        nsMenuItem.state = active ? NSControlStateValueOn : NSControlStateValueOff;
     }
 
     void SetEnabled(bool enabled) override {
@@ -344,7 +344,7 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 // Cocoa NSView and NSWindow extensions
 //-----------------------------------------------------------------------------
 
-@interface SSView : NSView
+@interface SSView : NSOpenGLView
 @property Platform::Window *receiver;
 
 @property BOOL acceptsFirstResponder;
@@ -362,8 +362,6 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 
 @implementation SSView
 {
-    GlOffscreen         offscreen;
-    NSOpenGLContext    *glContext;
     NSTrackingArea     *trackingArea;
     NSTextField        *editor;
 }
@@ -371,17 +369,14 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 @synthesize acceptsFirstResponder;
 
 - (id)initWithFrame:(NSRect)frameRect {
-    if(self = [super initWithFrame:frameRect]) {
+    NSOpenGLPixelFormatAttribute attrs[] = {
+        NSOpenGLPFAColorSize, 24,
+        NSOpenGLPFADepthSize, 24,
+        0
+    };
+    NSOpenGLPixelFormat *pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
+    if(self = [super initWithFrame:frameRect pixelFormat:pixelFormat]) {
         self.wantsLayer = YES;
-
-        NSOpenGLPixelFormatAttribute attrs[] = {
-            NSOpenGLPFAColorSize, 24,
-            NSOpenGLPFADepthSize, 24,
-            0
-        };
-        NSOpenGLPixelFormat *pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
-        glContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:NULL];
-
         editor = [[NSTextField alloc] init];
         editor.editable = YES;
         [[editor cell] setWraps:NO];
@@ -394,7 +389,6 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 }
 
 - (void)dealloc {
-    offscreen.Clear();
 }
 
 - (BOOL)isFlipped {
@@ -404,29 +398,11 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 @synthesize receiver;
 
 - (void)drawRect:(NSRect)aRect {
-    [glContext makeCurrentContext];
-
-    NSSize size   = [self convertSizeToBacking:self.bounds.size];
-    int    width  = (int)size.width,
-           height = (int)size.height;
-    offscreen.Render(width, height, [&] {
-        if(receiver->onRender) {
-            receiver->onRender();
-        }
-    });
-
-    CGDataProviderRef provider = CGDataProviderCreateWithData(
-        NULL, &offscreen.data[0], width * height * 4, NULL);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
-    CGImageRef image = CGImageCreate(width, height, 8, 32,
-        width * 4, colorspace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst,
-        provider, NULL, true, kCGRenderingIntentDefault);
-
-    CGContextDrawImage((CGContextRef) [[NSGraphicsContext currentContext] graphicsPort],
-                       [self bounds], image);
-
-    CGImageRelease(image);
-    CGDataProviderRelease(provider);
+    [[self openGLContext] makeCurrentContext];
+    if(receiver->onRender) {
+        receiver->onRender();
+    }
+    [[self openGLContext] flushBuffer];
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)event {
@@ -453,8 +429,8 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
     event.y = self.bounds.size.height - nsPoint.y;
 
     NSUInteger nsFlags = [nsEvent modifierFlags];
-    if(nsFlags & NSShiftKeyMask)   event.shiftDown   = true;
-    if(nsFlags & NSCommandKeyMask) event.controlDown = true;
+    if(nsFlags & NSEventModifierFlagShift)   event.shiftDown   = true;
+    if(nsFlags & NSEventModifierFlagCommand) event.controlDown = true;
 
     return event;
 }
@@ -587,9 +563,9 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
     KeyboardEvent event = {};
 
     NSUInteger nsFlags = [nsEvent modifierFlags];
-    if(nsFlags & NSShiftKeyMask)
+    if(nsFlags & NSEventModifierFlagShift)
         event.shiftDown = true;
-    if(nsFlags & NSCommandKeyMask)
+    if(nsFlags & NSEventModifierFlagCommand)
         event.controlDown = true;
 
     unichar chr = 0;
@@ -610,7 +586,7 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 - (void)keyDown:(NSEvent *)nsEvent {
     using Platform::KeyboardEvent;
 
-    if([NSEvent modifierFlags] & ~(NSShiftKeyMask|NSCommandKeyMask)) {
+    if([NSEvent modifierFlags] & ~(NSEventModifierFlagShift|NSEventModifierFlagCommand)) {
         [super keyDown:nsEvent];
         return;
     }
@@ -629,7 +605,7 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 - (void)keyUp:(NSEvent *)nsEvent {
     using Platform::KeyboardEvent;
 
-    if([NSEvent modifierFlags] & ~(NSShiftKeyMask|NSCommandKeyMask)) {
+    if([NSEvent modifierFlags] & ~(NSEventModifierFlagShift|NSEventModifierFlagCommand)) {
         [super keyUp:nsEvent];
         return;
     }
@@ -811,16 +787,16 @@ public:
         switch(kind) {
             case Window::Kind::TOPLEVEL:
                 nsWindow = [[NSWindow alloc] init];
-                nsWindow.styleMask = NSTitledWindowMask | NSResizableWindowMask |
-                                     NSClosableWindowMask | NSMiniaturizableWindowMask;
+                nsWindow.styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable |
+                                     NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
                 nsWindow.collectionBehavior = NSWindowCollectionBehaviorFullScreenPrimary;
                 ssView.acceptsFirstResponder = YES;
                 break;
 
             case Window::Kind::TOOL:
                 NSPanel *nsPanel = [[NSPanel alloc] init];
-                nsPanel.styleMask = NSTitledWindowMask | NSResizableWindowMask |
-                                    NSClosableWindowMask | NSUtilityWindowMask;
+                nsPanel.styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable |
+                                    NSWindowStyleMaskClosable | NSWindowStyleMaskUtilityWindow;
                 [nsPanel standardWindowButton:NSWindowMiniaturizeButton].hidden = YES;
                 [nsPanel standardWindowButton:NSWindowZoomButton].hidden = YES;
                 nsPanel.floatingPanel = YES;
@@ -1128,17 +1104,17 @@ void Open3DConnexion() {
     connexionClient = registerConnexionClient(connexionSignature, connexionName,
             kConnexionClientModeTakeOver, kConnexionMaskButtons | kConnexionMaskAxis);
 
-    [NSEvent addLocalMonitorForEventsMatchingMask:(NSKeyDownMask | NSFlagsChangedMask)
+    [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskKeyDown | NSEventMaskFlagsChanged)
                                           handler:^(NSEvent *event) {
-        connexionShiftIsDown = (event.modifierFlags & NSShiftKeyMask);
-        connexionCommandIsDown = (event.modifierFlags & NSCommandKeyMask);
+        connexionShiftIsDown = (event.modifierFlags & NSEventModifierFlagShift);
+        connexionCommandIsDown = (event.modifierFlags & NSEventModifierFlagCommand);
         return event;
     }];
 
-    [NSEvent addLocalMonitorForEventsMatchingMask:(NSKeyUpMask | NSFlagsChangedMask)
+    [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskKeyUp | NSEventMaskFlagsChanged)
                                           handler:^(NSEvent *event) {
-        connexionShiftIsDown = (event.modifierFlags & NSShiftKeyMask);
-        connexionCommandIsDown = (event.modifierFlags & NSCommandKeyMask);
+        connexionShiftIsDown = (event.modifierFlags & NSEventModifierFlagShift);
+        connexionCommandIsDown = (event.modifierFlags & NSEventModifierFlagCommand);
         return event;
     }];
 }
@@ -1173,12 +1149,12 @@ public:
         switch(type) {
             case Type::INFORMATION:
             case Type::QUESTION:
-                nsAlert.alertStyle = NSInformationalAlertStyle;
+                nsAlert.alertStyle = NSAlertStyleInformational;
                 break;
 
             case Type::WARNING:
             case Type::ERROR:
-                nsAlert.alertStyle = NSWarningAlertStyle;
+                nsAlert.alertStyle = NSAlertStyleWarning;
                 break;
         }
     }
@@ -1289,7 +1265,7 @@ public:
     }
 
     bool RunModal() override {
-        if([nsPanel runModal] == NSFileHandlingPanelOKButton) {
+        if([nsPanel runModal] == NSModalResponseOK) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
This is work done by @troughton (see: https://github.com/troughton/solvespace/commit/42f187aac1585de4e274118823b368edafd02b27).

See his comment in this issue: https://github.com/solvespace/solvespace/issues/354
I just wanted to turn it into a PR on this repository so more people can see it, and possibly try it out / continue working on it.

I also fixed some deprecation warnings I got in XCode on Catalina.

I can compile and run this, it make SolveSpace very fast again!
However, there is some flashing in the toolbar occurring now and then, and there are probably other issues that I haven't stumbled into yet.

Notice that this PR does not bring in the changes that @troughton made to `src/render/gl3shader.cpp` since I am not sure what the purpose of these changes are.

Can someone tell me how to crash it / what needs to be done to get this working reliably?