### PR TITLE
Fix CMake Xcode generator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ set(OPENGL 3 CACHE STRING "OpenGL version to use (one of: 1 3)")
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH    ${CMAKE_BINARY_DIR}/bin)
+if("${CMAKE_GENERATOR}" STREQUAL "Xcode")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}/bin>)
+endif()
 
 if(NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_CXX_COMPILER_ID)
     message(FATAL_ERROR "C and C++ compilers should be supplied by the same vendor")


### PR DESCRIPTION
By setting `CMAKE_RUNTIME_OUTPUT_DIRECTORY` to `$<1:${CMAKE_BINARY_DIR}/bin>`

Without this, the resources did not end up into the SolveSpace.app file, causing a crash on startup (where it was unable to load the locales.txt file)

The reason is that the XCode project puts things into the "bin/Debug/SolveSpace.app" or "bin/Release/SolveSpace.app" folders (depending on the target), and some files ended up in "bin/SolveSpace.app" instead, this seems to fix the locales ending up in the wrong place, but I still see some files (libraries) ending up in "bin/Debug" or "bin/Release" folders.

Here is a list of them:

```
$ ls bin/Debug
libcairo.a               libpixman-1.a            libslvs.dylib
libdxfrw.a               libpng16d.a              libsolvespace-core.a
libflatbuffers.a         libslvs.1.dylib          libsolvespace-headless.a
libfreetyped.a           libslvs.3.0.dylib        libz.a
```