### PR TITLE
Remove GL framebuffer on macOS

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -344,7 +344,7 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 // Cocoa NSView and NSWindow extensions
 //-----------------------------------------------------------------------------
 
-@interface SSView : NSView
+@interface SSView : NSOpenGLView
 @property Platform::Window *receiver;
 
 @property BOOL acceptsFirstResponder;
@@ -362,8 +362,6 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 
 @implementation SSView
 {
-    GlOffscreen         offscreen;
-    NSOpenGLContext    *glContext;
     NSTrackingArea     *trackingArea;
     NSTextField        *editor;
 }
@@ -371,17 +369,14 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 @synthesize acceptsFirstResponder;
 
 - (id)initWithFrame:(NSRect)frameRect {
-    if(self = [super initWithFrame:frameRect]) {
+    NSOpenGLPixelFormatAttribute attrs[] = {
+        NSOpenGLPFAColorSize, 24,
+        NSOpenGLPFADepthSize, 24,
+        0
+    };
+    NSOpenGLPixelFormat *pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
+    if(self = [super initWithFrame:frameRect pixelFormat:pixelFormat]) {
         self.wantsLayer = YES;
-
-        NSOpenGLPixelFormatAttribute attrs[] = {
-            NSOpenGLPFAColorSize, 24,
-            NSOpenGLPFADepthSize, 24,
-            0
-        };
-        NSOpenGLPixelFormat *pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs];
-        glContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:NULL];
-
         editor = [[NSTextField alloc] init];
         editor.editable = YES;
         [[editor cell] setWraps:NO];
@@ -394,7 +389,6 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 }
 
 - (void)dealloc {
-    offscreen.Clear();
 }
 
 - (BOOL)isFlipped {
@@ -404,29 +398,11 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 @synthesize receiver;
 
 - (void)drawRect:(NSRect)aRect {
-    [glContext makeCurrentContext];
-
-    NSSize size   = [self convertSizeToBacking:self.bounds.size];
-    int    width  = (int)size.width,
-           height = (int)size.height;
-    offscreen.Render(width, height, [&] {
-        if(receiver->onRender) {
-            receiver->onRender();
-        }
-    });
-
-    CGDataProviderRef provider = CGDataProviderCreateWithData(
-        NULL, &offscreen.data[0], width * height * 4, NULL);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
-    CGImageRef image = CGImageCreate(width, height, 8, 32,
-        width * 4, colorspace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst,
-        provider, NULL, true, kCGRenderingIntentDefault);
-
-    CGContextDrawImage((CGContextRef) [[NSGraphicsContext currentContext] graphicsPort],
-                       [self bounds], image);
-
-    CGImageRelease(image);
-    CGDataProviderRelease(provider);
+    [[self openGLContext] makeCurrentContext];
+    if(receiver->onRender) {
+        receiver->onRender();
+    }
+    [[self openGLContext] flushBuffer];
 }
 
 - (BOOL)acceptsFirstMouse:(NSEvent *)event {


### PR DESCRIPTION
This is work done by @troughton (see: troughton@42f187a).

See his comment in this issue: #354
I just wanted to turn it into a PR on this repository so more people can see it, and possibly try it out / continue working on it.

I can compile and run this, it make SolveSpace very fast again!
However, there is some flashing in the toolbar occurring now and then, and there are probably other issues that I haven't stumbled into yet.

Notice that this PR does not bring in the changes that @troughton made to src/render/gl3shader.cpp.
Those seemed to be another optimisation that I don't fully understand, and we might be able to do without.

Can someone tell me how to crash it / what needs to be done to get this working reliably?

This PR is supersedes #502 