### PR TITLE
Fix crash on macOS Catalina where GL info is missing

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -350,10 +350,14 @@ void TextWindow::ShowConfiguration() {
     if(canvas) {
         const char *gl_vendor, *gl_renderer, *gl_version;
         canvas->GetIdent(&gl_vendor, &gl_renderer, &gl_version);
-        Printf(false, "");
-        Printf(false, " %Ftgl vendor   %E%s", gl_vendor);
-        Printf(false, " %Ft   renderer %E%s", gl_renderer);
-        Printf(false, " %Ft   version  %E%s", gl_version);
+        if (!gl_vendor) {
+            Printf(false, "  gl info not found");
+        } else {
+            Printf(false, "");
+            Printf(false, " %Ftgl vendor   %E%s", gl_vendor);
+            Printf(false, " %Ft   renderer %E%s", gl_renderer);
+            Printf(false, " %Ft   version  %E%s", gl_version);
+        }
     }
 }
 


### PR DESCRIPTION
Opening the preferences no macOS Catalina crashes SolveSpace.
This is due to the way the gl_vendor / gl_renderer and gl_version is retrieved.
We use `glGetString` in `rendergl3.cpp` (in the `getIdent` function).

Somehow this doesn't seem to work anymore in Catalina.

Let me know if anything needs to change.