### PR TITLE
Refactor Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
 language: c
-os:
-  - linux
-  - osx
-sudo: required
-dist: trusty
-osx_image: xcode8.2
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./.travis/install-debian.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./.travis/install-macos.sh; fi
-script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./.travis/build-debian.sh; fi
-  # the awk command is a workaround for https://github.com/travis-ci/travis-ci/issues/4704.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./.travis/build-macos.sh | awk '/.{0,32}/ {print $0}'; fi
-deploy:
-  - provider: releases
-    api_key:
-      secure: dDlkIawHcODlW9B/20/cQCtzeoocvs0hKuNngRKXKqzXLWTRq33oq/B7+39tAixWbmv6exTpijiKrRNFiSCW5Z4iwHLwaRD4XJznxw63e/Hus/dxg2Tvqx7XFpkCz8mT1Z+gZQE5YxAngeZPpI/sZbZtF1UO3yH5eLeeokZ15p26ZskQUPoYuzrTgTzYL3XfpG3F+20rNBawH1ycsCTVD/08/n31d2m3CrKAsbW7er92ek6w4fzKr7NW8WeXjrPJETVpw5fQg1Od3pRGW8dPQaJcvKQEogMp8Mm0ETYd0qigg89/giBz7QwOgmAWQ4dH+DfZH4Ojl//127QztBolMvyDMQBykWrtJoGcij05sT6K2IJr2FHeUBO12MAEdjiVvhQj3DtTzjPiZAHHDBSLWxLKWWhlhHE4pq7g1MQhqXkaAHI2BLNzwLmaowbMT0bECf9yfz6xx18h6XPQFX44oOktraobVALFlyHqeKa8zdcUt22LF6uAL1m5dxL0tny3eXCIPE4UH/RZgua/cHV9G3cUvKQa/QnFSLRhvWVSbGB+7YsHouBJcsUOOW1gmd5442XuC7mpppccRldh+GSxUk6TBJRAx7TeQ0ybDUaoco9MUqp2twv3KreR2+8Q12PDaAhfQVNEGdF3wTm1sShImjCN4VN3eSLlBEbve1QRQXM=
-    skip_cleanup: true
-    file: build/SolveSpace.dmg
-    on:
-      repo: solvespace/solvespace
-      tags: true
-      condition: "$TRAVIS_OS_NAME == osx"
+git:
+  submodules: false
+jobs:
+  include:
+    - stage: test
+      name: "Debian"
+      os: linux
+      dist: bionic
+      install: ./.travis/install-debian.sh
+      script: ./.travis/build-debian.sh
+    - stage: deploy
+      name: "OSX"
+      os: osx
+      osx_image: xcode8.3
+      install: ./.travis/install-macos.sh
+      # the awk command is a workaround for https://github.com/travis-ci/travis-ci/issues/4704.
+      script: ./.travis/build-macos.sh | awk '/.{0,32}/ {print $0}'
+      deploy:
+        provider: releases
+        api_key:
+          secure: dDlkIawHcODlW9B/20/cQCtzeoocvs0hKuNngRKXKqzXLWTRq33oq/B7+39tAixWbmv6exTpijiKrRNFiSCW5Z4iwHLwaRD4XJznxw63e/Hus/dxg2Tvqx7XFpkCz8mT1Z+gZQE5YxAngeZPpI/sZbZtF1UO3yH5eLeeokZ15p26ZskQUPoYuzrTgTzYL3XfpG3F+20rNBawH1ycsCTVD/08/n31d2m3CrKAsbW7er92ek6w4fzKr7NW8WeXjrPJETVpw5fQg1Od3pRGW8dPQaJcvKQEogMp8Mm0ETYd0qigg89/giBz7QwOgmAWQ4dH+DfZH4Ojl//127QztBolMvyDMQBykWrtJoGcij05sT6K2IJr2FHeUBO12MAEdjiVvhQj3DtTzjPiZAHHDBSLWxLKWWhlhHE4pq7g1MQhqXkaAHI2BLNzwLmaowbMT0bECf9yfz6xx18h6XPQFX44oOktraobVALFlyHqeKa8zdcUt22LF6uAL1m5dxL0tny3eXCIPE4UH/RZgua/cHV9G3cUvKQa/QnFSLRhvWVSbGB+7YsHouBJcsUOOW1gmd5442XuC7mpppccRldh+GSxUk6TBJRAx7TeQ0ybDUaoco9MUqp2twv3KreR2+8Q12PDaAhfQVNEGdF3wTm1sShImjCN4VN3eSLlBEbve1QRQXM=
+        skip_cleanup: true
+        file: build/SolveSpace.dmg
+        on:
+          repo: solvespace/solvespace
+          tags: true

--- a/.travis/build-debian.sh
+++ b/.travis/build-debian.sh
@@ -4,12 +4,8 @@ if echo $TRAVIS_TAG | grep ^v; then BUILD_TYPE=RelWithDebInfo; else BUILD_TYPE=D
 
 mkdir build
 cd build
-# We build without the GUI until Travis updates to an Ubuntu version with GTK 3.16+.
 cmake .. \
-  -DCMAKE_C_COMPILER=gcc-5 \
-  -DCMAKE_CXX_COMPILER=g++-5 \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-  -DENABLE_GUI=OFF \
   -DENABLE_SANITIZERS=ON
 make VERBOSE=1
 make test_solvespace

--- a/.travis/install-debian.sh
+++ b/.travis/install-debian.sh
@@ -1,8 +1,10 @@
 #!/bin/sh -xe
 
-sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -qq
+
 sudo apt-get install -q -y \
-  cmake cmake-data libc6-dev libpng12-dev zlib1g-dev libjson0-dev libfontconfig1-dev \
-  libgtkmm-3.0-dev libpangomm-1.4-dev libcairo2-dev libgl1-mesa-dev libglu-dev \
-  libfreetype6-dev dpkg-dev gcc-5 g++-5 lcov
+  zlib1g-dev libpng-dev libcairo2-dev libfreetype6-dev libjson-c-dev \
+  libfontconfig1-dev libgtkmm-3.0-dev libpangomm-1.4-dev libgl-dev \
+  libgl-dev libglu-dev libspnav-dev 
+
+git submodule update --init extlib/libdxfrw extlib/flatbuffers extlib/q3d

--- a/.travis/install-macos.sh
+++ b/.travis/install-macos.sh
@@ -2,3 +2,4 @@
 
 brew update
 brew install freetype cairo
+git submodule update --init


### PR DESCRIPTION
- Fix invalid osx_image xcode8.2
- Drop depreceated sudo keyword
- Run debian build on bionic image & re-enable building with ui
- Split build into separate jobs & stages for better separation of concerns

Split out from #506 

We have two stages here:
- Test
- Deploy

Test runs the debian build. If that succeeds, we do OSX and later the Snap build in ```Deploy```.