### PR TITLE
Remove missing rendergl.cpp file from CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,7 +128,6 @@ elseif(APPLE)
         -fobjc-arc)
 
     list(APPEND platform_SOURCES
-        render/rendergl.cpp
         platform/guimac.mm)
 else()
     list(APPEND platform_SOURCES


### PR DESCRIPTION
macOS build broke with 07992cecaaeeeb0584f3c655eaaf32ba09bd3e6d this fixes that.