### PR TITLE
Fix preferences not opening when closed on macOS

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -1409,6 +1409,9 @@ void OpenInBrowser(const std::string &url) {
 
 @implementation SSApplicationDelegate
 - (IBAction)preferences:(id)sender {
+    if (!SS.GW.showTextWindow) {
+        SolveSpace::SS.GW.MenuView(SolveSpace::Command::SHOW_TEXT_WND);
+    }
     SolveSpace::SS.TW.GoToScreen(SolveSpace::TextWindow::Screen::CONFIGURATION);
     SolveSpace::SS.ScheduleShowTW();
 }


### PR DESCRIPTION
On macOS, when closing the preferences window, then clicking `Preferences` in the Menu, does not open the preferences window.

This PR fixes that.