### PR TITLE
Fix tooltips not closing on macOS Catalina

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -16,6 +16,7 @@ using namespace SolveSpace;
 + (NSToolTipManager *)sharedToolTipManager;
 - (void)setInitialToolTipDelay:(double)delay;
 - (void)orderOutToolTip;
+- (void)abortToolTip;
 - (void)_displayTemporaryToolTipForView:(id)arg1 withString:(id)arg2;
 @end
 
@@ -909,7 +910,11 @@ public:
 
             NSToolTipManager *nsToolTipManager = [NSToolTipManager sharedToolTipManager];
             if(newText.empty()) {
-                [nsToolTipManager orderOutToolTip];
+                if ([nsToolTipManager respondsToSelector:@selector(abortToolTip)]) {
+                    [nsToolTipManager abortToolTip];
+                } else {
+                    [nsToolTipManager orderOutToolTip];
+                }
             } else {
                 [nsToolTipManager _displayTemporaryToolTipForView:ssView withString:Wrap(newText)];
             }


### PR DESCRIPTION
This is the last bug I have found on Catalina.
Tooltips are not closed when hovering off something.
The private API seems to have changed, and implementing tooltips seems to be a pain in the butt, so I checked for the availability of the method and fall back to the old method for now.