### PR TITLE
Fix eight trivial "implicit conversion 'double' to 'int'" warnings. NFC.

### DIFF
--- a/src/render/rendergl1.cpp
+++ b/src/render/rendergl1.cpp
@@ -708,8 +708,8 @@ void OpenGl1Renderer::UpdateProjection() {
     UnSelectPrimitive();
 
     glViewport(0, 0,
-               camera.width  * camera.pixelRatio,
-               camera.height * camera.pixelRatio);
+               (GLsizei)(camera.width  * camera.pixelRatio),
+               (GLsizei)(camera.height * camera.pixelRatio));
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
@@ -821,8 +821,8 @@ void OpenGl1Renderer::FinishFrame() {
 }
 
 std::shared_ptr<Pixmap> OpenGl1Renderer::ReadFrame() {
-    int width  = camera.width  * camera.pixelRatio;
-    int height = camera.height * camera.pixelRatio;
+    int width  = (int)(camera.width  * camera.pixelRatio);
+    int height = (int)(camera.height * camera.pixelRatio);
     std::shared_ptr<Pixmap> pixmap =
         Pixmap::Create(Pixmap::Format::RGB, (size_t)width, (size_t)height);
     glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, &pixmap->data[0]);

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -361,7 +361,7 @@ std::string SolveSpaceUI::MmToStringSI(double v, int dim) {
     }
 
     v /= pow((viewUnits == Unit::INCHES) ? 25.4 : 1000, dim);
-    int vdeg = floor((log10(fabs(v))) / dim);
+    int vdeg = (int)((log10(fabs(v))) / dim);
     std::string unit;
     if(fabs(v) > 0.0) {
         int sdeg = 0;
@@ -371,7 +371,7 @@ std::string SolveSpaceUI::MmToStringSI(double v, int dim) {
             : SelectSIPrefixMm(vdeg);
         v /= pow(10.0, sdeg * dim);
     }
-    int pdeg = ceil(log10(fabs(v) + 1e-10));
+    int pdeg = (int)ceil(log10(fabs(v) + 1e-10));
     return ssprintf("%#.*g%s%s%s", pdeg + UnitDigitsAfterDecimal(), v,
                     compact ? "" : " ", unit.c_str(), DimToString(dim));
 }

--- a/src/srf/surface.cpp
+++ b/src/srf/surface.cpp
@@ -646,7 +646,7 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
     // for testing - hard code the axial distance, and number of sections.
     // distance will need to be parameters in the future.
     double dist  = distf - dists;
-    int sections = fabs(anglef - angles) / (PI / 2) + 1;
+    int sections = (int)(fabs(anglef - angles) / (PI / 2) + 1);
     double wedge = (anglef - angles) / sections;
 
     if(CheckNormalAxisRelationship(sbls, pt, axis, anglef-angles, distf-dists)) {

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -219,7 +219,7 @@ bool GraphicsWindow::ToolbarDrawOrHitTest(int mx, int my, UiCanvas *canvas,
             {
                 if(hitCommand) *hitCommand = icon.command;
                 if(hitX) *hitX = x - boxhw;
-                if(hitY) *hitY = height - (y + boxhw);
+                if(hitY) *hitY = (int)height - (y + boxhw);
             }
         }
 


### PR DESCRIPTION
Found when compiling with clang 9.