### PR TITLE
Fix some trivial warnings found by MSVC (NFC). And a bug with SpaceMouse.

### DIFF
--- a/src/export.cpp
+++ b/src/export.cpp
@@ -917,13 +917,13 @@ void SolveSpaceUI::ExportMeshAsQ3doTo(FILE *f, SMesh *sm) {
         }
 
         Vector faceNormal = t.Normal();
-        auto a = q3d::Vector3(t.a.x/s, t.a.y/s, t.a.z/s);
-        auto b = q3d::Vector3(t.b.x/s, t.b.y/s, t.b.z/s);
-        auto c = q3d::Vector3(t.c.x/s, t.c.y/s, t.c.z/s);
-        auto fn = q3d::Vector3(faceNormal.x, faceNormal.y, faceNormal.x);
-        auto n1 = q3d::Vector3(t.normals[0].x, t.normals[0].y, t.normals[0].z);
-        auto n2 = q3d::Vector3(t.normals[1].x, t.normals[1].y, t.normals[1].z);
-        auto n3 = q3d::Vector3(t.normals[2].x, t.normals[2].y, t.normals[2].z);
+        auto a = q3d::Vector3((float)(t.a.x/s), (float)(t.a.y/s), (float)(t.a.z/s));
+        auto b = q3d::Vector3((float)(t.b.x/s), (float)(t.b.y/s), (float)(t.b.z/s));
+        auto c = q3d::Vector3((float)(t.c.x/s), (float)(t.c.y/s), (float)(t.c.z/s));
+        auto fn = q3d::Vector3((float)faceNormal.x, (float)faceNormal.y, (float)faceNormal.x);
+        auto n1 = q3d::Vector3((float)t.normals[0].x, (float)t.normals[0].y, (float)t.normals[0].z);
+        auto n2 = q3d::Vector3((float)t.normals[1].x, (float)t.normals[1].y, (float)t.normals[1].z);
+        auto n3 = q3d::Vector3((float)t.normals[2].x, (float)t.normals[2].y, (float)t.normals[2].z);
         auto tri = q3d::CreateTriangle(builder, &a, &b, &c, &fn, &n1, &n2, &n3);
         materialTriangles[color].push_back(tri);
     }

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1389,7 +1389,7 @@ WindowRef CreateWindow(Window::Kind kind, WindowRef parentWindow) {
 static HWND hSpaceWareDriverClass;
 
 void Open3DConnexion() {
-    HWND hSpaceWareDriverClass = FindWindowW(L"SpaceWare Driver Class", NULL);
+    hSpaceWareDriverClass = FindWindowW(L"SpaceWare Driver Class", NULL);
     if(hSpaceWareDriverClass != NULL) {
         SiInitialize();
     }

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1227,7 +1227,7 @@ public:
     }
 
     void SetCursor(Cursor cursor) override {
-        LPWSTR cursorName;
+        LPWSTR cursorName = IDC_ARROW;
         switch(cursor) {
             case Cursor::POINTER: cursorName = IDC_ARROW; break;
             case Cursor::HAND:    cursorName = IDC_HAND;  break;

--- a/src/render/render.h
+++ b/src/render/render.h
@@ -285,8 +285,8 @@ public:
     const Camera &GetCamera() const override { return camera; }
 
     // ViewportCanvas interface.
-    void SetCamera(const Camera &camera) override { this->camera = camera; }
-    void SetLighting(const Lighting &lighting) override { this->lighting = lighting; }
+    void SetCamera(const Camera &cam) override { this->camera = cam; }
+    void SetLighting(const Lighting &light) override { this->lighting = light; }
 
     void DrawLine(const Vector &a, const Vector &b, hStroke hcs) override;
     void DrawEdges(const SEdgeList &el, hStroke hcs) override;

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -802,7 +802,6 @@ void SolveSpaceUI::MenuAnalyze(Command id) {
         case Command::AREA: {
             Group *g = SK.GetGroup(SS.GW.activeGroup);
             SS.GW.GroupSelection();
-            auto const &gs = SS.GW.gs;
 
             if(gs.faces > 0) {
                 std::vector<uint32_t> faces;
@@ -844,8 +843,8 @@ void SolveSpaceUI::MenuAnalyze(Command id) {
             if(gs.n > 0 && gs.n == gs.entities) {
                 double perimeter = 0.0;
                 for(int i = 0; i < gs.entities; i++) {
-                    Entity *e = SK.entity.FindById(gs.entity[i]);
-                    SEdgeList *el = e->GetOrGenerateEdges();
+                    Entity *en = SK.entity.FindById(gs.entity[i]);
+                    SEdgeList *el = en->GetOrGenerateEdges();
                     for(const SEdge &e : el->l) {
                         perimeter += e.b.Minus(e.a).Magnitude();
                     }

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -604,7 +604,7 @@ void TextWindow::ScreenStepDimGo(int link, uint32_t v) {
                 if(time - SS.TW.stepDim.time < STEP_MILLIS) {
                     SS.TW.stepDim.timer->RunAfterNextFrame();
                 } else {
-                    SS.TW.stepDim.timer->RunAfter(time - SS.TW.stepDim.time - STEP_MILLIS);
+                    SS.TW.stepDim.timer->RunAfter((unsigned)(time - SS.TW.stepDim.time - STEP_MILLIS));
                 }
                 SS.TW.stepDim.time = time;
             } else {
@@ -758,7 +758,8 @@ void TextWindow::EditControlDone(std::string s) {
 
                 Group *g = SK.group.FindByIdNoOops(SS.TW.shown.group);
                 if(!g) break;
-                g->color = RgbaColor::FromFloat(rgb.x, rgb.y, rgb.z, g->color.alphaF());
+                g->color = RgbaColor::FromFloat((float)rgb.x, (float)rgb.y, (float)rgb.z,
+                                                g->color.alphaF());
 
                 SS.MarkGroupDirty(g->h);
                 SS.GW.ClearSuper();


### PR DESCRIPTION
Found with /W4 by MSVC 2019 (Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28314)

A bunch of implicit casts 'double' to 'float' and one 'int64_t' to 'unsigned'.

.\src\platform\guiwin.cpp(1237): warning C4701: potentially uninitialized local variable 'cursorName' used
.\src\platform\guiwin.cpp(1237): warning C4703: potentially uninitialized local pointer variable 'cursorName' used

.\src\solvespace.cpp(805,30): warning C4456: declaration of 'gs' hides previous local declaration
.\src\solvespace.cpp(715,17): message : see declaration of 'gs'

.\src\solvespace.cpp(849,47): warning C4456: declaration of 'e' hides previous local declaration
.\src\solvespace.cpp(847,29): message : see declaration of 'e'

.\src\render\render.h(288,51): warning C4458: declaration of 'camera' hides class member
.\src\render\render.h(271,17): message : see declaration of 'SolveSpace::SurfaceRenderer::camera'

.\src\render\render.h(289,57): warning C4458: declaration of 'lighting' hides class member
.\src\render\render.h(272,17): message : see declaration of 'SolveSpace::SurfaceRenderer::lighting'

 Fix a potential bug with 3Dconnexion: SpaceMouse

**Another warning is an actual bug. How does the SpaceMouse (I do not have one) work at all?**

.\src\platform\guiwin.cpp(1392,34): warning C4459: declaration of 'hSpaceWareDriverClass' hides global declaration
.\src\platform\guiwin.cpp(1389,13): message : see declaration of 'SolveSpace::Platform::hSpaceWareDriverClass'