### PR TITLE
Win32: Drastically reduce stack usage at startup. NFC?

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -340,7 +340,7 @@ if(ENABLE_GUI)
 
     if(MSVC)
         set_target_properties(solvespace PROPERTIES
-            LINK_FLAGS "/MANIFEST:NO /SAFESEH:NO /INCREMENTAL:NO /OPT:REF /STACK:33554432")
+            LINK_FLAGS "/MANIFEST:NO /SAFESEH:NO /INCREMENTAL:NO /OPT:REF")
     elseif(APPLE)
         set_target_properties(solvespace PROPERTIES
             OUTPUT_NAME SolveSpace)

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -810,8 +810,8 @@ public:
     // where it puts zero-initialized global data in the binary (~30M of zeroes)
     // in release builds.
     SolveSpaceUI()
-        : pTW(new TextWindow({})), TW(*pTW),
-          pSys(new System({})), sys(*pSys) {}
+        : pTW(new TextWindow()), TW(*pTW),
+          pSys(new System()), sys(*pSys) {}
 
     ~SolveSpaceUI() {
         delete pTW;


### PR DESCRIPTION
See:
https://github.com/solvespace/solvespace/issues/92#issuecomment-567831112

The problem was first introduced here:
https://github.com/solvespace/solvespace/commit/dabd57847edf142f145491175fb203455023d9d7

and later "fixed" here:
https://github.com/solvespace/solvespace/commit/f324477dd06c15022670a4486bf83be3abbf48b5
by setting the stack size to /STACK:33554432

Solvespace now starts up even with /STACK:554432

According to this:
https://en.cppreference.com/w/cpp/language/value_initialization
```
"2) if T is a class type with a default constructor that is neither user-provided nor deleted (that is, it may be a class with an implicitly-defined or defaulted default constructor), the object is zero-initialized and then it is default-initialized if it has a non-trivial default constructor; "
```
So removing the `{}` should leave both the `System` and `TextWindow` class instances properly initialized.