### PR TITLE
Win32: Open a console in debug mode to display stderr debug messages.

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1665,6 +1665,16 @@ void InitGui(int argc, char **argv) {
     if(!SetLocale((uint16_t)GetUserDefaultLCID())) {
         SetLocale("en_US");
     }
+
+#ifndef NDEBUG
+    // create a debug console
+    if(AllocConsole()) {
+        (void)freopen("CONOUT$", "w", /*stdout*/stderr);
+        SetConsoleTitle(L"Debug Console");
+        SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE),
+                                FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_RED);
+    }
+#endif
 }
 
 void RunGui() {


### PR DESCRIPTION
It may be useful when running a debug build directly (instead of using a debugger that captures and displays `stderr`).