### PR TITLE
snap: Release snaps to store via script instead of snap provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,15 @@ jobs:
             confinement: classic
       script: ./.travis/build-snap.sh
       deploy:
-        - provider: snap
+        - provider: script
+          script: ./.travis/deploy-snap.sh edge
           skip_cleanup: true
-          snap: pkg/snap/*.snap
-          channel: edge
           on:
             branch: master
             tags: false
-        - provider: snap
+        - provider: script
+          script: ./.travis/deploy-snap.sh edge,beta
           skip_cleanup: true
-          snap: pkg/snap/*.snap
-          channel: edge,beta
           on:
             branch: master
             tags: true

--- a/.travis/deploy-snap.sh
+++ b/.travis/deploy-snap.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+channels="$1"
+echo "$SNAP_TOKEN" | snapcraft login --with -
+
+for snap in ./pkg/snap/*.snap; do
+  snapcraft push "$snap" --release "$channels"
+done


### PR DESCRIPTION
dpl-snap only supports pushing one snap at a time.
Instead of many repetitive deploy statements, we use our own script to loop over the snaps to be released.