### PR TITLE
snap: Add missing sudo in Travis deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ jobs:
       script: ./.travis/build-snap.sh
       deploy:
         - provider: script
-          script: ./.travis/deploy-snap.sh edge
+          script: sudo ./.travis/deploy-snap.sh edge
           skip_cleanup: true
           on:
             branch: master
             tags: false
         - provider: script
-          script: ./.travis/deploy-snap.sh edge,beta
+          script: sudo ./.travis/deploy-snap.sh edge,beta
           skip_cleanup: true
           on:
             branch: master


### PR DESCRIPTION
Running the build step with sudo necessitates running the deploy step with sudo too.
Otherwise, we face permission problems.