### PR TITLE
snap: Remove superfluous files from package & fix missing extension for cli

### DIFF
--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ apps:
     extensions: [gnome-3-28]
     plugs: [opengl, unity7, home, removable-media, gsettings, network]
     environment:
-      __EGL_VENDOR_LIBRARY_DIRS: $SNAP/usr/share/glvnd/egl_vendor.d
+      __EGL_VENDOR_LIBRARY_DIRS: $SNAP/gnome-platform/usr/share/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
   cli:
     command: usr/bin/solvespace-cli
     plugs: [home, removable-media, network]
@@ -71,6 +71,14 @@ parts:
       - libglibmm-2.4-1v5
       - libpangomm-1.4-1v5
       - libsigc++-2.0-0v5
-      - libglew2.0
-      - libegl-mesa0
-      - libdrm2
+  cleanup:
+    after: [solvespace]
+    plugin: nil
+    build-snaps: [core18, gnome-3-28-1804]
+    override-prime: |
+      # Remove all files from snap that are already included in the base snap or in
+      # any connected content snaps
+      set -eux
+      for snap in "core18" "gnome-3-28-1804"; do  # List all content-snaps and base snaps you're using here
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+      done

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -29,6 +29,7 @@ apps:
       __EGL_VENDOR_LIBRARY_DIRS: $SNAP/gnome-platform/usr/share/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
   cli:
     command: usr/bin/solvespace-cli
+    extensions: [gnome-3-28]
     plugs: [home, removable-media, network]
 
 parts:


### PR DESCRIPTION
Remove all files from snap that are already included in the base snap
or in any connected content snaps.

The main advantage is the massively reduced snap size:
From **~70 MB** down to **~6 MB**:

```shell
  edge:      3.0~dcc80de7 2020-02-08 (10) 69MB -
installed:   3.0~b809e41a            (x1)  5MB -
```

## Additional bugfix

solvespace-cli needs the gnome-3-28 extension to find its libraries. LD_LIBRARY_PATH wasn't getting modified on launch because the gnome extension was only applied to the GUI app "solvespace".


