### PR TITLE
Fix two trivial implicit double to int conversion warnings. NFC

### DIFF
--- a/src/render/rendergl3.cpp
+++ b/src/render/rendergl3.cpp
@@ -693,8 +693,8 @@ void OpenGl3Renderer::Clear() {
 }
 
 std::shared_ptr<Pixmap> OpenGl3Renderer::ReadFrame() {
-    int width  = camera.width  * camera.pixelRatio;
-    int height = camera.height * camera.pixelRatio;
+    int width  = (int)(camera.width  * camera.pixelRatio);
+    int height = (int)(camera.height * camera.pixelRatio);
     std::shared_ptr<Pixmap> pixmap =
         Pixmap::Create(Pixmap::Format::RGBA, (size_t)width, (size_t)height);
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, &pixmap->data[0]);


### PR DESCRIPTION
Same warning and fix as in 16c5fa6889202f2059b52c4a89599910541dd1a0, but for `rendergl3.cpp`.