### PR TITLE
Solve crash when trying to show error with bad separator.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -138,9 +138,11 @@ static void MessageBox(const char *fmt, va_list va, bool error,
         }
     }
 
-    std::string::iterator it = description.begin();
-    while(isspace(*it)) it++;
-    description = description.substr(it - description.begin());
+    if(description.length() > 0) {
+        std::string::iterator it = description.begin();
+        while(isspace(*it)) it++;
+        description = description.substr(it - description.begin());
+    }
 
     Platform::MessageDialogRef dialog = CreateMessageDialog(SS.GW.window);
     if (!dialog) {


### PR DESCRIPTION
This should solve #490 

The problem was that the message box tries to split the `description` string after the first dot or colon, but if there is only a single dot at the very end of the string, when calling `isspace(*it)`, the value of `*it` is `\0` and crashes.