### PR TITLE
Pre-populate file dialogs with sensible defaults

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -904,11 +904,13 @@ try_again:
         } else if(linkMap.count(g.linkFile) == 0) {
             dbp("Missing file for group: %s", g.name.c_str());
             // The file was moved; prompt the user for its new location.
-            switch(LocateImportedFile(g.linkFile.RelativeTo(saveFile), canCancel)) {
+            const auto linkFileRelative = g.linkFile.RelativeTo(saveFile);
+            switch(LocateImportedFile(linkFileRelative, canCancel)) {
                 case Platform::MessageDialog::Response::YES: {
                     Platform::FileDialogRef dialog = Platform::CreateOpenFileDialog(SS.GW.window);
                     dialog->AddFilters(Platform::SolveSpaceModelFileFilters);
                     dialog->ThawChoices(settings, "LinkSketch");
+                    dialog->SuggestFilename(linkFileRelative);
                     if(dialog->RunModal()) {
                         dialog->FreezeChoices(settings, "LinkSketch");
                         linkMap[g.linkFile] = dialog->GetFilename();
@@ -985,6 +987,7 @@ bool SolveSpaceUI::ReloadLinkedImage(const Platform::Path &saveFile,
         Platform::FileDialogRef dialog = Platform::CreateOpenFileDialog(SS.GW.window);
         dialog->AddFilters(Platform::RasterFileFilters);
         dialog->ThawChoices(settings, "LinkImage");
+        dialog->SuggestFilename(filename->RelativeTo(saveFile));
         if(dialog->RunModal()) {
             dialog->FreezeChoices(settings, "LinkImage");
             *filename = dialog->GetFilename();

--- a/src/platform/gui.h
+++ b/src/platform/gui.h
@@ -356,6 +356,7 @@ public:
 
     virtual Platform::Path GetFilename() = 0;
     virtual void SetFilename(Platform::Path path) = 0;
+    virtual void SuggestFilename(Platform::Path path) = 0;
 
     virtual void AddFilter(std::string name, std::vector<std::string> extensions) = 0;
     void AddFilter(const FileFilter &filter);

--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -1246,6 +1246,10 @@ public:
         gtkChooser->set_filename(path.raw);
     }
 
+    void SuggestFilename(Platform::Path path) override {
+        SetFilename(path.WithExtension(""));  // TODO
+    }
+
     void AddFilter(std::string name, std::vector<std::string> extensions) override {
         Glib::RefPtr<Gtk::FileFilter> gtkFilter = Gtk::FileFilter::create();
         Glib::ustring desc;

--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -1274,6 +1274,10 @@ public:
         nsPanel.nameFieldStringValue = Wrap(path.FileStem());
     }
 
+    void SuggestFilename(Platform::Path path) override {
+        SetFilename(path.WithExtension(""));
+    }
+
     void FreezeChoices(SettingsRef settings, const std::string &key) override {
         settings->FreezeString("Dialog_" + key + "_Folder",
                                [nsPanel.directoryURL.absoluteString UTF8String]);

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1582,6 +1582,10 @@ public:
         wcsncpy(filenameWC, Widen(path.raw).c_str(), sizeof(filenameWC) / sizeof(wchar_t) - 1);
     }
 
+    void SuggestFilename(Platform::Path path) override {
+        SetFilename(Platform::Path::From(path.FileStem()));
+    }
+
     void AddFilter(std::string name, std::vector<std::string> extensions) override {
         std::string desc, patterns;
         for(auto extension : extensions) {

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -185,8 +185,10 @@ Path Path::WithExtension(std::string ext) const {
     if(dot != std::string::npos) {
         withExt.raw.erase(dot);
     }
-    withExt.raw += ".";
-    withExt.raw += ext;
+    if(!ext.empty()) {
+        withExt.raw += ".";
+        withExt.raw += ext;
+    }
     return withExt;
 }
 

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -627,6 +627,7 @@ void SolveSpaceUI::MenuFile(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::RasterFileFilters);
             dialog->ThawChoices(settings, "ExportImage");
+            dialog->SuggestFilename(SS.saveFile);
             if(dialog->RunModal()) {
                 dialog->FreezeChoices(settings, "ExportImage");
                 SS.ExportAsPngTo(dialog->GetFilename());
@@ -638,6 +639,7 @@ void SolveSpaceUI::MenuFile(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::VectorFileFilters);
             dialog->ThawChoices(settings, "ExportView");
+            dialog->SuggestFilename(SS.saveFile);
             if(!dialog->RunModal()) break;
             dialog->FreezeChoices(settings, "ExportView");
 
@@ -661,6 +663,7 @@ void SolveSpaceUI::MenuFile(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::Vector3dFileFilters);
             dialog->ThawChoices(settings, "ExportWireframe");
+            dialog->SuggestFilename(SS.saveFile);
             if(!dialog->RunModal()) break;
             dialog->FreezeChoices(settings, "ExportWireframe");
 
@@ -672,6 +675,7 @@ void SolveSpaceUI::MenuFile(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::VectorFileFilters);
             dialog->ThawChoices(settings, "ExportSection");
+            dialog->SuggestFilename(SS.saveFile);
             if(!dialog->RunModal()) break;
             dialog->FreezeChoices(settings, "ExportSection");
 
@@ -683,6 +687,7 @@ void SolveSpaceUI::MenuFile(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::MeshFileFilters);
             dialog->ThawChoices(settings, "ExportMesh");
+            dialog->SuggestFilename(SS.saveFile);
             if(!dialog->RunModal()) break;
             dialog->FreezeChoices(settings, "ExportMesh");
 
@@ -694,6 +699,7 @@ void SolveSpaceUI::MenuFile(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::SurfaceFileFilters);
             dialog->ThawChoices(settings, "ExportSurfaces");
+            dialog->SuggestFilename(SS.saveFile);
             if(!dialog->RunModal()) break;
             dialog->FreezeChoices(settings, "ExportSurfaces");
 
@@ -907,6 +913,7 @@ void SolveSpaceUI::MenuAnalyze(Command id) {
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::CsvFileFilters);
             dialog->ThawChoices(settings, "Trace");
+            dialog->SetFilename(SS.saveFile);
             if(dialog->RunModal()) {
                 dialog->FreezeChoices(settings, "Trace");
 

--- a/test/core/path/test.cpp
+++ b/test/core/path/test.cpp
@@ -83,6 +83,7 @@ TEST_CASE(extension) {
 }
 
 TEST_CASE(with_extension) {
+    CHECK_EQ_STR(Path::From("foo.bar").WithExtension("").raw, "foo");
     CHECK_EQ_STR(Path::From("foo.bar").WithExtension("baz").raw, "foo.baz");
     CHECK_EQ_STR(Path::From("foo").WithExtension("baz").raw, "foo.baz");
 }


### PR DESCRIPTION
Example: ![screenshot](https://user-images.githubusercontent.com/6709544/77234221-e8a69680-6bac-11ea-93a5-96881e40cd1c.png)

Tested on Windows only, with the assumption that other platforms' `Platform::FileDialog` behaves the same.

Ref: #538