### PR TITLE
Accept both slashes in test harness on Win32

### DIFF
--- a/test/harness.cpp
+++ b/test/harness.cpp
@@ -23,9 +23,11 @@ namespace Platform {
 
 
 #ifdef TEST_BUILD_ON_WINDOWS
-static char BUILD_PATH_SEP = '\\';
+static const char *VALID_BUILD_PATH_SEPS = "/\\";
+static char BUILD_PATH_SEP               = '\\';
 #else
-static char BUILD_PATH_SEP = '/';
+static const char *VALID_BUILD_PATH_SEPS = "/";
+static char BUILD_PATH_SEP               = '/';
 #endif
 
 static std::string BuildRoot() {
@@ -33,7 +35,7 @@ static std::string BuildRoot() {
     if(!rootDir.empty()) return rootDir;
 
     rootDir = __FILE__;
-    rootDir.erase(rootDir.rfind(BUILD_PATH_SEP) + 1);
+    rootDir.erase(rootDir.find_last_of(VALID_BUILD_PATH_SEPS) + 1);
     return rootDir;
 }
 
@@ -156,7 +158,7 @@ Platform::Path Test::Helper::GetAssetPath(std::string testFile, std::string asse
         assetName.insert(assetName.rfind('.'), "." + mangle);
     }
     testFile.erase(0, BuildRoot().size());
-    testFile.erase(testFile.rfind(BUILD_PATH_SEP) + 1);
+    testFile.erase(testFile.find_last_of(VALID_BUILD_PATH_SEPS) + 1);
     return HostRoot().Join(Platform::Path::FromPortable(testFile + assetName));
 }
 
@@ -354,7 +356,7 @@ int main(int argc, char **argv) {
     for(Test::Case &testCase : *testCasesPtr) {
         std::string testCaseName = testCase.fileName;
         testCaseName.erase(0, BuildRoot().size());
-        testCaseName.erase(testCaseName.rfind(BUILD_PATH_SEP));
+        testCaseName.erase(testCaseName.find_last_of(VALID_BUILD_PATH_SEPS));
         testCaseName += BUILD_PATH_SEP + testCase.caseName;
 
         std::smatch filterMatch;


### PR DESCRIPTION
This fixes tests when `__FILE__` produces output separated with `/` instead of `\`