### PR TITLE
Optionally export background colour in vector files

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -88,6 +88,10 @@ void TextWindow::ScreenChangeFixExportColors(int link, uint32_t v) {
     SS.fixExportColors = !SS.fixExportColors;
 }
 
+void TextWindow::ScreenChangeExportBackgroundColor(int link, uint32_t v) {
+    SS.exportBackgroundColor = !SS.exportBackgroundColor;
+}
+
 void TextWindow::ScreenChangeBackFaces(int link, uint32_t v) {
     SS.drawBackFaces = !SS.drawBackFaces;
     SS.GW.Invalidate(/*clearPersistent=*/true);
@@ -289,6 +293,9 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "  %Fd%f%Ll%s  fix white exported lines%E",
         &ScreenChangeFixExportColors,
         SS.fixExportColors ? CHECK_TRUE : CHECK_FALSE);
+    Printf(false, "  %Fd%f%Ll%s  export background color%E",
+        &ScreenChangeExportBackgroundColor,
+        SS.exportBackgroundColor ? CHECK_TRUE : CHECK_FALSE);
 
     Printf(false, "");
     Printf(false, "%Ft export canvas size:  "

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -724,6 +724,9 @@ void VectorFileWriter::OutputLinesAndMesh(SBezierLoopSetSet *sblss, SMesh *sm) {
     }
 
     StartFile();
+    if(SS.exportBackgroundColor) {
+        Background(SS.backgroundColor);
+    }
     if(sm && SS.exportShadedTriangles) {
         for(tr = sm->l.First(); tr; tr = sm->l.NextAfter(tr)) {
             Triangle(tr);

--- a/src/exportvector.cpp
+++ b/src/exportvector.cpp
@@ -551,6 +551,9 @@ void DxfFileWriter::StartFile() {
     paths.clear();
 }
 
+void DxfFileWriter::Background(RgbaColor color) {
+}
+
 void DxfFileWriter::StartPath(RgbaColor strokeRgb, double lineWidth,
                               bool filled, RgbaColor fillRgb, hStyle hs)
 {
@@ -694,6 +697,35 @@ void EpsFileWriter::StartFile() {
             (int)ceil(MmToPts(ptMax.y - ptMin.y)),
             MmToPts(ptMax.x - ptMin.x),
             MmToPts(ptMax.y - ptMin.y));
+}
+
+void EpsFileWriter::Background(RgbaColor color) {
+    double width  = ptMax.x - ptMin.x;
+    double height = ptMax.y - ptMin.y;
+
+    fprintf(f,
+"%.3f %.3f %.3f setrgbcolor\r\n"
+"newpath\r\n"
+"    %.3f %.3f moveto\r\n"
+"    %.3f %.3f lineto\r\n"
+"    %.3f %.3f lineto\r\n"
+"    %.3f %.3f lineto\r\n"
+"    closepath\r\n"
+"gsave fill grestore\r\n",
+            color.redF(), color.greenF(), color.blueF(),
+            MmToPts(0),     MmToPts(0),
+            MmToPts(width), MmToPts(0),
+            MmToPts(width), MmToPts(height),
+            MmToPts(0),     MmToPts(height));
+
+    // same issue with cracks, stroke it to avoid them
+    double sw = max(width, height) / 1000;
+    fprintf(f,
+"1 setlinejoin\r\n"
+"1 setlinecap\r\n"
+"%.3f setlinewidth\r\n"
+"gsave stroke grestore\r\n",
+            MmToPts(sw));
 }
 
 void EpsFileWriter::StartPath(RgbaColor strokeRgb, double lineWidth,
@@ -926,6 +958,30 @@ void PdfFileWriter::FinishAndCloseFile() {
 
 }
 
+void PdfFileWriter::Background(RgbaColor color) {
+    double width  = ptMax.x - ptMin.x;
+    double height = ptMax.y - ptMin.y;
+    double sw     = max(width, height) / 1000;
+
+    fprintf(f,
+"1 J 1 j\r\n"
+"%.3f %.3f %.3f RG\r\n"
+"%.3f %.3f %.3f rg\r\n"
+"%.3f w\r\n"
+"%.3f %.3f m\r\n"
+"%.3f %.3f l\r\n"
+"%.3f %.3f l\r\n"
+"%.3f %.3f l\r\n"
+"b\r\n",
+            color.redF(), color.greenF(), color.blueF(),
+            color.redF(), color.greenF(), color.blueF(),
+            MmToPts(sw),
+            MmToPts(0),     MmToPts(0),
+            MmToPts(width), MmToPts(0),
+            MmToPts(width), MmToPts(height),
+            MmToPts(0),     MmToPts(height));
+}
+
 void PdfFileWriter::StartPath(RgbaColor strokeRgb, double lineWidth,
                               bool filled, RgbaColor fillRgb, hStyle hs)
 {
@@ -1051,6 +1107,16 @@ void SvgFileWriter::StartFile() {
     fprintf(f, "]]></style>\r\n");
 }
 
+void SvgFileWriter::Background(RgbaColor color) {
+    fprintf(f,
+"<style><![CDATA[\r\n"
+"svg {\r\n"
+"background-color:#%02x%02x%02x;\r\n"
+"}\r\n"
+"]]></style>\r\n",
+        color.red, color.green, color.blue);
+}
+
 void SvgFileWriter::StartPath(RgbaColor strokeRgb, double lineWidth,
                               bool filled, RgbaColor fillRgb, hStyle hs)
 {
@@ -1146,6 +1212,9 @@ void HpglFileWriter::StartFile() {
     fprintf(f, "SP1;\r\n");
 }
 
+void HpglFileWriter::Background(RgbaColor color) {
+}
+
 void HpglFileWriter::StartPath(RgbaColor strokeRgb, double lineWidth,
                                bool filled, RgbaColor fillRgb, hStyle hs)
 {
@@ -1186,6 +1255,8 @@ void GCodeFileWriter::StartFile() {
 void GCodeFileWriter::StartPath(RgbaColor strokeRgb, double lineWidth,
                                 bool filled, RgbaColor fillRgb, hStyle hs)
 {
+}
+void GCodeFileWriter::Background(RgbaColor color) {
 }
 void GCodeFileWriter::FinishPath(RgbaColor strokeRgb, double lineWidth,
                                  bool filled, RgbaColor fillRgb, hStyle hs)
@@ -1246,6 +1317,9 @@ void Step2dFileWriter::StartFile() {
     sfw = {};
     sfw.f = f;
     sfw.WriteHeader();
+}
+
+void Step2dFileWriter::Background(RgbaColor color) {
 }
 
 void Step2dFileWriter::Triangle(STriangle *tr) {

--- a/src/platform/entrycli.cpp
+++ b/src/platform/entrycli.cpp
@@ -25,6 +25,8 @@ Common options:
         piecewise linear, and exact surfaces into triangle meshes.
         For export commands, the unit is mm, and the default is 1.0 mm.
         For non-export commands, the unit is %%, and the default is 1.0 %%.
+    -b, --bg-color <on|off>
+        Whether to export the background colour in vector formats. Defaults to off.
 
 Commands:
     thumbnail --output <pattern> --size <size> --view <direction>
@@ -33,6 +35,7 @@ Commands:
         <size> is <width>x<height>, in pixels. Graphics acceleration is
         not used, and the output may look slightly different from the GUI.
     export-view --output <pattern> --view <direction> [--chord-tol <tolerance>]
+                [--bg-color <on|off>]
         Exports a view of the sketch, in a 2d vector format.
     export-wireframe --output <pattern> [--chord-tol <tolerance>]
         Exports a wireframe of the sketch, in a 3d vector format.
@@ -155,6 +158,21 @@ static bool RunCommand(const std::vector<std::string> args) {
         } else return false;
     };
 
+    bool bg_color = false;
+    auto ParseBgColor = [&](size_t &argn) {
+        if(argn + 1 < args.size() && (args[argn] == "--bg-color" ||
+                                      args[argn] == "-b")) {
+            argn++;
+            if(args[argn] == "on") {
+                bg_color = true;
+                return true;
+            } else if(args[argn] == "off") {
+                bg_color = false;
+                return true;
+            } else return false;
+        } else return false;
+    };
+
     unsigned width = 0, height = 0;
     if(args[1] == "thumbnail") {
         auto ParseSize = [&](size_t &argn) {
@@ -221,7 +239,8 @@ static bool RunCommand(const std::vector<std::string> args) {
             if(!(ParseInputFile(argn) ||
                  ParseOutputPattern(argn) ||
                  ParseViewDirection(argn) ||
-                 ParseChordTolerance(argn))) {
+                 ParseChordTolerance(argn) ||
+                 ParseBgColor(argn))) {
                 fprintf(stderr, "Unrecognized option '%s'.\n", args[argn].c_str());
                 return false;
             }
@@ -233,9 +252,10 @@ static bool RunCommand(const std::vector<std::string> args) {
         }
 
         runner = [&](const Platform::Path &output) {
-            SS.GW.projRight   = projRight;
-            SS.GW.projUp      = projUp;
-            SS.exportChordTol = chordTol;
+            SS.GW.projRight          = projRight;
+            SS.GW.projUp             = projUp;
+            SS.exportChordTol        = chordTol;
+            SS.exportBackgroundColor = bg_color;
 
             SS.ExportViewOrWireframeTo(output, /*exportWireframe=*/false);
         };

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -68,6 +68,8 @@ void SolveSpaceUI::Init() {
     exportOffset = settings->ThawFloat("ExportOffset", 0.0);
     // Rewrite exported colors close to white into black (assuming white bg)
     fixExportColors = settings->ThawBool("FixExportColors", true);
+    // Export background color
+    exportBackgroundColor = settings->ThawBool("ExportBackgroundColor", false);
     // Draw back faces of triangles (when mesh is leaky/self-intersecting)
     drawBackFaces = settings->ThawBool("DrawBackFaces", true);
     // Use turntable mouse navigation
@@ -245,6 +247,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeFloat("ExportOffset", exportOffset);
     // Rewrite exported colors close to white into black (assuming white bg)
     settings->FreezeBool("FixExportColors", fixExportColors);
+    // Export background color
+    settings->FreezeBool("ExportBackgroundColor", exportBackgroundColor);
     // Draw back faces of triangles (when mesh is leaky/self-intersecting)
     settings->FreezeBool("DrawBackFaces", drawBackFaces);
     // Draw closed polygons areas

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -343,6 +343,7 @@ public:
     virtual void Bezier(SBezier *sb) = 0;
     virtual void Triangle(STriangle *tr) = 0;
     virtual bool OutputConstraints(IdList<Constraint,hConstraint> *) { return false; }
+    virtual void Background(RgbaColor color) = 0;
     virtual void StartFile() = 0;
     virtual void FinishAndCloseFile() = 0;
     virtual bool HasCanvasSize() const = 0;
@@ -367,6 +368,7 @@ public:
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return false; }
@@ -384,6 +386,7 @@ public:
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return true; }
@@ -402,6 +405,7 @@ public:
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return true; }
@@ -418,6 +422,7 @@ public:
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return true; }
@@ -432,6 +437,7 @@ public:
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return false; }
@@ -445,6 +451,7 @@ class Step2dFileWriter : public VectorFileWriter {
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return false; }
@@ -459,6 +466,7 @@ public:
                     bool filled, RgbaColor fillRgb, hStyle hs) override;
     void Triangle(STriangle *tr) override;
     void Bezier(SBezier *sb) override;
+    void Background(RgbaColor color) override;
     void StartFile() override;
     void FinishAndCloseFile() override;
     bool HasCanvasSize() const override { return false; }

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -563,6 +563,7 @@ public:
     double   exportScale;
     double   exportOffset;
     bool     fixExportColors;
+    bool     exportBackgroundColor;
     bool     drawBackFaces;
     bool     showContourAreas;
     bool     checkClosedContour;

--- a/src/ui.h
+++ b/src/ui.h
@@ -429,6 +429,7 @@ public:
     static void ScreenGoToWebsite(int link, uint32_t v);
 
     static void ScreenChangeFixExportColors(int link, uint32_t v);
+    static void ScreenChangeExportBackgroundColor(int link, uint32_t v);
     static void ScreenChangeBackFaces(int link, uint32_t v);
     static void ScreenChangeShowContourAreas(int link, uint32_t v);
     static void ScreenChangeCheckClosedContour(int link, uint32_t v);


### PR DESCRIPTION
Produces non-zero diffs for EPS, PDF, and SVG:

<details>
<summary>EPS</summary>

```diff
diff --git a/no.eps b/yes.eps
index 3d6a0a9..86fcb68 100644
--- a/no.eps
+++ b/yes.eps
@@ -9,6 +9,18 @@
 
 gsave
 
+0.000 0.400 0.000 setrgbcolor
+newpath
+    0.000 0.000 moveto
+    176.882 0.000 lineto
+    176.882 159.307 lineto
+    0.000 159.307 lineto
+    closepath
+gsave fill grestore
+1 setlinejoin
+1 setlinecap
+0.177 setlinewidth
+gsave stroke grestore
 newpath
     162.709 14.173 moveto
     162.709 145.134 lineto
```

</details>

<details>
<summary>PDF</summary>

```diff
diff --git a/no.pdf b/yes.pdf
index 1a6d964..3d231c0 100644
--- a/no.pdf
+++ b/yes.pdf
@@ -30,6 +30,15 @@ endobj
 5 0 obj
   << /Length 6 0 R >>
 stream
+1 J 1 j
+0.000 0.400 0.000 RG
+0.000 0.400 0.000 rg
+0.177 w
+0.000 0.000 m
+176.882 0.000 l
+176.882 159.307 l
+0.000 159.307 l
+b
 1 J 1 j 0.344 w [] 0 d 0.000 0.000 0.000 RG
 162.709 14.173 m
 162.709 145.134 l
@@ -60,7 +69,7 @@ S
 endstream
 endobj
 6 0 obj
-  501
+  634
 endobj
 7 0 obj
   [/PDF /Text]
@@ -84,10 +93,10 @@ xref
 0000000162 00000 n
 0000000239 00000 n
 0000000457 00000 n
-0000001017 00000 n
-0000001041 00000 n
-0000001074 00000 n
-0000001213 00000 n
+0000001150 00000 n
+0000001174 00000 n
+0000001207 00000 n
+0000001346 00000 n
 
 trailer
   << /Size 10
@@ -95,5 +104,5 @@ trailer
      /Info 9 0 R
   >>
 startxref
-1256
+1389
 %%EOF
```

</details>

<details>
<summary>SVG</summary>

```diff
diff --git a/no.svg b/yes.svg
index e1cb614..bc5e698 100644
--- a/no.svg
+++ b/yes.svg
@@ -115,6 +115,7 @@ stroke-linejoin:round;
 fill:none;
 }
 ]]></style>
+<polygon points='0.000,56.200 62.400,56.200 62.400,0.000 0.000,0.000' stroke='#006600' fill='#006600'/>
 <path d='M57.400 51.200 L57.400,5.000 L5.000,5.000 L5.000,51.200 L57.400,51.200 ' class='s0' />
 <path d='M56.147 27.574 L56.470,28.545 L56.794,27.574 M30.917 50.702 L30.917,49.812 M31.483 50.702 L31.483,49.812 M30.917 50.207 L31.483,50.207 M5.606 27.574 L5.930,28.545 L6.253,27.574 M30.917 6.388 L30.917,5.418 M31.483 6.388 L31.483,5.418 M30.917 5.849 L31.483,5.849 ' class='s6' />
```

</details>

Converted to PNG with imagemagick:
EPS, no:
![no-eps](https://user-images.githubusercontent.com/6709544/77591904-50cce380-6ef1-11ea-9d7b-da5271c5ddd6.png)
EPS, yes:
![yes-eps](https://user-images.githubusercontent.com/6709544/77591905-51657a00-6ef1-11ea-8512-9fc00923b938.png)

PDF, no:
![no-pdf](https://user-images.githubusercontent.com/6709544/77591940-5de9d280-6ef1-11ea-9c69-6108c8332f51.png)
PDF, yes:
![yes-pdf](https://user-images.githubusercontent.com/6709544/77591942-5e826900-6ef1-11ea-8157-693776f607e0.png)

SVG, no:
![no-svg](https://user-images.githubusercontent.com/6709544/77592073-a7d2b880-6ef1-11ea-9f74-7da0c7e333eb.png)
SVG, yes:
![yes-svg](https://user-images.githubusercontent.com/6709544/77592075-a86b4f00-6ef1-11ea-8d97-3532591bc0a8.png)

Config GUI option name might need some bikeshedding: "export background color" isn't exactly right since it's for vector files only "export background color in vector files" maybe?

Exports tested in the GUI only due to #567, but the option gets loaded right before crashing, so it should work.

This doesn't change exporting PNGs since those are screenshots and I don't know how to make them not so/if that's viable at all.

Ref: #525