### PR TITLE
Fix segfault in Remove Spline Point context menu

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -647,7 +647,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
             int index = r->IndexOfPoint(gs.point[0]);
             if((r->type == Request::Type::CUBIC && (index > 1 && index < r->extraPoints + 2)) ||
                     r->type == Request::Type::CUBIC_PERIODIC) {
-                menu->AddItem(_("Remove Spline Point"), [&]() {
+                menu->AddItem(_("Remove Spline Point"), [this, r]() {
                     int index = r->IndexOfPoint(gs.point[0]);
                     ssassert(r->extraPoints != 0,
                              "Expected a bezier with interior control points");


### PR DESCRIPTION
This was incorrectly capturing `r` by reference and using it after it left its scope. Changed to capture by value, and also explicitly capture `this` in case we were accidentally capturing any other scope variables by reference.

Fixes #571