### PR TITLE
Add menu options for line styles / view / configuration

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -77,7 +77,9 @@ const MenuEntry Menu[] = {
 { 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
 { 1, N_("&Line Styles..."),             Command::EDIT_LINE_STYLES, 0,       KN, mEdit  },
 { 1, N_("&View Projection..."),         Command::VIEW_PROJECTION,  0,       KN, mEdit  },
+#ifndef __APPLE__
 { 1, N_("Con&figuration..."),           Command::CONFIGURATION,    0,       KN, mEdit  },
+#endif
 
 { 0, N_("&View"),                       Command::NONE,             0,       KN, mView  },
 { 1, N_("Zoom &In"),                    Command::ZOOM_IN,          '+',     KN, mView  },

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -74,6 +74,10 @@ const MenuEntry Menu[] = {
 { 1, N_("Select &Edge Chain"),          Command::SELECT_CHAIN,     C|'e',   KN, mEdit  },
 { 1, N_("Select &All"),                 Command::SELECT_ALL,       C|'a',   KN, mEdit  },
 { 1, N_("&Unselect All"),               Command::UNSELECT_ALL,     '\x1b',  KN, mEdit  },
+{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1, N_("&Line Styles"),                Command::EDIT_LINE_STYLES, 0,       KN, mEdit  },
+{ 1, N_("&View Projection"),            Command::VIEW_PROJECTION,  0,       KN, mEdit  },
+{ 1, N_("&Configuration"),              Command::CONFIGURATION,    0,       KN, mEdit  },
 
 { 0, N_("&View"),                       Command::NONE,             0,       KN, mView  },
 { 1, N_("Zoom &In"),                    Command::ZOOM_IN,          '+',     KN, mView  },
@@ -1180,6 +1184,22 @@ void GraphicsWindow::MenuEdit(Command id) {
             SS.images.clear();
             SS.ReloadAllLinked(SS.saveFile);
             SS.GenerateAll(SolveSpaceUI::Generate::UNTIL_ACTIVE);
+            SS.ScheduleShowTW();
+            break;
+
+        case Command::EDIT_LINE_STYLES:
+            SS.TW.GoToScreen(TextWindow::Screen::LIST_OF_STYLES);
+            SS.GW.ForceTextWindowShown();
+            SS.ScheduleShowTW();
+            break;
+        case Command::VIEW_PROJECTION:
+            SS.TW.GoToScreen(TextWindow::Screen::EDIT_VIEW);
+            SS.GW.ForceTextWindowShown();
+            SS.ScheduleShowTW();
+            break;
+        case Command::CONFIGURATION:
+            SS.TW.GoToScreen(TextWindow::Screen::CONFIGURATION);
+            SS.GW.ForceTextWindowShown();
             SS.ScheduleShowTW();
             break;
 

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -75,9 +75,9 @@ const MenuEntry Menu[] = {
 { 1, N_("Select &All"),                 Command::SELECT_ALL,       C|'a',   KN, mEdit  },
 { 1, N_("&Unselect All"),               Command::UNSELECT_ALL,     '\x1b',  KN, mEdit  },
 { 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
-{ 1, N_("&Line Styles"),                Command::EDIT_LINE_STYLES, 0,       KN, mEdit  },
-{ 1, N_("&View Projection"),            Command::VIEW_PROJECTION,  0,       KN, mEdit  },
-{ 1, N_("Con&figuration"),              Command::CONFIGURATION,    0,       KN, mEdit  },
+{ 1, N_("&Line Styles..."),             Command::EDIT_LINE_STYLES, 0,       KN, mEdit  },
+{ 1, N_("&View Projection..."),         Command::VIEW_PROJECTION,  0,       KN, mEdit  },
+{ 1, N_("Con&figuration..."),           Command::CONFIGURATION,    0,       KN, mEdit  },
 
 { 0, N_("&View"),                       Command::NONE,             0,       KN, mView  },
 { 1, N_("Zoom &In"),                    Command::ZOOM_IN,          '+',     KN, mView  },

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -77,7 +77,7 @@ const MenuEntry Menu[] = {
 { 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
 { 1, N_("&Line Styles"),                Command::EDIT_LINE_STYLES, 0,       KN, mEdit  },
 { 1, N_("&View Projection"),            Command::VIEW_PROJECTION,  0,       KN, mEdit  },
-{ 1, N_("&Configuration"),              Command::CONFIGURATION,    0,       KN, mEdit  },
+{ 1, N_("Con&figuration"),              Command::CONFIGURATION,    0,       KN, mEdit  },
 
 { 0, N_("&View"),                       Command::NONE,             0,       KN, mView  },
 { 1, N_("Zoom &In"),                    Command::ZOOM_IN,          '+',     KN, mView  },

--- a/src/ui.h
+++ b/src/ui.h
@@ -105,6 +105,9 @@ enum class Command : uint32_t {
     ROTATE_90,
     UNSELECT_ALL,
     REGEN_ALL,
+    EDIT_LINE_STYLES,
+    VIEW_PROJECTION,
+    CONFIGURATION,
     // Request
     SEL_WORKPLANE,
     FREE_IN_3D,


### PR DESCRIPTION
This is to make them a bit easier to find, since the natural place to look for config options is somewhere like File->Preferences or Edit->Settings. On Mac the Configuration should be under the "App" menu but I'm not sure how to do that.