### PR TITLE
snap: Use symlink instead of bind-mount for layout

### DIFF
--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ license: GPL-3.0
 
 layout:
   /usr/share/solvespace:
-    bind: $SNAP/usr/share/solvespace
+    symlink: $SNAP/usr/share/solvespace
 
 apps:
   solvespace:


### PR DESCRIPTION
As per https://snapcraft.io/docs/snap-layouts,
bind-mounts significantly increase the startup time of the snap.
Use symlink instead for better performance.