### PR TITLE
Eliminate some entity copies in lathe groups.

### DIFF
--- a/src/sketch.h
+++ b/src/sketch.h
@@ -279,10 +279,11 @@ public:
         REMAP_LATHE_END    = 1007,
         REMAP_PT_TO_ARC    = 1008,
         REMAP_PT_TO_NORMAL = 1009,
+        REMAP_LATHE_ARC_CENTER = 1010,
     };
     hEntity Remap(hEntity in, int copyNumber);
     void MakeExtrusionLines(EntityList *el, hEntity in);
-    void MakeLatheCircles(IdList<Entity,hEntity> *el, IdList<Param,hParam> *param, hEntity in, Vector pt, Vector axis, int ai);
+    void MakeLatheCircles(IdList<Entity,hEntity> *el, IdList<Param,hParam> *param, hEntity in, Vector pt, Vector axis);
     void MakeLatheSurfacesSelectable(IdList<Entity, hEntity> *el, hEntity in, Vector axis);
     void MakeExtrusionTopBottomFaces(EntityList *el, hEntity pt);
     void CopyEntity(EntityList *el,


### PR DESCRIPTION
Eliminates a crash due to copy numbers going over 1000.
May break some older files with constraints on lathed entities.