### PR TITLE
Travis: allow Snap arm64 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: c
 git:
   submodules: false
 jobs:
+  allow_failures:
+    - stage: deploy
+      name: Snap arm64
   include:
     - stage: test
       name: "Debian"


### PR DESCRIPTION
arm64 builds on Travis are not yet fully mature and this
causes a high failure rate that is not caused by our code.

Continue building and deploying arm64 to the edge channel,
but don't consider the result for the success of the whole
build job.

Alleviates #587