### PR TITLE
WIP Initial mirror groups implementation.

### DIFF
--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -86,6 +86,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::POINT_N_ROT_TRANS:
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
+        case Type::POINT_MIRROR:
         case Type::POINT_IN_3D:
         case Type::POINT_IN_2D:
             refs->push_back(PointGetNum());
@@ -96,6 +97,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::NORMAL_N_ROT_AA:
         case Type::NORMAL_IN_3D:
         case Type::NORMAL_IN_2D:
+        case Type::NORMAL_MIRROR:
         case Type::WORKPLANE:
         case Type::CIRCLE:
         case Type::ARC_OF_CIRCLE:
@@ -121,6 +123,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_MIRROR:
             break;
     }
 }
@@ -503,7 +506,8 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
         case Type::POINT_IN_3D:
-        case Type::POINT_IN_2D: {
+        case Type::POINT_IN_2D:
+        case Type::POINT_MIRROR: {
             if(how == DrawAs::HIDDEN) return;
 
             // If we're analyzing the sketch to show the degrees of freedom,
@@ -547,6 +551,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::NORMAL_N_COPY:
         case Type::NORMAL_N_ROT:
         case Type::NORMAL_N_ROT_AA:
+        case Type::NORMAL_MIRROR:
         case Type::NORMAL_IN_3D:
         case Type::NORMAL_IN_2D: {
             const Camera &camera = canvas->GetCamera();
@@ -757,6 +762,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_MIRROR:
             // Do nothing; these are drawn with the triangle mesh
             return;
     }

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -114,6 +114,7 @@ const MenuEntry Menu[] = {
 { 1, N_("&Helix"),                      Command::GROUP_HELIX,      S|'h',   KN, mGrp   },
 { 1, N_("&Lathe"),                      Command::GROUP_LATHE,      S|'l',   KN, mGrp   },
 { 1, N_("Re&volve"),                    Command::GROUP_REVOLVE,    S|'v',   KN, mGrp   },
+{ 1, N_("&Mirror"),                     Command::GROUP_MIRROR ,    S|'m',   KN, mGrp   },
 { 1, NULL,                              Command::NONE,             0,       KN, NULL   },
 { 1, N_("Link / Assemble..."),          Command::GROUP_LINK,       S|'i',   KN, mGrp   },
 { 1, N_("Link Recent"),                 Command::GROUP_RECENT,     0,       KN, mGrp   },

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -163,6 +163,23 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
             g.name = C_("group-name", "extrude");
             break;
 
+        case Command::GROUP_MIRROR:
+//            g.predef.entityB = SS.GW.ActiveWorkplane();
+/*
+            // If entities are selected we will constrain the mirror plane to them later
+            if(gs.points == 1 && gs.vectors == 1 && gs.n == 2) {
+                g.predef.origin = gs.point[0];
+                g.predef.entityB = gs.vector[0];
+            } else if(gs.lineSegments == 1 && gs.n == 1) {
+                g.predef.origin = SK.GetEntity(gs.entity[0])->point[0];
+                g.predef.entityB = gs.entity[0];
+            }
+*/
+            g.type = Type::MIRROR;
+            g.opA = SS.GW.activeGroup;
+            g.name = C_("group-name", "mirror");
+            break;
+
         case Command::GROUP_LATHE:
             if(!SS.GW.LockedInWorkplane()) {
                 Error(_("Lathe operation can only be applied to planar sketches."));
@@ -512,6 +529,36 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             return;
         }
 
+        case Type::MIRROR: {
+            Vector norm = gp.WithMagnitude(1.0);
+            AddParam(param, h.param(0), norm.x);
+            AddParam(param, h.param(1), norm.y);
+            AddParam(param, h.param(2), norm.z);
+            AddParam(param, h.param(3), 25.0);
+
+            // Get some arbitrary point in the sketch, that will be used
+            // as a reference when defining top and bottom faces.
+            // Not using range-for here because we're changing the size of entity in the loop.
+            for(i = 0; i < entity->n; i++) {
+                Entity *e = &(entity->Get(i));
+                if(e->group != opA) continue;
+
+                e->CalculateNumerical(/*forExport=*/false);
+                hEntity he = e->h;
+                // As soon as I call CopyEntity, e may become invalid! That
+                // adds entities, which may cause a realloc.
+                CopyEntity(entity, SK.GetEntity(he), 0, REMAP_BOTTOM,
+                    h.param(0), h.param(1), h.param(2),
+                    h.param(3), NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM,
+                    CopyAs::NUMERIC);
+                CopyEntity(entity, SK.GetEntity(he), 1, REMAP_TOP,
+                    h.param(0), h.param(1), h.param(2),
+                    h.param(3), NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM,
+                    CopyAs::MIRROR);
+            }
+            return;
+        }
+
         case Type::LATHE: {
             Vector axis_pos = SK.GetEntity(predef.origin)->PointGetNum();
             Vector axis_dir = SK.GetEntity(predef.entityB)->VectorGetNum();
@@ -812,6 +859,21 @@ void Group::GenerateEquations(IdList<Equation,hEquation> *l) {
             AddEq(l, u.Dot(extruden), 0);
             AddEq(l, v.Dot(extruden), 1);
         }
+    } else if(type == Type::MIRROR) {
+        // Normalize the mirror normal
+        ExprVector n = {
+            Expr::From(h.param(0)),
+            Expr::From(h.param(1)),
+            Expr::From(h.param(2)) };
+        AddEq(l, (n.Magnitude())->Minus(Expr::From(1)), 0);
+
+        if (predef.entityB != Entity::FREE_IN_3D) {
+            // to reflect in plane, mirror normal must be perpendicular to the sketch normal
+            Entity *w = SK.GetEntity(predef.entityB);
+            ExprVector u = w->Normal()->NormalExprsU();
+            ExprVector v = w->Normal()->NormalExprsV();
+            AddEq(l, (n.Dot(u.Cross(v))), 1);
+        }
     } else if(type == Type::TRANSLATE) {
         if(predef.entityB != Entity::FREE_IN_3D) {
             Entity *w = SK.GetEntity(predef.entityB);
@@ -1043,6 +1105,7 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::POINT_N_ROT_TRANS:
         case Entity::Type::POINT_N_ROT_AA:
         case Entity::Type::POINT_N_ROT_AXIS_TRANS:
+        case Entity::Type::POINT_MIRROR:
         case Entity::Type::POINT_IN_3D:
         case Entity::Type::POINT_IN_2D:
             if(as == CopyAs::N_TRANS) {
@@ -1052,6 +1115,12 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
                 en.param[2] = dz;
             } else if(as == CopyAs::NUMERIC) {
                 en.type = Entity::Type::POINT_N_COPY;
+            } else if(as == CopyAs::MIRROR) {
+                en.type = Entity::Type::POINT_MIRROR;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
             } else {
                 if(as == CopyAs::N_ROT_AA) {
                     en.type = Entity::Type::POINT_N_ROT_AA;
@@ -1077,10 +1146,17 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::NORMAL_N_COPY:
         case Entity::Type::NORMAL_N_ROT:
         case Entity::Type::NORMAL_N_ROT_AA:
+        case Entity::Type::NORMAL_MIRROR:
         case Entity::Type::NORMAL_IN_3D:
         case Entity::Type::NORMAL_IN_2D:
             if(as == CopyAs::N_TRANS || as == CopyAs::NUMERIC) {
                 en.type = Entity::Type::NORMAL_N_COPY;
+            } else if (as == CopyAs::MIRROR) {
+                en.type = Entity::Type::NORMAL_MIRROR;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
             } else {  // N_ROT_AXIS_TRANS probably doesn't warrant a new entity Type
                 if(as == CopyAs::N_ROT_AA || as == CopyAs::N_ROT_AXIS_TRANS) {
                     en.type = Entity::Type::NORMAL_N_ROT_AA;
@@ -1110,6 +1186,7 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::FACE_N_TRANS:
         case Entity::Type::FACE_N_ROT_AA:
         case Entity::Type::FACE_ROT_NORMAL_PT:
+        case Entity::Type::FACE_MIRROR:
             if(as == CopyAs::N_TRANS) {
                 en.type = Entity::Type::FACE_N_TRANS;
                 en.param[0] = dx;
@@ -1117,6 +1194,12 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
                 en.param[2] = dz;
             } else if (as == CopyAs::NUMERIC) {
                 en.type = Entity::Type::FACE_NORMAL_PT;
+            } else if (as == CopyAs::MIRROR) {
+                en.type = Entity::Type::FACE_MIRROR;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
             } else {
                 if(as == CopyAs::N_ROT_AA || as == CopyAs::N_ROT_AXIS_TRANS) {
                     en.type = Entity::Type::FACE_N_ROT_AA;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -152,6 +152,7 @@ public:
         N_ROT_AA,
         N_ROT_TRANS,
         N_ROT_AXIS_TRANS,
+        MIRROR,
     };
 
     enum class Type : uint32_t {
@@ -161,6 +162,7 @@ public:
         LATHE                         = 5101,
         REVOLVE                       = 5102,
         HELIX                         = 5103,
+        MIRROR                        = 5104,
         ROTATE                        = 5200,
         TRANSLATE                     = 5201,
         LINKED                        = 5300
@@ -312,6 +314,7 @@ public:
     void GenerateShellAndMesh();
     template<class T> void GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat);
     template<class T> void GenerateForBoolean(T *a, T *b, T *o, Group::CombineAs how);
+    template<class T> void GenerateForMirror(T *steps, T *outs, Group::CombineAs forWhat);
     void GenerateDisplayItems();
 
     enum class DrawMeshAs { DEFAULT, HOVERED, SELECTED };
@@ -392,12 +395,14 @@ public:
         POINT_N_COPY           =  2012,
         POINT_N_ROT_AA         =  2013,
         POINT_N_ROT_AXIS_TRANS =  2014,
+        POINT_MIRROR           =  2015,
 
         NORMAL_IN_3D           =  3000,
         NORMAL_IN_2D           =  3001,
         NORMAL_N_COPY          =  3010,
         NORMAL_N_ROT           =  3011,
         NORMAL_N_ROT_AA        =  3012,
+        NORMAL_MIRROR          =  3015,
 
         DISTANCE               =  4000,
         DISTANCE_N_COPY        =  4001,
@@ -408,6 +413,7 @@ public:
         FACE_N_TRANS           =  5003,
         FACE_N_ROT_AA          =  5004,
         FACE_ROT_NORMAL_PT     =  5005,
+        FACE_MIRROR            =  5006,
 
         WORKPLANE              = 10000,
         LINE_SEGMENT           = 11000,

--- a/src/ui.h
+++ b/src/ui.h
@@ -130,6 +130,7 @@ enum class Command : uint32_t {
     GROUP_EXTRUDE,
     GROUP_HELIX,
     GROUP_LATHE,
+    GROUP_MIRROR,
     GROUP_REVOLVE,
     GROUP_ROT,
     GROUP_TRANS,


### PR DESCRIPTION
WIP so this isn't ready. I am looking for some help.

This implements mirror groups (SHIFT-M) which can be a sketch or a solid. It creates a non-visible mirror plane between the original and copy of the sketch/model. In 3D you get 3DoF. In 2D it constrains the mirror to be orthogonal to the sketch plane so only 2DoF. That's what works. What I'd like help with is the following:

1) Faces of the solid are not selectable for either the original or copy.

2) After mirroring a 2D sketch, you can't extrude the resulting 2D entities.

3) In 2D I'd like to optionally select 2 points or a point-and-vector to constrain the mirror plane. Not sure where or how to store the selection information for use later when constraints on the mirror are created.

4) Same issue as #3 but for 3D. I'd like to be able to select a face and constrain the mirror plane to that. Optionally if one is selected when the group is created.

I don't think it wise to merge this until these issues are resolved. Any advice or code would be appreciated. Oh, or comments on how it should be done differently.