### PR TITLE
No message if cached points to don't converge. Quiet the terminal.

### DIFF
--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -436,6 +436,13 @@ void SSurface::ClosestPointTo(Vector p, double *u, double *v, bool mustConverge)
     }
 
     // If we failed to converge, then at least don't return NaN.
+    if(mustConverge) {
+        Vector p0 = PointAt(*u, *v);
+        dbp("didn't converge");
+        dbp("have %.3f %.3f %.3f", CO(p0));
+        dbp("want %.3f %.3f %.3f", CO(p));
+        dbp("distance = %g", (p.Minus(p0)).Magnitude());
+    }
     if(isnan(*u) || isnan(*v)) {
         *u = *v = 0;
     }
@@ -477,12 +484,6 @@ bool SSurface::ClosestPointNewton(Vector p, double *u, double *v, bool mustConve
 
     }
 
-    if(mustConverge) {
-        dbp("didn't converge");
-        dbp("have %.3f %.3f %.3f", CO(p0));
-        dbp("want %.3f %.3f %.3f", CO(p));
-        dbp("distance = %g", (p.Minus(p0)).Magnitude());
-    }
     return false;
 }
 


### PR DESCRIPTION
Don't report failed convergence when using cached U,V from ClosestPointTo. Add a separate message for when all efforts fail to converge.