### PR TITLE
 Improve triangle mesh (splitting of quads based on angle).

### DIFF
--- a/src/srf/triangulate.cpp
+++ b/src/srf/triangulate.cpp
@@ -482,7 +482,11 @@ void SPolygon::UvGridTriangulateInto(SMesh *mesh, SSurface *srf) {
                 if (this_flag) {
                     // Add the quad to our mesh
                     srf->TangentsAt(us,vs, &tu,&tv);
-                    if (tu.Dot(tv) < 0.0) {  //split the other way if angle>90
+                    if(tu.Dot(tv) < LENGTH_EPS) {
+                        /* Split "the other way" if angle>90
+                           compare to LENGTH_EPS instead of zero to avoid alternating triangle
+                           "orientations" when the tangents are orthogonal (revolve, lathe etc.)
+                           this results in a higher quality mesh. */
                         STriangle tr = {};
                         tr.a = a;
                         tr.b = b;


### PR DESCRIPTION
When checking the dot product of the tangents `tu` and `tv` to decide in which direction to split a quad compare it to to `LENGTH_EPS` instead of zero to avoid alternating triangle "orientations" when the tangents are orthogonal (revolve, lathe etc.). This improves the quality of the resulting triangle mesh.
Before:
![QadSplitOriginal](https://user-images.githubusercontent.com/15338069/81748467-9732cd80-94b2-11ea-8d36-5b2bae7783e0.png)
After:
![QadSplitImprove](https://user-images.githubusercontent.com/15338069/81748501-a580e980-94b2-11ea-8283-1f8e03f58b8b.png)

Model:
[LatheSpline.zip](https://github.com/solvespace/solvespace/files/4618604/LatheSpline.zip)
