### PR TITLE
Better helical triangulation #489 and #550 fixed.

### DIFF
--- a/src/srf/surface.cpp
+++ b/src/srf/surface.cpp
@@ -746,7 +746,9 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
                     sc         = {};
                     sc.isExact = true;
                     sc.exact   = sb->TransformedBy(ts, qs, 1.0);
-                    (sc.exact).MakePwlInto(&(sc.pts));
+                    double max_dt = 0.5;
+                    if (sc.exact.deg > 1) max_dt = 0.25;
+                    (sc.exact).MakePwlInto(&(sc.pts), 0.0, max_dt);
 
                     // the surfaces already exist so trim with this curve
                     if(j < sections) {
@@ -771,7 +773,9 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
                     sc         = {};
                     sc.isExact = true;
                     sc.exact   = sb->TransformedBy(ts, qs, 1.0);
-                    (sc.exact).MakePwlInto(&(sc.pts));
+                    double max_dt = 0.5;
+                    if (sc.exact.deg > 1) max_dt = 0.25;
+                    (sc.exact).MakePwlInto(&(sc.pts), 0.0, max_dt);
                     sc.surfA    = hs1; // end cap
                     sc.surfB    = hs0; // staring cap
                     hSCurve hcb = curve.AddAndAssignId(&sc);
@@ -793,7 +797,9 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
                     sc.isExact = true;
                     sc.exact   = SBezier::From(ss->ctrl[0][0], ss->ctrl[0][1], ss->ctrl[0][2]);
                     sc.exact.weight[1] = ss->weight[0][1];
-                    (sc.exact).MakePwlInto(&(sc.pts));
+                    double max_dt = 0.5;
+                    if (sc.exact.deg > 1) max_dt = 0.125;
+                    (sc.exact).MakePwlInto(&(sc.pts), 0.0, max_dt);
                     sc.surfA = revs[j];
                     sc.surfB = revsp[j];
 

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -92,12 +92,12 @@ public:
     Vector Start() const;
     Vector Finish() const;
     bool Equals(SBezier *b) const;
-    void MakePwlInto(SEdgeList *sel, double chordTol=0) const;
-    void MakePwlInto(List<SCurvePt> *l, double chordTol=0) const;
-    void MakePwlInto(SContour *sc, double chordTol=0) const;
-    void MakePwlInto(List<Vector> *l, double chordTol=0) const;
-    void MakePwlWorker(List<Vector> *l, double ta, double tb, double chordTol) const;
-    void MakePwlInitialWorker(List<Vector> *l, double ta, double tb, double chordTol) const;
+    void MakePwlInto(SEdgeList *sel, double chordTol=0, double max_dt=0.0) const;
+    void MakePwlInto(List<SCurvePt> *l, double chordTol=0, double max_dt=0.0) const;
+    void MakePwlInto(SContour *sc, double chordTol=0, double max_dt=0.0) const;
+    void MakePwlInto(List<Vector> *l, double chordTol=0, double max_dt=0.0) const;
+    void MakePwlWorker(List<Vector> *l, double ta, double tb, double chordTol, double max_dt) const;
+    void MakePwlInitialWorker(List<Vector> *l, double ta, double tb, double chordTol, double max_dt) const;
     void MakeNonrationalCubicInto(SBezierList *bl, double tolerance, int depth = 0) const;
 
     void AllIntersectionsWith(const SBezier *sbb, SPointList *spl) const;
@@ -362,8 +362,9 @@ public:
     void MakeClassifyingBsp(SShell *shell, SShell *useCurvesFrom);
     double ChordToleranceForEdge(Vector a, Vector b) const;
     void MakeTriangulationGridInto(List<double> *l, double vs, double vf,
-                                    bool swapped) const;
+                                    bool swapped, int depth) const;
     Vector PointAtMaybeSwapped(double u, double v, bool swapped) const;
+    Vector NormalAtMaybeSwapped(double u, double v, bool swapped) const;
 
     void Reverse();
     void Clear();


### PR DESCRIPTION
…4 segments and forcing grid triangulation to use a minimum of 4x4 quads. This helps with issue #489. Also add a max_dt parameter for PWL creation and use that for helical edges.