### PR TITLE
WIP:  Triangle Fans

### DIFF
--- a/src/polygon.h
+++ b/src/polygon.h
@@ -131,6 +131,7 @@ public:
     void FindPointWithMinX();
     Vector AnyEdgeMidpoint() const;
 
+    bool IsEmptyTriangle(int ap, int bp, int cp, double scaledEPS) const;
     bool IsEar(int bp, double scaledEps) const;
     bool BridgeToContour(SContour *sc, SEdgeList *el, List<Vector> *vl);
     void ClipEarInto(SMesh *m, int bp, double scaledEps);


### PR DESCRIPTION
This is still experimental. I noticed that ear triangulation calls RemoveTagged() for every ear and that function scans (copies?) the entire list of verticies. It also has to check IsEar() for the adjacent verticies afterward. I figured we can make a pass looking for chains of ears that form a sort of meta-ear and triangulate that independently, and only make one call to RemoveTagged() to dispose all those ears. This runs prior to the existing triangulation code (and only for flat surfaces) so it might be faster overall for very complex surfaces. It does tend to make better-formed triangles.

Still some bugs and odd cases to figure out.
The logic is not clear yet.
Haven't proven any practical benefit like speed improvement.

One odd thing I did notice. If you look at the mesh for a circle it can look less round when showing the triangles. It's not, but your eyes can trick you due to the structured lines.