### PR TITLE
Fix #647 Helix mesh defects.

### DIFF
--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -817,7 +817,7 @@ void SCurve::RemoveShortSegments(SSurface *srfA, SSurface *srfB) {
             continue;
         }
 
-        // if the curve is exact and points are >0.1 appart wrt t, point is there
+        // if the curve is exact and points are >0.05 appart wrt t, point is there
         // deliberately regardless of chord tolerance (ex: small circles)
         tprev = t = tnext = 0;
         if (isExact) {
@@ -825,7 +825,7 @@ void SCurve::RemoveShortSegments(SSurface *srfA, SSurface *srfB) {
             exact.ClosestPointTo(sct->p, &t, /*mustconverge=*/ true);
             exact.ClosestPointTo(scn->p, &tnext, /*mustconverge=*/ true);
         }
-        if ( (t - tprev > 0.1) && (tnext - t > 0.1) ) {
+        if ( (t - tprev > 0.05) && (tnext - t > 0.05) ) {
             prev = sct->p;
             continue;
         }

--- a/src/srf/triangulate.cpp
+++ b/src/srf/triangulate.cpp
@@ -429,7 +429,7 @@ void SSurface::MakeTriangulationGridInto(List<double> *l, double vs, double vf,
 
     double step = 1.0/SS.GetMaxSegments();
     if( ((vf - vs) < step || worst < SS.ChordTolMm())
-        && ((worst_twist > 0.999) || (depth > 4)) ) {
+        && ((worst_twist > 0.999) || (depth > 3)) ) {
         l->Add(&vf);
     } else {
         MakeTriangulationGridInto(l, vs, (vs+vf)/2, swapped, depth+1);


### PR DESCRIPTION
Use the grid spacing algorithm for helical curve PWL creation.
This makes the grid and trim curves have similar spacing.