### PR TITLE
Implement #524 Allow flat colors. Adds an edit control for Ambient li…

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -18,6 +18,12 @@ void TextWindow::ScreenChangeLightIntensity(int link, uint32_t v) {
     SS.TW.edit.i = v;
 }
 
+void TextWindow::ScreenChangeLightAmbient(int link, uint32_t v) {
+    SS.TW.ShowEditControl(31, ssprintf("%.2f", SS.ambientIntensity));
+    SS.TW.edit.meaning = Edit::LIGHT_AMBIENT;
+    SS.TW.edit.i = 0;
+}
+
 void TextWindow::ScreenChangeColor(int link, uint32_t v) {
     SS.TW.ShowEditControlWithColorPicker(13, SS.modelColor[v]);
 
@@ -218,6 +224,10 @@ void TextWindow::ShowConfiguration() {
             CO(SS.lightDir[i]), i, &ScreenChangeLightDirection,
             SS.lightIntensity[i], i, &ScreenChangeLightIntensity);
     }
+    Printf(false, "%Bp         ambient lighting     "
+                  "%2 %Fl%D%f%Ll[c]%E",
+            (i & 1) ? 'd' : 'a', i,
+        SS.ambientIntensity, &ScreenChangeLightAmbient);
 
     Printf(false, "");
     Printf(false, "%Ft chord tolerance (in percents)%E");
@@ -371,7 +381,10 @@ bool TextWindow::EditControlDoneForConfiguration(const std::string &s) {
             SS.lightIntensity[edit.i] = min(1.0, max(0.0, atof(s.c_str())));
             SS.GW.Invalidate();
             break;
-
+        case Edit::LIGHT_AMBIENT:
+            SS.ambientIntensity = min(1.0, max(0.0, atof(s.c_str())));
+            SS.GW.Invalidate();
+            break;
         case Edit::LIGHT_DIRECTION: {
             double x, y, z;
             if(sscanf(s.c_str(), "%lf, %lf, %lf", &x, &y, &z)==3) {

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -33,7 +33,7 @@ void SolveSpaceUI::Init() {
     // Light intensities
     lightIntensity[0] = settings->ThawFloat("LightIntensity_0", 1.0);
     lightIntensity[1] = settings->ThawFloat("LightIntensity_1", 0.5);
-    ambientIntensity = 0.3; // no setting for that yet
+    ambientIntensity = settings->ThawFloat("Light_Ambient", 0.3);
     // Light positions
     lightDir[0].x = settings->ThawFloat("LightDir_0_Right",   -1.0);
     lightDir[0].y = settings->ThawFloat("LightDir_0_Up",       1.0);
@@ -213,6 +213,7 @@ void SolveSpaceUI::Exit() {
     // Light intensities
     settings->FreezeFloat("LightIntensity_0", (float)lightIntensity[0]);
     settings->FreezeFloat("LightIntensity_1", (float)lightIntensity[1]);
+    settings->FreezeFloat("Light_Ambient", (float)ambientIntensity);
     // Light directions
     settings->FreezeFloat("LightDir_0_Right",   (float)lightDir[0].x);
     settings->FreezeFloat("LightDir_0_Up",      (float)lightDir[0].y);

--- a/src/ui.h
+++ b/src/ui.h
@@ -315,6 +315,7 @@ public:
         G_CODE_FEED           = 114,
         G_CODE_PLUNGE_FEED    = 115,
         AUTOSAVE_INTERVAL     = 116,
+        LIGHT_AMBIENT         = 117,
         // For TTF text
         TTF_TEXT              = 300,
         // For the step dimension screen
@@ -467,6 +468,7 @@ public:
     static void ScreenChangeGroupScale(int link, uint32_t v);
     static void ScreenChangeLightDirection(int link, uint32_t v);
     static void ScreenChangeLightIntensity(int link, uint32_t v);
+    static void ScreenChangeLightAmbient(int link, uint32_t v);
     static void ScreenChangeColor(int link, uint32_t v);
     static void ScreenChangeChordTolerance(int link, uint32_t v);
     static void ScreenChangeMaxSegments(int link, uint32_t v);


### PR DESCRIPTION
@whitequark  can you have a look at the text window code here? The change[c] link isn't working.

When that's fixed we should be able to turn off the 2 directional lights (set intensity to 0) and turn up ambient to 1 to get flat colors.