### PR TITLE
Fix issue659 - Problems constraining to ends of Helix.

### DIFF
--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -121,6 +121,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_N_ROT_AXIS_TRANS:
             break;
     }
 }
@@ -757,6 +758,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_N_ROT_AXIS_TRANS:
             // Do nothing; these are drawn with the triangle mesh
             return;
     }

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -702,6 +702,7 @@ bool EntityBase::IsFace() const {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_N_ROT_AXIS_TRANS:
             return true;
         default:
             return false;
@@ -774,6 +775,15 @@ ExprVector EntityBase::FaceGetPointExprs() const {
         r = ExprVector::From(numPoint);
         r = q.Rotate(r);
         r = r.Plus(trans);
+    } else if(type == Type::FACE_N_ROT_AXIS_TRANS) {
+            ExprVector orig = ExprVector::From(numPoint);
+            ExprVector trans = ExprVector::From(param[0], param[1], param[2]);
+            ExprVector displace = ExprVector::From(param[4], param[5], param[6])
+               .WithMagnitude(Expr::From(param[7])).ScaledBy(Expr::From(timesApplied));
+            ExprQuaternion q = GetAxisAngleQuaternionExprs(3);
+            orig = orig.Minus(trans);
+            orig = q.Rotate(orig);
+            r = orig.Plus(trans).Plus(displace);
     } else if(type == Type::FACE_N_TRANS) {
         ExprVector trans = ExprVector::From(param[0], param[1], param[2]);
         r = ExprVector::From(numPoint);
@@ -801,6 +811,14 @@ Vector EntityBase::FaceGetPointNum() const {
         Quaternion q = Quaternion::From(param[3], param[4], param[5], param[6]);
         r = q.Rotate(numPoint);
         r = r.Plus(trans);
+    } else if(type == Type::FACE_N_ROT_AXIS_TRANS) {
+            Vector offset = Vector::From(param[0], param[1], param[2]);
+            Vector displace = Vector::From(param[4], param[5], param[6])
+               .WithMagnitude(SK.GetParam(param[7])->val).ScaledBy(timesApplied);
+            Quaternion q = PointGetQuaternion();
+            r = numPoint.Minus(offset);
+            r = q.Rotate(r);
+            r = r.Plus(offset).Plus(displace);
     } else if(type == Type::FACE_N_TRANS) {
         Vector trans = Vector::From(param[0], param[1], param[2]);
         r = numPoint.Plus(trans.ScaledBy(timesApplied));

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1113,6 +1113,7 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::FACE_N_TRANS:
         case Entity::Type::FACE_N_ROT_AA:
         case Entity::Type::FACE_ROT_NORMAL_PT:
+        case Entity::Type::FACE_N_ROT_AXIS_TRANS:
             if(as == CopyAs::N_TRANS) {
                 en.type = Entity::Type::FACE_N_TRANS;
                 en.param[0] = dx;
@@ -1120,8 +1121,18 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
                 en.param[2] = dz;
             } else if (as == CopyAs::NUMERIC) {
                 en.type = Entity::Type::FACE_NORMAL_PT;
+            } else if (as == CopyAs::N_ROT_AXIS_TRANS) {
+                en.type = Entity::Type::FACE_N_ROT_AXIS_TRANS;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
+                en.param[4] = qvx;
+                en.param[5] = qvy;
+                en.param[6] = qvz;
+                en.param[7] = dist;
             } else {
-                if(as == CopyAs::N_ROT_AA || as == CopyAs::N_ROT_AXIS_TRANS) {
+                if(as == CopyAs::N_ROT_AA) {
                     en.type = Entity::Type::FACE_N_ROT_AA;
                 } else {
                     en.type = Entity::Type::FACE_N_ROT_TRANS;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -409,6 +409,7 @@ public:
         FACE_N_TRANS           =  5003,
         FACE_N_ROT_AA          =  5004,
         FACE_ROT_NORMAL_PT     =  5005,
+        FACE_N_ROT_AXIS_TRANS  =  5006,
 
         WORKPLANE              = 10000,
         LINE_SEGMENT           = 11000,

--- a/src/srf/surface.cpp
+++ b/src/srf/surface.cpp
@@ -648,12 +648,14 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
     double dist  = distf - dists;
     int sections = (int)(fabs(anglef - angles) / (PI / 2) + 1);
     double wedge = (anglef - angles) / sections;
+    int startMapping = Group::REMAP_LATHE_START, endMapping = Group::REMAP_LATHE_END;
 
     if(CheckNormalAxisRelationship(sbls, pt, axis, anglef-angles, distf-dists)) {
         swap(angles, anglef);
         swap(dists, distf);
         dist  = -dist;
         wedge = -wedge;
+        swap(startMapping, endMapping);
     }
 
     // Define a coordinate system to contain the original sketch, and get
@@ -678,7 +680,7 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
                              u.RotatedAbout(axis, angles), v.RotatedAbout(axis, angles));
     s0.color = color;
 
-    hEntity face0 = group->Remap(Entity::NO_ENTITY, Group::REMAP_LATHE_START);
+    hEntity face0 = group->Remap(Entity::NO_ENTITY, startMapping);
     s0.face = face0.v;
 
     s1 = SSurface::FromPlane(
@@ -686,7 +688,7 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
         u.ScaledBy(-1).RotatedAbout(axis, anglef), v.RotatedAbout(axis, anglef));
     s1.color = color;
 
-    hEntity face1 = group->Remap(Entity::NO_ENTITY, Group::REMAP_LATHE_END);
+    hEntity face1 = group->Remap(Entity::NO_ENTITY, endMapping);
     s1.face = face1.v;
 
     hSSurface hs0 = surface.AddAndAssignId(&s0);


### PR DESCRIPTION
Create a new copy type for faces that includes the translation aspect of helical extrusions. Also swap the end remappings when the shell is inside out - this was also affecting some Revolve extrusions.