### PR TITLE
Improve text screens for selected constraint and entity

### DIFF
--- a/src/constrainteq.cpp
+++ b/src/constrainteq.cpp
@@ -28,6 +28,50 @@ bool ConstraintBase::HasLabel() const {
     }
 }
 
+bool ConstraintBase::IsProjectible() const {
+    switch(type) {
+        case Type::POINTS_COINCIDENT:
+        case Type::PT_PT_DISTANCE:
+        case Type::PT_LINE_DISTANCE:
+        case Type::PT_ON_LINE:
+        case Type::EQUAL_LENGTH_LINES:
+        case Type::EQ_LEN_PT_LINE_D:
+        case Type::EQ_PT_LN_DISTANCES:
+        case Type::EQUAL_ANGLE:
+        case Type::LENGTH_RATIO:
+        case Type::LENGTH_DIFFERENCE:
+        case Type::SYMMETRIC:
+        case Type::SYMMETRIC_HORIZ:
+        case Type::SYMMETRIC_VERT:
+        case Type::SYMMETRIC_LINE:
+        case Type::AT_MIDPOINT:
+        case Type::HORIZONTAL:
+        case Type::VERTICAL:
+        case Type::ANGLE:
+        case Type::PARALLEL:
+        case Type::PERPENDICULAR:
+        case Type::WHERE_DRAGGED:
+        case Type::COMMENT:
+            return true;
+
+        case Type::PT_PLANE_DISTANCE:
+        case Type::PT_FACE_DISTANCE:
+        case Type::PROJ_PT_DISTANCE:
+        case Type::PT_IN_PLANE:
+        case Type::PT_ON_FACE:
+        case Type::EQUAL_LINE_ARC_LEN:
+        case Type::DIAMETER:
+        case Type::PT_ON_CIRCLE:
+        case Type::SAME_ORIENTATION:
+        case Type::CUBIC_LINE_TANGENT:
+        case Type::CURVE_CURVE_TANGENT:
+        case Type::ARC_LINE_TANGENT:
+        case Type::EQUAL_RADIUS:
+            return false;
+    }
+    ssassert(false, "Impossible");
+}
+
 ExprVector ConstraintBase::VectorsParallel3d(ExprVector a, ExprVector b, hParam p) {
     return a.Minus(b.ScaledBy(Expr::From(p)));
 }

--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -221,52 +221,96 @@ void TextWindow::DescribeSelection() {
                 break;
         }
 
-        Group *g = SK.GetGroup(e->group);
         Printf(false, "");
-        Printf(false, "%FtIN GROUP%E      %s", g->DescriptionString().c_str());
+        if(e->h.isFromRequest()) {
+            Request *r = SK.GetRequest(e->h.request());
+            if(e->h == r->h.entity(0)) {
+                Printf(false, "%FtFROM REQUEST%E  %s",
+                    r->DescriptionString().c_str());
+            } else {
+                Printf(false, "%FtFROM REQUEST%E  %Fl%Ll%D%f%h%s%E",
+                    r->h.v, (&TextWindow::ScreenSelectRequest), &(TextWindow::ScreenHoverRequest),
+                    r->DescriptionString().c_str());
+            }
+        }
+        Group *g = SK.GetGroup(e->group);
+        Printf(false, "%FtIN GROUP%E      %Fl%Ll%D%f%s%E",
+            g->h.v, (&TextWindow::ScreenSelectGroup),
+            g->DescriptionString().c_str());
         if(e->workplane == Entity::FREE_IN_3D) {
             Printf(false, "%FtNOT LOCKED IN WORKPLANE%E");
         } else {
             Entity *w = SK.GetEntity(e->workplane);
-            Printf(false, "%FtIN WORKPLANE%E  %s", w->DescriptionString().c_str());
+            if(w->h.isFromRequest()) {
+                Printf(false, "%FtIN WORKPLANE%E  %Fl%Ll%D%f%h%s%E",
+                    w->h.request().v,
+                    (&TextWindow::ScreenSelectRequest), &(TextWindow::ScreenHoverRequest),
+                    w->DescriptionString().c_str());
+            } else {
+                Printf(false, "%FtIN WORKPLANE%E  %Fl%Ll%D%f%h%s%E",
+                    w->h.group().v,
+                    (&TextWindow::ScreenSelectGroup), (&TextWindow::ScreenHoverGroupWorkplane),
+                    w->DescriptionString().c_str());
+            }
         }
-        if(e->style.v) {
-            Style *s = Style::Get(e->style);
-            Printf(false, "%FtIN STYLE%E      %s", s->DescriptionString().c_str());
-        } else {
-            Printf(false, "%FtIN STYLE%E      none");
+        if(e->IsStylable()) {
+            if(e->style.v) {
+                Style *s = Style::Get(e->style);
+                Printf(false, "%FtIN STYLE%E      %Fl%Ll%D%f%s%E",
+                    s->h.v, (&TextWindow::ScreenShowStyleInfo),
+                    s->DescriptionString().c_str());
+            } else {
+                Printf(false, "%FtIN STYLE%E      none");
+            }
         }
         if(e->construction) {
             Printf(false, "%FtCONSTRUCTION");
         }
 
         std::vector<hConstraint> lhc = {};
-        for(const Constraint &c : SK.constraint) {
-            if(!(c.ptA == e->h ||
-                 c.ptB == e->h ||
-                 c.entityA == e->h ||
-                 c.entityB == e->h ||
-                 c.entityC == e->h ||
-                 c.entityD == e->h))
-                continue;
-            lhc.push_back(c.h);
+        auto FindConstraints = [&](hEntity he) {
+            for(const Constraint &c : SK.constraint) {
+                if(!(c.ptA == he || c.ptB == he ||
+                     c.entityA == he || c.entityB == he || c.entityC == he || c.entityD == he))
+                    continue;
+                lhc.push_back(c.h);
+            }
+        };
+        FindConstraints(e->h);
+        if(!e->IsPoint()) {
+            for(int i = 0; i < MAX_POINTS_IN_ENTITY; i++) {
+                if(e->point[i].v == 0) break;
+                FindConstraints(e->point[i]);
+            }
         }
 
-        if(!lhc.empty()) {
-            Printf(true, "%FtCONSTRAINED BY:%E");
+        std::sort(lhc.begin(), lhc.end());
+        lhc.erase(std::unique(lhc.begin(), lhc.end()), lhc.end());
 
+        auto ListConstraints = [&](bool reference) {
+            bool first = true;
             int a = 0;
             for(hConstraint hc : lhc) {
                 Constraint *c = SK.GetConstraint(hc);
-                std::string s = c->DescriptionString();
-                Printf(false, "%Bp   %Fl%Ll%D%f%h%s%E %s",
+                if(c->reference != reference) continue;
+                if(first) {
+                    first = false;
+                    if(reference) {
+                        Printf(true, "%FtMEASURED BY:%E");
+                    } else {
+                        Printf(true, "%FtCONSTRAINED BY:%E");
+                    }
+                }
+                Printf(false, "%Bp   %Fl%Ll%D%f%h%s%E",
                     (a & 1) ? 'd' : 'a',
                     c->h.v, (&TextWindow::ScreenSelectConstraint),
-                    (&TextWindow::ScreenHoverConstraint), s.c_str(),
-                    c->reference ? "(ref)" : "");
+                    (&TextWindow::ScreenHoverConstraint),
+                    c->DescriptionString().c_str());
                 a++;
             }
-        }
+        };
+        ListConstraints(/*reference=*/false);
+        ListConstraints(/*reference=*/true);
     } else if(gs.n == 2 && gs.points == 2) {
         Printf(false, "%FtTWO POINTS");
         Vector p0 = SK.GetEntity(gs.point[0])->PointGetNum();

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -703,6 +703,7 @@ public:
     }
 
     bool HasLabel() const;
+    bool IsProjectible() const;
 
     void Generate(IdList<Param, hParam> *param);
 

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -375,6 +375,7 @@ void TextWindow::ScreenShowListOfStyles(int link, uint32_t v) {
     SS.TW.GoToScreen(Screen::LIST_OF_STYLES);
 }
 void TextWindow::ScreenShowStyleInfo(int link, uint32_t v) {
+    GraphicsWindow::MenuEdit(Command::UNSELECT_ALL);
     SS.TW.GoToScreen(Screen::STYLE_INFO);
     SS.TW.shown.style.v = v;
 }

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -44,6 +44,7 @@ void TextWindow::ShowHeader(bool withNav) {
 // to hide or show them, and to view them in detail. This is our home page.
 //-----------------------------------------------------------------------------
 void TextWindow::ScreenSelectGroup(int link, uint32_t v) {
+    GraphicsWindow::MenuEdit(Command::UNSELECT_ALL);
     SS.TW.GoToScreen(Screen::GROUP_INFO);
     SS.TW.shown.group.v = v;
 }
@@ -167,12 +168,16 @@ void TextWindow::ShowListOfGroups() {
 // The screen that shows information about a specific group, and allows the
 // user to edit various things about it.
 //-----------------------------------------------------------------------------
-void TextWindow::ScreenHoverConstraint(int link, uint32_t v) {
-    if(!SS.GW.showConstraints) return;
-
-    hConstraint hc = { v };
+void TextWindow::ScreenHoverGroupWorkplane(int link, uint32_t v) {
     SS.GW.hover.Clear();
-    SS.GW.hover.constraint = hc;
+    hGroup hg = { v };
+    SS.GW.hover.entity = hg.entity(0);
+    SS.GW.hover.emphasized = true;
+}
+void TextWindow::ScreenHoverEntity(int link, uint32_t v) {
+    SS.GW.hover.Clear();
+    hEntity he = { v };
+    SS.GW.hover.entity = he;
     SS.GW.hover.emphasized = true;
 }
 void TextWindow::ScreenHoverRequest(int link, uint32_t v) {
@@ -181,10 +186,19 @@ void TextWindow::ScreenHoverRequest(int link, uint32_t v) {
     SS.GW.hover.entity = hr.entity(0);
     SS.GW.hover.emphasized = true;
 }
-void TextWindow::ScreenSelectConstraint(int link, uint32_t v) {
+void TextWindow::ScreenHoverConstraint(int link, uint32_t v) {
+    if(!SS.GW.showConstraints) return;
+
+    hConstraint hc = { v };
+    SS.GW.hover.Clear();
+    SS.GW.hover.constraint = hc;
+    SS.GW.hover.emphasized = true;
+}
+void TextWindow::ScreenSelectEntity(int link, uint32_t v) {
     SS.GW.ClearSelection();
     GraphicsWindow::Selection sel = {};
-    sel.constraint.v = v;
+    hEntity he = { v };
+    sel.entity = he;
     SS.GW.selection.Add(&sel);
 }
 void TextWindow::ScreenSelectRequest(int link, uint32_t v) {
@@ -192,6 +206,12 @@ void TextWindow::ScreenSelectRequest(int link, uint32_t v) {
     GraphicsWindow::Selection sel = {};
     hRequest hr = { v };
     sel.entity = hr.entity(0);
+    SS.GW.selection.Add(&sel);
+}
+void TextWindow::ScreenSelectConstraint(int link, uint32_t v) {
+    SS.GW.ClearSelection();
+    GraphicsWindow::Selection sel = {};
+    sel.constraint.v = v;
     SS.GW.selection.Add(&sel);
 }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -397,6 +397,7 @@ public:
     static void ScreenUnselectAll(int link, uint32_t v);
 
     // when we're describing a constraint
+    static void ScreenConstraintToggleReference(int link, uint32_t v);
     static void ScreenConstraintShowAsRadius(int link, uint32_t v);
 
     // and the rest from the stuff in textscreens.cpp

--- a/src/ui.h
+++ b/src/ui.h
@@ -408,9 +408,12 @@ public:
     static void ScreenShowGroupsSpecial(int link, uint32_t v);
     static void ScreenDeleteGroup(int link, uint32_t v);
 
-    static void ScreenHoverConstraint(int link, uint32_t v);
+    static void ScreenHoverGroupWorkplane(int link, uint32_t v);
     static void ScreenHoverRequest(int link, uint32_t v);
+    static void ScreenHoverEntity(int link, uint32_t v);
+    static void ScreenHoverConstraint(int link, uint32_t v);
     static void ScreenSelectRequest(int link, uint32_t v);
+    static void ScreenSelectEntity(int link, uint32_t v);
     static void ScreenSelectConstraint(int link, uint32_t v);
 
     static void ScreenChangeGroupOption(int link, uint32_t v);


### PR DESCRIPTION
Improve text screen for a selected constraint:
  * Show the type of a constraint.
  * Show the workplane a constraint is in, for constraints which can be both projected to workplane or be free in 3d space.
  * Clearly distinguish reference from non-reference constraints.
  * Add a checkbox for toggling the reference option.
  * When showing requests a constraint applies to, highlight on hover the specific entity being constrained, not just the first one.

Improve text screen for a selected entity:
  * Add a link to its request, unless it's the first entity in that request (which would just select the same entity again).
  * Add a link to its group.
  * Add a link to its workplane.
  * Add a link to its style; and hide the style row for entities that aren't stylable.
  * Show constraints and measurements (reference constraints) in separate lists.
  * For curve entities, show constraints that apply to the points related to the curve, not just to the curve itself.

![Screenshot_20200730_094122](https://user-images.githubusercontent.com/54771/88907986-d4546380-d248-11ea-93fb-d064668ed4e1.png)
