### PR TITLE
NURBS boolean improvement.

### DIFF
--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -88,8 +88,15 @@ SCurve SCurve::MakeCopySplitAgainst(SShell *agnstA, SShell *agnstB,
                     }
                 }
 
-                // We're keeping the intersection, so actually refine it.
-                (pi->srf)->PointOnSurfaces(srfA, srfB, &(puv.x), &(puv.y));
+                // We're keeping the intersection, so actually refine it. Finding the intersection
+                // to within EPS is important to match the ends of different chopped trim curves.
+                // The general 3-surface intersection fails to refine for trims where surfaces
+                // are tangent at the curve, but those trims are usually exact, so…
+                if(isExact) {
+                    (pi->srf)->PointOnCurve(&exact, &(puv.x), &(puv.y));
+                } else {
+                    (pi->srf)->PointOnSurfaces(srfA, srfB, &(puv.x), &(puv.y));
+                }
                 pi->p = (pi->srf)->PointAt(puv);
             }
             il.RemoveTagged();

--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -634,3 +634,58 @@ void SSurface::PointOnSurfaces(SSurface *s1, SSurface *s2, double *up, double *v
     dbp("didn't converge (three surfaces intersecting)");
 }
 
+void SSurface::PointOnCurve(const SBezier *curve, double *up, double *vp)
+{
+    Vector tu,tv,n;
+    double u = *up, v = *vp;
+    Vector ps = PointAt(u, v);
+    // Get initial guesses for t on the curve
+    double tCurve = 0.5;
+    curve->ClosestPointTo(ps, &tCurve, /*mustConverge=*/false);
+    if(tCurve < 0.0) tCurve = 0.0;
+    if(tCurve > 1.0) tCurve = 1.0;
+
+    for(int i = 0; i < 30; i++) {
+        // Approximate the surface by a plane
+        Vector ps = PointAt(u, v);
+        TangentsAt(u, v, &tu, &tv);
+        n = tu.Cross(tv).WithMagnitude(1);
+
+        // point on curve and tangent line direction
+        Vector pc = curve->PointAt(tCurve);
+        Vector tc = curve->TangentAt(tCurve);
+
+        if(ps.Equals(pc, RATPOLY_EPS)) {
+            *up = u;
+            *vp = v;
+            return;
+        }
+
+        //pi is where the curve tangent line intersects the surface tangent plane
+        Vector pi;
+        double d = tc.Dot(n);
+        if (fabs(d) < 1e-10) { // parallel line and plane, guess the average rather than fail
+            pi = pc.Plus(ps).ScaledBy(0.5);
+        } else {
+            pi = pc.Minus(tc.ScaledBy(pc.Minus(ps).Dot(n)/d));
+        }
+
+        // project the point onto the tangent plane and line
+        {
+            Vector n = tu.Cross(tv);
+            Vector ty = n.Cross(tu).ScaledBy(1.0/tu.MagSquared());
+            Vector tx = tv.Cross(n).ScaledBy(1.0/tv.MagSquared());
+
+            Vector dp = pi.Minus(ps);
+            double du = dp.Dot(tx), dv = dp.Dot(ty);
+
+            u += du / tx.MagSquared();
+            v += dv / ty.MagSquared();
+        }
+        tCurve += pi.Minus(pc).Dot(tc) / tc.MagSquared();
+        if(tCurve < 0.0) tCurve = 0.0;
+        if(tCurve > 1.0) tCurve = 1.0;
+    }
+    dbp("didn't converge (surface and curve intersecting)");
+}
+

--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -447,11 +447,13 @@ void SSurface::ClosestPointTo(Vector p, double *u, double *v, bool mustConverge)
 
     // If we failed to converge, then at least don't return NaN.
     if(mustConverge) {
-        Vector p0 = PointAt(*u, *v);
-        dbp("didn't converge");
-        dbp("have %.3f %.3f %.3f", CO(p0));
-        dbp("want %.3f %.3f %.3f", CO(p));
-        dbp("distance = %g", (p.Minus(p0)).Magnitude());
+// This is expected not to converge when the target point is not on the surface but nearby.
+// let's not pollute the output window for normal use.
+//        Vector p0 = PointAt(*u, *v);
+//        dbp("didn't converge");
+//        dbp("have %.3f %.3f %.3f", CO(p0));
+//        dbp("want %.3f %.3f %.3f", CO(p));
+//        dbp("distance = %g", (p.Minus(p0)).Magnitude());
     }
     if(IsReasonable(*u) || IsReasonable(*v)) {
         *u = *v = 0;
@@ -500,7 +502,7 @@ bool SSurface::ClosestPointNewton(Vector p, double *u, double *v, bool mustConve
 bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v) const
 {
     int i;
-    for(i = 0; i < 15; i++) {
+    for(i = 0; i < 20; i++) {
         Vector pi, p, tu, tv;
         p = PointAt(*u, *v);
         TangentsAt(*u, *v, &tu, &tv);
@@ -510,7 +512,10 @@ bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v)
 
         bool parallel;
         pi = Vector::AtIntersectionOfPlaneAndLine(n, d, p0, p1, &parallel);
-        if(parallel) break;
+        if(parallel) {
+            dbp("parallel (surface intersecting line)");
+            break;
+        }
 
         // Check for convergence
         if(pi.Equals(p, RATPOLY_EPS)) return true;
@@ -617,7 +622,10 @@ void SSurface::PointOnSurfaces(SSurface *s1, SSurface *s2, double *up, double *v
         Vector pi = Vector::AtIntersectionOfPlanes(n[0], d[0],
                                                    n[1], d[1],
                                                    n[2], d[2], &parallel);
-        if(parallel) break;
+
+        if(parallel) { // lets try something else for parallel planes
+            pi = p[0].Plus(p[1]).Plus(p[2]).ScaledBy(1.0/3.0);
+        }
 
         for(j = 0; j < 3; j++) {
             Vector n = tu[j].Cross(tv[j]);

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -332,6 +332,7 @@ public:
     bool PointIntersectingLine(Vector p0, Vector p1, double *u, double *v) const;
     Vector ClosestPointOnThisAndSurface(SSurface *srf2, Vector p);
     void PointOnSurfaces(SSurface *s1, SSurface *s2, double *u, double *v);
+    void PointOnCurve(const SBezier *curve, double *up, double *vp);
     Vector PointAt(double u, double v) const;
     Vector PointAt(Point2d puv) const;
     void TangentsAt(double u, double v, Vector *tu, Vector *tv) const;

--- a/src/srf/surfinter.cpp
+++ b/src/srf/surfinter.cpp
@@ -341,7 +341,11 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
                     Vector p = si->p;
                     double u, v;
                     srfB->ClosestPointTo(p, &u, &v);
-                    srfB->PointOnSurfaces(srfA, other, &u, &v);
+                    if(sc->isExact) {
+                        srfB->PointOnCurve(&(sc->exact), &u, &v);
+                    } else {
+                        srfB->PointOnSurfaces(srfA, other, &u, &v);
+                    }
                     p = srfB->PointAt(u, v);
                     if(!spl.ContainsPoint(p)) {
                         SPoint sp;


### PR DESCRIPTION
I'd like to get input on this from @jwesthues  @ruevs and @Evil-Spirit 

The code in Boolean tries to intersect a curve with a surface. It uses the PWL representation of the curve (the more general case) and the 2 surfaces it trims. To do the intersection it calls SSurface::PointOnSurfaces() which finds the U,V intersection of the 3 surfaces. I noticed that function will not converge (it gives up) if 2 of the surfaces are tangent along the curve, which is the case for Lathe and Helical surfaces joined every 90 or less degrees. In that case we always have an exact representation of the curve, so I created a new function to intersect an exact curve with a surface which can be used in the (common) special case that we have and exact curve. I thought this may result in better accuracy finding the intersection points and might fix some of the boolean issues.

Unfortunately I have not seen any broken boolean start working, but I do see this broken one being more consistent:
![Bug1_before](https://user-images.githubusercontent.com/14852918/90057222-17352300-dcae-11ea-9ee9-11972cf650a9.png)
![Bug1_after](https://user-images.githubusercontent.com/14852918/90057228-18fee680-dcae-11ea-91e3-282544ddbab6.png)

The first picture is before this change. The red lines tend to flicker between the upper missing 90 degree surface patch and the lower one, but very rarely will all the curves show in red. It flickers back and forth as you drag the cylinder. With the change it very consistently shows all the curves. In neither case does it ever show the surfaces. The thing is I'm not sure this is consistently better than before or consistently worse. From a theoretical point of view this change should be better.

What do you think?

BTW I have not seen any regressions with 10-20 sketches.
BTW2 the above sketch is a lathed object (spool) with a circle/cylinder cut out to demo boolean failure.