### PR TITLE
NFC: Performance optimizations

### DIFF
--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -624,16 +624,17 @@ SSurface SSurface::MakeCopyTrimAgainst(SShell *parent,
 }
 
 void SShell::CopySurfacesTrimAgainst(SShell *sha, SShell *shb, SShell *into, SSurface::CombineAs type) {
+    std::vector <SSurface> ssn(surface.n);
 #pragma omp parallel for
     for (int i = 0; i < surface.n; i++)
     {
         SSurface *ss = &surface[i];
-        SSurface ssn;
-        ssn = ss->MakeCopyTrimAgainst(this, sha, shb, into, type, i);
-#pragma omp critical
-        {
-            ss->newH = into->surface.AddAndAssignId(&ssn);
-        }
+        ssn[i] = ss->MakeCopyTrimAgainst(this, sha, shb, into, type, i);
+    }
+
+    for (int i = 0; i < surface.n; i++)
+    {
+        surface[i].newH = into->surface.AddAndAssignId(&ssn[i]);
     }
     I += surface.n;
 }


### PR DESCRIPTION
Together these reduce Generate on a complex sketch from 50 seconds to 30. The first replaces 2 nested for loops with one loop and a lookup by ID. The second removes an OMP critical from a loop - puts that update in a non-parallel loop by itself.