### PR TITLE
NFC: performance improvements

### DIFF
--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -106,25 +106,27 @@ void SMesh::RemapFaces(Group *g, int remap) {
 
 template<class T>
 void Group::GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat) {
-    T workA, workB;
-    workA = {};
-    workB = {};
-    T *soFar = &workA, *scratch = &workB;
 
     int n = (int)valA, a0 = 0;
     if(subtype == Subtype::ONE_SIDED && skipFirst) {
         a0++; n++;
     }
-    int a;
-    for(a = a0; a < n; a++) {
-        int ap = a*2 - (subtype == Subtype::ONE_SIDED ? 0 : (n-1));
-        int remap = (a == (n - 1)) ? REMAP_LAST : a;
 
-        T transd = {};
+    int a;
+    // create all the transformed copies
+    std::vector <T> transd(n);
+    std::vector <T> workA(n);
+    workA[0] = {};
+#pragma omp parallel for
+    for(a = a0; a < n; a++) {
+        transd[a] = {};
+        workA[a] = {};
+        int ap = a*2 - (subtype == Subtype::ONE_SIDED ? 0 : (n-1));
+
         if(type == Type::TRANSLATE) {
             Vector trans = Vector::From(h.param(0), h.param(1), h.param(2));
             trans = trans.ScaledBy(ap);
-            transd.MakeFromTransformationOf(steps,
+            transd[a].MakeFromTransformationOf(steps,
                 trans, Quaternion::IDENTITY, 1.0);
         } else {
             Vector trans = Vector::From(h.param(0), h.param(1), h.param(2));
@@ -133,29 +135,40 @@ void Group::GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat
             Vector axis = Vector::From(h.param(4), h.param(5), h.param(6));
             Quaternion q = Quaternion::From(c, s*axis.x, s*axis.y, s*axis.z);
             // Rotation is centered at t; so A(x - t) + t = Ax + (t - At)
-            transd.MakeFromTransformationOf(steps,
+            transd[a].MakeFromTransformationOf(steps,
                 trans.Minus(q.Rotate(trans)), q, 1.0);
         }
-
+    }
+    for(a = a0; a < n; a++) {
         // We need to rewrite any plane face entities to the transformed ones.
-        transd.RemapFaces(this, remap);
-
-        // And tack this transformed copy on to the return.
-        if(soFar->IsEmpty()) {
-            scratch->MakeFromCopyOf(&transd);
-        } else if(forWhat == CombineAs::ASSEMBLE) {
-            scratch->MakeFromAssemblyOf(soFar, &transd);
-        } else {
-            scratch->MakeFromUnionOf(soFar, &transd);
-        }
-
-        swap(scratch, soFar);
-        scratch->Clear();
-        transd.Clear();
+        int remap = (a == (n - 1)) ? REMAP_LAST : a;
+        transd[a].RemapFaces(this, remap);
     }
 
+    std::vector<T> *soFar = &transd;
+    std::vector<T> *scratch = &workA;
+    // do the boolean operations
+    while(n > 1) {
+#pragma omp parallel for
+        for(a = 0; a < n; a+=2) {
+            scratch->at(a/2).Clear();
+            // combine a pair of shells
+            if((a==0) && (a0==1)) { // if the first was skipped just copy the 2nd
+                scratch->at(a/2).MakeFromCopyOf(&(soFar->at(a+1)));
+                a0 = 0;
+            } else if (a == n-1) { // for an odd number just copy the last one
+                scratch->at(a/2).MakeFromCopyOf(&(soFar->at(a)));
+            } else if(forWhat == CombineAs::ASSEMBLE) {
+                scratch->at(a/2).MakeFromAssemblyOf(&(soFar->at(a)), &(soFar->at(a+1)));
+            } else {
+                scratch->at(a/2).MakeFromUnionOf(&(soFar->at(a)), &(soFar->at(a+1)));
+            }
+        }
+        swap(scratch, soFar);
+        n = (n+1)/2;
+    }
     outs->Clear();
-    *outs = *soFar;
+    *outs = soFar->at(0);
 }
 
 template<class T>

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -149,7 +149,6 @@ void Group::GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat
     std::vector<T> *scratch = &workA;
     // do the boolean operations
     while(n > 1) {
-#pragma omp parallel for
         for(a = 0; a < n; a+=2) {
             scratch->at(a/2).Clear();
             // combine a pair of shells

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -640,8 +640,10 @@ void SShell::CopySurfacesTrimAgainst(SShell *sha, SShell *shb, SShell *into, SSu
 }
 
 void SShell::MakeIntersectionCurvesAgainst(SShell *agnst, SShell *into) {
-    SSurface *sa;
-    for(sa = surface.First(); sa; sa = surface.NextAfter(sa)) {
+#pragma omp parallel for
+    for(int i = 0; i< surface.n; i++) {
+        SSurface *sa = &surface[i];
+
         SSurface *sb;
         for(sb = agnst->surface.First(); sb; sb = agnst->surface.NextAfter(sb)){
             // Intersect every surface from our shell against every surface

--- a/src/srf/surfinter.cpp
+++ b/src/srf/surfinter.cpp
@@ -27,19 +27,22 @@ void SSurface::AddExactIntersectionCurve(SBezier *sb, SSurface *srfB,
     SBezier sbrev = *sb;
     sbrev.Reverse();
     bool backwards = false;
-    for(se = into->curve.First(); se; se = into->curve.NextAfter(se)) {
-        if(se->isExact) {
-            if(sb->Equals(&(se->exact))) {
-                existing = se;
-                break;
-            }
-            if(sbrev.Equals(&(se->exact))) {
-                existing = se;
-                backwards = true;
-                break;
+#pragma omp critical(into)
+    {
+        for(se = into->curve.First(); se; se = into->curve.NextAfter(se)) {
+            if(se->isExact) {
+                if(sb->Equals(&(se->exact))) {
+                    existing = se;
+                    break;
+                }
+                if(sbrev.Equals(&(se->exact))) {
+                    existing = se;
+                    backwards = true;
+                    break;
+                }
             }
         }
-    }
+    }// end omp critical
     if(existing) {
         SCurvePt *v;
         for(v = existing->pts.First(); v; v = existing->pts.NextAfter(v)) {
@@ -101,7 +104,10 @@ void SSurface::AddExactIntersectionCurve(SBezier *sb, SSurface *srfB,
              "Unexpected zero-length edge");
 
     split.source = SCurve::Source::INTERSECTION;
-    into->curve.AddAndAssignId(&split);
+#pragma omp critical(into)
+    {
+        into->curve.AddAndAssignId(&split);
+    }
 }
 
 void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
@@ -456,7 +462,10 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
             // And now we split and insert the curve
             SCurve split = sc.MakeCopySplitAgainst(agnstA, agnstB, this, b);
             sc.Clear();
-            into->curve.AddAndAssignId(&split);
+#pragma omp critical(into)
+            {
+                into->curve.AddAndAssignId(&split);
+            }
         }
         spl.Clear();
     }


### PR DESCRIPTION
First commit changes the order of booleans in repeat-groups. This reduces the average time for the booleans by combining equal size pieces. It also does the transforms in parallel when build with OMP.

Second commit brings OpenMP to the remaining time-consuming part of boolean operations.