### PR TITLE
Fix #131

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -204,6 +204,11 @@ void TextWindow::ScreenChangeAutosaveInterval(int link, uint32_t v) {
     SS.TW.edit.meaning = Edit::AUTOSAVE_INTERVAL;
 }
 
+void TextWindow::ScreenChangeFindConstraintTimeout(int link, uint32_t v) {
+    SS.TW.ShowEditControl(3, std::to_string(SS.timeoutRedundantConstr));
+    SS.TW.edit.meaning = Edit::FIND_CONSTRAINT_TIMEOUT;
+}
+
 void TextWindow::ShowConfiguration() {
     int i;
     Printf(true, "%Ft user color (r, g, b)");
@@ -371,6 +376,10 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "%Ft autosave interval (in minutes)%E");
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
         SS.autosaveInterval, &ScreenChangeAutosaveInterval);
+    Printf(false, "");
+    Printf(false, "%Ft redundant constraint timeout (in ms)%E");
+    Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
+        SS.timeoutRedundantConstr, &ScreenChangeFindConstraintTimeout);
 
     if(canvas) {
         const char *gl_vendor, *gl_renderer, *gl_version;
@@ -539,6 +548,17 @@ bool TextWindow::EditControlDoneForConfiguration(const std::string &s) {
                 }
             } else {
                 Error(_("Bad format: specify interval in integral minutes"));
+            }
+            break;
+        }
+        case Edit::FIND_CONSTRAINT_TIMEOUT: {
+            int timeout = atoi(s.c_str());
+            if(timeout) {
+                if(timeout >= 1) {
+                    SS.timeoutRedundantConstr = timeout;
+                } else {
+                    SS.timeoutRedundantConstr = 1000;
+                }
             }
             break;
         }

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -533,6 +533,7 @@ void SolveSpaceUI::SolveGroup(hGroup hg, bool andFindFree) {
     WriteEqSystemForGroup(hg);
     Group *g = SK.GetGroup(hg);
     g->solved.remove.Clear();
+    g->solved.findToFixTimeout = SS.timeoutRedundantConstr;
     SolveResult how = sys.Solve(g, NULL,
                                    &(g->solved.dof),
                                    &(g->solved.remove),

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -189,6 +189,7 @@ public:
     struct {
         SolveResult         how;
         int                 dof;
+        bool                timeout;
         List<hConstraint>   remove;
     } solved;
 

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -189,6 +189,7 @@ public:
     struct {
         SolveResult         how;
         int                 dof;
+        int                 findToFixTimeout;
         bool                timeout;
         List<hConstraint>   remove;
     } solved;

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -51,6 +51,8 @@ void SolveSpaceUI::Init() {
     exportChordTol = settings->ThawFloat("ExportChordTolerance", 0.1);
     // Max pwl segments to generate
     exportMaxSegments = settings->ThawInt("ExportMaxSegments", 64);
+    // Timeout value for finding redundant constrains (ms)
+    timeoutRedundantConstr = settings->ThawInt("TimeoutRedundantConstraints", 1000);
     // View units
     viewUnits = (Unit)settings->ThawInt("ViewUnits", (uint32_t)Unit::MM);
     // Number of digits after the decimal point
@@ -231,6 +233,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeFloat("ExportChordTolerance", (float)exportChordTol);
     // Export Max pwl segments to generate
     settings->FreezeInt("ExportMaxSegments", (uint32_t)exportMaxSegments);
+    // Timeout for finding which constraints to fix Jacobian
+    settings->FreezeInt("TimeoutRedundantConstraints", (uint32_t)timeoutRedundantConstr);
     // View units
     settings->FreezeInt("ViewUnits", (uint32_t)viewUnits);
     // Number of digits after the decimal point

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -268,7 +268,8 @@ public:
     void EvalJacobian();
 
     void WriteEquationsExceptFor(hConstraint hc, Group *g);
-    void FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad, bool forceDofCheck);
+    void FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad,
+                                        bool forceDofCheck);
     void SolveBySubstitution();
 
     bool IsDragged(hParam p);
@@ -562,6 +563,7 @@ public:
     int      maxSegments;
     double   exportChordTol;
     int      exportMaxSegments;
+    int      timeoutRedundantConstr; //milliseconds
     double   cameraTangent;
     double   gridSpacing;
     double   exportScale;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -361,7 +361,7 @@ void System::FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad, bo
 
     for(a = 0; a < 2; a++) {
         for(auto &con : SK.constraint) {
-            if((GetMilliseconds() - time) > 1500) { // todo: make timeout configurable
+            if((GetMilliseconds() - time) > g->solved.findToFixTimeout) {
                 g->solved.timeout = true;
                 return;
             }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -355,10 +355,17 @@ void System::WriteEquationsExceptFor(hConstraint hc, Group *g) {
 }
 
 void System::FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad, bool forceDofCheck) {
+    auto time = GetMilliseconds();
+    g->solved.timeout = false;
     int a;
 
     for(a = 0; a < 2; a++) {
         for(auto &con : SK.constraint) {
+            if((GetMilliseconds() - time) > 1500) { // todo: make timeout configurable
+                g->solved.timeout = true;
+                return;
+            }
+
             ConstraintBase *c = &con;
             if(c->group != g->h) continue;
             if((c->type == Constraint::Type::POINTS_COINCIDENT && a == 0) ||

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -578,6 +578,11 @@ void TextWindow::ShowGroupSolveInfo() {
             c->DescriptionString().c_str());
     }
 
+    if(g->solved.timeout) {
+        Printf(true,  "%FxSome items in list have been ommitted%Fd");
+        Printf(false,  "%Fxbecause the operation timed out.%Fd");
+    }
+
     Printf(true,  "It may be possible to fix the problem ");
     Printf(false, "by selecting Edit -> Undo.");
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -316,6 +316,7 @@ public:
         G_CODE_PLUNGE_FEED    = 115,
         AUTOSAVE_INTERVAL     = 116,
         LIGHT_AMBIENT         = 117,
+        FIND_CONSTRAINT_TIMEOUT = 118,
         // For TTF text
         TTF_TEXT              = 300,
         // For the step dimension screen
@@ -488,6 +489,7 @@ public:
     static void ScreenChangeExportOffset(int link, uint32_t v);
     static void ScreenChangeGCodeParameter(int link, uint32_t v);
     static void ScreenChangeAutosaveInterval(int link, uint32_t v);
+    static void ScreenChangeFindConstraintTimeout(int link, uint32_t v);
     static void ScreenChangeStyleName(int link, uint32_t v);
     static void ScreenChangeStyleMetric(int link, uint32_t v);
     static void ScreenChangeStyleTextAngle(int link, uint32_t v);


### PR DESCRIPTION
Add a timeout when listing redundant constraints is taking too long.

I manually merged the @Evil-Spirit patch with master for this.