### PR TITLE
Update Menu checkboxes after failed workplane activation. Fixes 197.

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -1243,6 +1243,8 @@ void GraphicsWindow::MenuRequest(Command id) {
                         "not have a default workplane. Try selecting a "
                         "workplane, or activating a sketch-in-new-workplane "
                         "group."));
+                //update checkboxes in the menus
+                SS.GW.EnsureValidActives();
             }
             break;
         }


### PR DESCRIPTION
FIxes issue 197. Opted for EnsureValidActive() rather than ClearSuper() so selections will remain selected.