### PR TITLE
solvespace-cli: Fix --view

### DIFF
--- a/src/platform/entrycli.cpp
+++ b/src/platform/entrycli.cpp
@@ -211,8 +211,8 @@ static bool RunCommand(const std::vector<std::string> args) {
             camera.gridFit    = true;
             camera.width      = width;
             camera.height     = height;
-            camera.projUp     = SS.GW.projUp;
-            camera.projRight  = SS.GW.projRight;
+            camera.projUp     = projUp;
+            camera.projRight  = projRight;
 
             SS.GW.projUp      = projUp;
             SS.GW.projRight   = projRight;


### PR DESCRIPTION
This fixes issue #499. The --view option changes projUp and projRight. For --view to affect the camera, the camera needs to be initialized using these values.