### PR TITLE
Fix view centering for cli thumbnail function.

### DIFF
--- a/src/platform/entrycli.cpp
+++ b/src/platform/entrycli.cpp
@@ -121,22 +121,22 @@ static bool RunCommand(const std::vector<std::string> args) {
             argn++;
             if(args[argn] == "top") {
                 projRight = Vector::From(1, 0, 0);
-                projUp    = Vector::From(0, 1, 0);
+                projUp    = Vector::From(0, 0, -1);
             } else if(args[argn] == "bottom") {
-                projRight = Vector::From(-1, 0, 0);
-                projUp    = Vector::From(0, 1, 0);
-            } else if(args[argn] == "left") {
-                projRight = Vector::From(0, 1, 0);
-                projUp    = Vector::From(0, 0, 1);
-            } else if(args[argn] == "right") {
-                projRight = Vector::From(0, -1, 0);
-                projUp    = Vector::From(0, 0, 1);
-            } else if(args[argn] == "front") {
-                projRight = Vector::From(-1, 0, 0);
-                projUp    = Vector::From(0, 0, 1);
-            } else if(args[argn] == "back") {
                 projRight = Vector::From(1, 0, 0);
                 projUp    = Vector::From(0, 0, 1);
+            } else if(args[argn] == "left") {
+                projRight = Vector::From(0, 0, 1);
+                projUp    = Vector::From(0, 1, 0);
+            } else if(args[argn] == "right") {
+                projRight = Vector::From(0, 0, -1);
+                projUp    = Vector::From(0, 1, 0);
+            } else if(args[argn] == "front") {
+                projRight = Vector::From(1, 0, 0);
+                projUp    = Vector::From(0, 1, 0);
+            } else if(args[argn] == "back") {
+                projRight = Vector::From(-1, 0, 0);
+                projUp    = Vector::From(0, 1, 0);
             } else if(args[argn] == "isometric") {
                 projRight = Vector::From(0.707,  0.000, -0.707);
                 projUp    = Vector::From(-0.408, 0.816, -0.408);
@@ -218,6 +218,7 @@ static bool RunCommand(const std::vector<std::string> args) {
             SS.GW.projRight   = projRight;
             SS.GW.scale       = SS.GW.ZoomToFit(camera);
             camera.scale      = SS.GW.scale;
+            camera.offset     = SS.GW.offset;
             SS.GenerateAll();
 
             CairoPixmapRenderer pixmapCanvas;


### PR DESCRIPTION
This is for issue #499. A recent commit fixed the --view selection but it was still not centered, nor were the various direction options working correctly.