### PR TITLE
Convert revovled line to planes correctly when theta < 0.

### DIFF
--- a/src/srf/surface.cpp
+++ b/src/srf/surface.cpp
@@ -984,6 +984,10 @@ void SShell::MakeFirstOrderRevolvedSurfaces(Vector pt, Vector axis, int i0) {
 
                 double vm = (ff.Minus(of)).Dot(v);
                 v = v.ScaledBy(vm);
+                if(vm <  0) { // happens when we revolve with negative theta
+                    of = of.Minus(v);
+                    v = v.ScaledBy(-1);
+                }
 
                 srf->degm = 1;
                 srf->degn = 1;


### PR DESCRIPTION
Fixes issue 680.

I think the function ideally needs to be rewritten or it may fail on revolves or lathes around an axis that is not in the sketch plane. It also won't work if we allow sections over 90 degrees - things might fall outside the range [0..1] for U or V.