### PR TITLE
NURBS: Improve calculation of tangents on degenerate NURBS patches

### DIFF
--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -340,9 +340,64 @@ void SSurface::TangentsAt(double u, double v, Vector *tu, Vector *tv) const {
            den_u = 0,
            den_v = 0;
 
-    int i, j;
-    for(i = 0; i <= degm; i++) {
-        for(j = 0; j <= degn; j++) {
+    // Check if we are trying to calculate a tengent "along" a degenerate (zero length)
+    // edge of a NURBS patch. In this case move the `u` or `v` parameter "inward" a bit.
+    if(EXACT(0.0 == u)) {
+        bool shift_inward = true;
+        // For the edge to be degenerate all control points along it have to be the same.
+        for(int i = 0; i < degn; i++) { // not <= we use i+1 in the body of the lopp
+            if (!(ctrl[0][i].EqualsExactly(ctrl[0][i + 1]))) {
+                shift_inward = false;
+                break;
+            }
+        }
+        if(true == shift_inward) {
+            u += LENGTH_EPS;
+        }
+    } else if(EXACT(1.0 == u)) {
+        bool shift_inward = true;
+        // For the edge to be degenerate all control points along it have to be the same.
+        for(int i = 0; i < degn; i++) { // not <= we use i+1 in the body of the lopp
+            if(!(ctrl[degm][i].EqualsExactly(ctrl[degm][i + 1]))) {
+                shift_inward = false;
+                break;
+            }
+        }
+        if(true == shift_inward) {
+            u -= LENGTH_EPS;
+        }
+    }
+
+    if(EXACT(0.0 == v)) {
+        bool shift_inward = true;
+        // For the edge to be degenerate all control points along it have to be the same.
+        for(int i = 0; i < degm; i++) { // not <= we use i+1 in the body of the lopp
+            if(!(ctrl[i][0].EqualsExactly(ctrl[i + 1][0]))) {
+                shift_inward = false;
+                break;
+            }
+        }
+        if(true == shift_inward) {
+            v += LENGTH_EPS;
+            dbp("NURBS patch pinched along 'u' at v=0 how did you do this?");
+        }
+    } else if(EXACT(1.0 == v)) {
+        bool shift_inward = true;
+        // For the edge to be degenerate all control points along it have to be the same.
+        for(int i = 0; i < degm; i++) {         // not <= we use i+1 in the body of the lopp
+            if(!(ctrl[i][degn].EqualsExactly(ctrl[i + 1][degn]))) {
+                shift_inward = false;
+                break;
+            }
+        }
+        if(true == shift_inward) {
+            v -= LENGTH_EPS;
+            dbp("NURBS patch pinched along 'u' at v=1 how did you do this?");
+        }
+    }
+
+    for(int i = 0; i <= degm; i++) {
+        for(int j = 0; j <= degn; j++) {
             double Bi  = Bernstein(i, degm, u),
                    Bj  = Bernstein(j, degn, v),
                    Bip = BernsteinDerivative(i, degm, u),


### PR DESCRIPTION
This avoids zero length normals.

Sometimes NURBS patches have a "degenerate" (zero length/to a point)
edge/side. In this case the tangent(s) on points "along" that "edge"
become zero length.

A normal `n` at a point (u.v) on a NURBS surface is calculated by calculating
the tangents `tu` and `tv` at that point and taking the cross product.
However when an edge is "degenerate" (for example a cone created by lathing
a triangle) then `tv` (and possibly `tu`) becomes zero and `n` becomes zero.
This causes a problems with NURBS booleans.

To solve this problem the tangent calculation is changed to shift `u` or `v` inwards
if they are on a degenerate/pinched point on the surface.

Fixes: https://github.com/solvespace/solvespace/issues/652
Alternative to: https://github.com/solvespace/solvespace/pull/734

![NURBSPatchWithDegenerateEdgeCausesZeroLengthNormalsBecauseOfUndefinedTangent](https://user-images.githubusercontent.com/15338069/95861136-b6879c80-0d69-11eb-89a2-b2ff51a422f8.png)