### PR TITLE
Win32: Fix "File|Open...", "Save" and "Save As" when a command line argument is used.

### DIFF
--- a/src/platform/entrygui.cpp
+++ b/src/platform/entrygui.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv) {
             dbp("Only the first file passed on command line will be opened.");
         }
 
-        SS.Load(Platform::Path::From(args.back()).Expand(/*fromCurrentDirectory=*/true));
+        SS.Load(Platform::Path::From(args.back()));
     }
 
     Platform::RunGui();

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -401,7 +401,7 @@ FILE *OpenFile(const Platform::Path &filename, const char *mode) {
     ssassert(filename.raw.length() == strlen(filename.raw.c_str()),
              "Unexpected null byte in middle of a path");
 #if defined(WIN32)
-    return _wfopen(Widen(filename.Expand().raw).c_str(), Widen(mode).c_str());
+    return _wfopen(Widen(filename.Expand(/*fromCurrentDirectory=*/true).raw).c_str(), Widen(mode).c_str());
 #else
     return fopen(filename.raw.c_str(), mode);
 #endif


### PR DESCRIPTION
`GetSaveFileNameA` `OPENFILENAMEA` does not like UNC ( "\\\\?\\C:\\..." ) file prefixes in `lpstrFile`.
Work around it by not `Expand`-ing parameters passed on the command line too early.

The only user visible change is that "File|Open Recent" will show items as they
were passed instead of expanded to full path for example:
"..\..\NURBSTests\Intersection2.slvs"

Fixes: https://github.com/solvespace/solvespace/issues/622