### PR TITLE
Travis: add windows target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ jobs:
       dist: bionic
       install: ./.travis/install-debian.sh
       script: ./.travis/build-debian.sh
+    - stage: test
+      name: "Windows Visual Studio 2017"
+      os: windows
+      install: ./.travis/install-windows.sh
+      script: ./.travis/build-windows.sh
     - stage: deploy
       name: "OSX"
       os: osx

--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -xe
+
+MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
+export PATH=$MSBUILD_PATH:$PATH
+
+if echo $TRAVIS_TAG | grep ^v; then BUILD_TYPE=RelWithDebInfo; else BUILD_TYPE=Debug; fi
+
+mkdir build
+cd build
+cmake .. -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+MSBuild.exe "src/solvespace.vcxproj"
+MSBuild.exe "src/solvespace-cli.vcxproj"
+MSBuild.exe "test/solvespace-testsuite.vcxproj"
+
+bin/$BUILD_TYPE/solvespace-testsuite.exe

--- a/.travis/install-windows.sh
+++ b/.travis/install-windows.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -xe
+
+git submodule update --init


### PR DESCRIPTION
Mimic the appveyor cfg without the artifact deployment.
Also upgrade to Visual Studio 2017/v141 toolset.