### PR TITLE
macOS: add NSOpenGLPFADoubleBuffer to NSOpenGLPixelFormatAttribute

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -371,6 +371,7 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
 
 - (id)initWithFrame:(NSRect)frameRect {
     NSOpenGLPixelFormatAttribute attrs[] = {
+        NSOpenGLPFADoubleBuffer,
         NSOpenGLPFAColorSize, 24,
         NSOpenGLPFADepthSize, 24,
         0


### PR DESCRIPTION
This seems to solve a flickering issue.
Should I be using the `macOS:` prefix?