### PR TITLE
snap: enable OpenMP and LTO

### DIFF
--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -51,6 +51,8 @@ parts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_TESTS=OFF
       - -DSNAP=ON
+      - -DENABLE_OPENMP=ON
+      - -DENABLE_LTO=ON
     build-packages:
       - zlib1g-dev
       - libpng-dev


### PR DESCRIPTION
`libgomp` is provided by the gnome platform snap:

```shell
ldd solvespace | grep gomp
	libgomp.so.1 => /snap/solvespace/x2/gnome-platform/usr/lib/x86_64-linux-gnu/libgomp.so.1 (0x00007f752d0b7000)
```

LTO seems to be there as well:

```shell
readelf -Wa solvespace | grep lto
   752: 000000000050083d     1 OBJECT  LOCAL  DEFAULT   28 _ZStL8__ioinit.lto_priv.860
   753: 000000000050083c     1 OBJECT  LOCAL  DEFAULT   28 _ZStL8__ioinit.lto_priv.859
   888: 00000000005012e1     1 OBJECT  LOCAL  DEFAULT   28 _ZStL8__ioinit.lto_priv.742
   889: 00000000005012e0     1 OBJECT  LOCAL  DEFAULT   28 _ZStL8__ioinit.lto_priv.741
[...]
```

Need to check:

- [ ] ARM64 builds
- [ ] General testing of the builds