### PR TITLE
CMake: Give ENABLE_LTO a default and a description so it shows up in cmake-gui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ set(ENABLE_SANITIZERS OFF CACHE BOOL
     "Whether to enable Clang's AddressSanitizer and UndefinedBehaviorSanitizer")
 set(ENABLE_OPENMP     OFF CACHE BOOL
     "Whether geometric operations will be parallelized using OpenMP")
+set(ENABLE_LTO     OFF CACHE BOOL
+    "Whether interprocedural (global) optimizations are enabled")
 
 set(OPENGL 3 CACHE STRING "OpenGL version to use (one of: 1 3)")
 


### PR DESCRIPTION
just the title