### PR TITLE
Travis: release macOS and Windows edge builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,29 @@ jobs:
       install: ".travis/install-macos.sh"
       script: ".travis/build-macos.sh"
     - stage: deploy
-      if: tag IS present
       name: macOS deploy
+      if: (NOT type IN (pull_request)) AND (branch = master)
       os: osx
       osx_image: xcode12.2
       install: ".travis/install-macos.sh"
-      script: ".travis/build-macos.sh && .travis/sign-macos.sh"
+      script: ".travis/build-macos.sh release && .travis/sign-macos.sh"
+      before_deploy:
+        - git config --local user.name "solvespace-cd"
+        - git config --local user.email "no-reply@solvespace.com"
+        - export TRAVIS_TAG=${TRAVIS_TAG:-edge}
+        - git tag $TRAVIS_TAG
       deploy:
         provider: releases
         token:
           secure: dDlkIawHcODlW9B/20/cQCtzeoocvs0hKuNngRKXKqzXLWTRq33oq/B7+39tAixWbmv6exTpijiKrRNFiSCW5Z4iwHLwaRD4XJznxw63e/Hus/dxg2Tvqx7XFpkCz8mT1Z+gZQE5YxAngeZPpI/sZbZtF1UO3yH5eLeeokZ15p26ZskQUPoYuzrTgTzYL3XfpG3F+20rNBawH1ycsCTVD/08/n31d2m3CrKAsbW7er92ek6w4fzKr7NW8WeXjrPJETVpw5fQg1Od3pRGW8dPQaJcvKQEogMp8Mm0ETYd0qigg89/giBz7QwOgmAWQ4dH+DfZH4Ojl//127QztBolMvyDMQBykWrtJoGcij05sT6K2IJr2FHeUBO12MAEdjiVvhQj3DtTzjPiZAHHDBSLWxLKWWhlhHE4pq7g1MQhqXkaAHI2BLNzwLmaowbMT0bECf9yfz6xx18h6XPQFX44oOktraobVALFlyHqeKa8zdcUt22LF6uAL1m5dxL0tny3eXCIPE4UH/RZgua/cHV9G3cUvKQa/QnFSLRhvWVSbGB+7YsHouBJcsUOOW1gmd5442XuC7mpppccRldh+GSxUk6TBJRAx7TeQ0ybDUaoco9MUqp2twv3KreR2+8Q12PDaAhfQVNEGdF3wTm1sShImjCN4VN3eSLlBEbve1QRQXM=
-        cleanup: false
+        skip_cleanup: true
+        prerelease: true
+        overwrite: true
+        name: ${TRAVIS_TAG:-edge}
+        body: $TRAVIS_COMMIT_MESSAGE
         file: build/bin/SolveSpace.dmg
         on:
           repo: solvespace/solvespace
-          tags: true
     - stage: test
       name: "Debian"
       os: linux
@@ -37,10 +45,33 @@ jobs:
       install: .travis/install-debian.sh
       script: .travis/build-debian.sh
     - stage: test
-      name: "Windows Visual Studio 2017"
+      name: "Windows Visual Studio 2017 test"
       os: windows
       install: .travis/install-windows.sh
       script: .travis/build-windows.sh
+    - stage: deploy
+      name: "Windows Visual Studio 2017 deploy"
+      os: windows
+      install: .travis/install-windows.sh
+      script: .travis/build-windows.sh release
+      before_deploy:
+        - git config --local user.name "solvespace-cd"
+        - git config --local user.email "no-reply@solvespace.com"
+        - export TRAVIS_TAG=${TRAVIS_TAG:-edge}
+        - git tag $TRAVIS_TAG
+      deploy:
+        provider: releases
+        token:
+          secure: dDlkIawHcODlW9B/20/cQCtzeoocvs0hKuNngRKXKqzXLWTRq33oq/B7+39tAixWbmv6exTpijiKrRNFiSCW5Z4iwHLwaRD4XJznxw63e/Hus/dxg2Tvqx7XFpkCz8mT1Z+gZQE5YxAngeZPpI/sZbZtF1UO3yH5eLeeokZ15p26ZskQUPoYuzrTgTzYL3XfpG3F+20rNBawH1ycsCTVD/08/n31d2m3CrKAsbW7er92ek6w4fzKr7NW8WeXjrPJETVpw5fQg1Od3pRGW8dPQaJcvKQEogMp8Mm0ETYd0qigg89/giBz7QwOgmAWQ4dH+DfZH4Ojl//127QztBolMvyDMQBykWrtJoGcij05sT6K2IJr2FHeUBO12MAEdjiVvhQj3DtTzjPiZAHHDBSLWxLKWWhlhHE4pq7g1MQhqXkaAHI2BLNzwLmaowbMT0bECf9yfz6xx18h6XPQFX44oOktraobVALFlyHqeKa8zdcUt22LF6uAL1m5dxL0tny3eXCIPE4UH/RZgua/cHV9G3cUvKQa/QnFSLRhvWVSbGB+7YsHouBJcsUOOW1gmd5442XuC7mpppccRldh+GSxUk6TBJRAx7TeQ0ybDUaoco9MUqp2twv3KreR2+8Q12PDaAhfQVNEGdF3wTm1sShImjCN4VN3eSLlBEbve1QRQXM=
+        skip_cleanup: true
+        draft: true
+        prerelease: true
+        overwrite: true
+        name: ${TRAVIS_TAG:-edge}
+        body: $TRAVIS_COMMIT_MESSAGE
+        file: build/bin/RelWithDebInfo/solvespace.exe
+        on:
+          repo: solvespace/solvespace
     - &deploy-snap
       stage: deploy
       name: Snap amd64
@@ -55,13 +86,13 @@ jobs:
       deploy:
         - provider: script
           script: sudo .travis/deploy-snap.sh edge
-          cleanup: false
+          skip_cleanup: true
           on:
             branch: master
             tags: false
         - provider: script
           script: sudo .travis/deploy-snap.sh edge,beta
-          cleanup: false
+          skip_cleanup: true
           on:
             branch: master
             tags: true

--- a/.travis/build-macos.sh
+++ b/.travis/build-macos.sh
@@ -11,7 +11,7 @@ export LDFLAGS="-L${LLVM_PREFIX}/lib -Wl,-rpath,${LLVM_PREFIX}/lib" \
 export CFLAGS="-I${LLVM_PREFIX}/include"
 export CPPFLAGS="-I${LLVM_PREFIX}/include"
 
-if echo $TRAVIS_TAG | grep ^v; then
+if [ "$1" == "release" ]; then
     BUILD_TYPE=RelWithDebInfo
     cmake \
         -DCMAKE_OSX_DEPLOYMENT_TARGET="${OSX_TARGET}" \

--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -3,14 +3,23 @@
 MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
 export PATH=$MSBUILD_PATH:$PATH
 
-if echo $TRAVIS_TAG | grep ^v; then BUILD_TYPE=RelWithDebInfo; else BUILD_TYPE=Debug; fi
-
 mkdir build
 cd build
-cmake .. -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-MSBuild.exe "src/solvespace.vcxproj" -maxcpucount
-MSBuild.exe "src/solvespace-cli.vcxproj" -maxcpucount
-MSBuild.exe "test/solvespace-testsuite.vcxproj" -maxcpucount
+if [ "$1" == "release" ]; then
+    BUILD_TYPE=RelWithDebInfo
+    cmake \
+        -G "Visual Studio 15 2017 Win64" \
+        -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .. \
+        -DENABLE_OPENMP=ON \
+        -DENABLE_LTO=ON
+else
+    BUILD_TYPE=Debug
+    cmake \
+        -G "Visual Studio 15 2017 Win64" \
+        -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ..
+fi
+
+cmake --build . --config "${BUILD_TYPE}" -- -maxcpucount
 
 bin/$BUILD_TYPE/solvespace-testsuite.exe

--- a/.travis/sign-macos.sh
+++ b/.travis/sign-macos.sh
@@ -39,7 +39,7 @@ notarize_uuid=$(xcrun altool --notarize-app --primary-bundle-id "${bundle_id}" -
 echo $notarize_uuid
 
 # wait a bit so we don't get errors during checking
-sleep 5
+sleep 10
 
 success=0
 for (( ; ; ))


### PR DESCRIPTION
This will release every commit on the master branch to the "edge" tag, it also:

- Fixes windows build type not being picked up
- Revert `cleanup: false` back to `skip_cleanup: true` (to fix snap releases)
- Waits 10 seconds to get notarize_uuid for macOS since it would sometimes fail
- Build test stages in `Debug` mode and deploy stages in `RelWithDebInfo` mode