### PR TITLE
Vertex split

### DIFF
--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -219,6 +219,7 @@ public:
     SSurface *GetSurfaceB(SShell *a, SShell *b) const;
 
     void Clear();
+    void GetAxisAlignedBounding(Vector *ptMax, Vector *ptMin) const;
 };
 
 // A segment of a curve by which a surface is trimmed: indicates which curve,


### PR DESCRIPTION
Two commits. One fixes the huge performance regression and is only a little slower than prior to the regression. 18.5 seconds compared to 193 seconds. Prior to the NURBS fix that same test took a bit over 15 seconds. That seems reasonable for adding more code in order to fix an issue.  The second commit here adds OpenMP parallelism to the same part of the code and bring the test down to 11.x seconds.