### PR TITLE
STEP Export: fix colors in  Horison EDA and probaly KiCAD

### DIFF
--- a/src/exportstep.cpp
+++ b/src/exportstep.cpp
@@ -281,22 +281,21 @@ void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
         fprintf(f, "#%d=COLOUR_RGB('',%.2f,%.2f,%.2f);\n", ++id, ss->color.redF(),
                 ss->color.greenF(), ss->color.blueF());
 
+/*      // This works in Kisters 3DViewStation but not in KiCAD and Horison EDA,
+		// it seems they do not support transparency so use the more verbose one below
         fprintf(f, "#%d=SURFACE_STYLE_TRANSPARENT(%.2f);\n", ++id, 1.0 - ss->color.alphaF());
         fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n",
                 ++id, id - 2, id - 1);
-
         fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d));\n", ++id, id - 1);
+*/
 
-    /*      // This also works but is more verbose.
-            fprintf(f, "#%d=FILL_AREA_STYLE_COLOUR('',#%d);\n", ++id, id - 1);
-            fprintf(f, "#%d=FILL_AREA_STYLE('',(#%d));\n", ++id, id - 1);
-            fprintf(f, "#%d=SURFACE_STYLE_FILL_AREA(#%d);\n", ++id, id - 1);
-
-            fprintf(f, "#%d=SURFACE_STYLE_TRANSPARENT(%.2f);\n", ++id, 1.0 - ss->color.alphaF());
-            fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n", ++id, id - 5, id - 1);
-
-            fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d, #%d));\n", ++id, id - 3, id - 1);
-    */
+        // This works in Horison EDA but is more verbose.
+        fprintf(f, "#%d=FILL_AREA_STYLE_COLOUR('',#%d);\n", ++id, id - 1);
+        fprintf(f, "#%d=FILL_AREA_STYLE('',(#%d));\n", ++id, id - 1);
+        fprintf(f, "#%d=SURFACE_STYLE_FILL_AREA(#%d);\n", ++id, id - 1);
+        fprintf(f, "#%d=SURFACE_STYLE_TRANSPARENT(%.2f);\n", ++id, 1.0 - ss->color.alphaF());
+        fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n", ++id, id - 5, id - 1);
+        fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d, #%d));\n", ++id, id - 3, id - 1);
 
         fprintf(f, "#%d=SURFACE_STYLE_USAGE(.BOTH.,#%d);\n", ++id, id - 1);
         fprintf(f, "#%d=PRESENTATION_STYLE_ASSIGNMENT((#%d));\n", ++id, id - 1);


### PR DESCRIPTION
Make the color export work in KiCAD and Horison EDA which do not support
transparency.

Fixes: https://github.com/solvespace/solvespace/issues/452
https://github.com/solvespace/solvespace/pull/763