### PR TITLE
CMake: use sanitizer flags for internal targets only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,19 +170,15 @@ if(ENABLE_SANITIZERS)
     endif()
 
     string(REPLACE ";" "," SANITIZE_OPTIONS "${SANITIZE_OPTIONS}")
-    set(SANITIZE_FLAGS "-O1 -fsanitize=${SANITIZE_OPTIONS}")
-    set(SANITIZE_FLAGS "${SANITIZE_FLAGS} -fno-sanitize-recover=address,undefined")
+    set(SANITIZE_FLAGS "-O1;-fsanitize=${SANITIZE_OPTIONS};-fno-sanitize-recover=address,undefined")
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(SANITIZE_FLAGS "${SANITIZE_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+        list(APPEND SANITIZE_FLAGS -fno-omit-frame-pointer -fno-optimize-sibling-calls)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        set(SANITIZE_FLAGS "${SANITIZE_FLAGS} -fuse-ld=gold")
+        list(APPEND SANITIZE_FLAGS -fuse-ld=gold)
     else()
         message(FATAL_ERROR "Sanitizers are only available when using GCC or Clang")
     endif()
-
-    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${SANITIZE_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS}")
 endif()
 
 # common dependencies

--- a/exposed/CMakeLists.txt
+++ b/exposed/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_compile_options(${SANITIZE_FLAGS})
+
 include_directories(
     ${CMAKE_SOURCE_DIR}/include)
 
@@ -5,4 +7,5 @@ add_executable(CDemo
     CDemo.c)
 
 target_link_libraries(CDemo
-    slvs)
+    slvs
+    ${SANITIZE_FLAGS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,10 @@ if(APPLE)
         ${APPKIT_LIBRARY})
 endif()
 
+# sanitizers for all code in src and below
+
+add_compile_options(${SANITIZE_FLAGS})
+
 # libslvs
 
 set(libslvs_SOURCES
@@ -55,7 +59,8 @@ target_include_directories(slvs
 
 target_link_libraries(slvs
     ${util_LIBRARIES}
-    mimalloc-static)
+    mimalloc-static
+    ${SANITIZE_FLAGS})
 
 add_dependencies(slvs
     mimalloc-static)
@@ -225,7 +230,8 @@ target_link_libraries(solvespace-core
     ${PNG_LIBRARY}
     ${FREETYPE_LIBRARY}
     flatbuffers
-    mimalloc-static)
+    mimalloc-static
+    ${SANITIZE_FLAGS})
 
 if(Backtrace_FOUND)
     target_link_libraries(solvespace-core
@@ -332,7 +338,8 @@ if(ENABLE_GUI)
         solvespace-core
         ${OPENGL_LIBRARIES}
         ${platform_LIBRARIES}
-        ${COVERAGE_LIBRARY})
+        ${COVERAGE_LIBRARY}
+        ${SANITIZE_FLAGS})
 
     if(MSVC)
         set_target_properties(solvespace PROPERTIES
@@ -361,7 +368,8 @@ target_include_directories(solvespace-headless
 
 target_link_libraries(solvespace-headless
     solvespace-core
-    ${CAIRO_LIBRARIES})
+    ${CAIRO_LIBRARIES}
+    ${SANITIZE_FLAGS})
 
 target_compile_options(solvespace-headless
     PRIVATE ${COVERAGE_FLAGS})
@@ -375,7 +383,8 @@ if(ENABLE_CLI)
 
     target_link_libraries(solvespace-cli
         solvespace-core
-        solvespace-headless)
+        solvespace-headless
+        ${SANITIZE_FLAGS})
 
     add_dependencies(solvespace-cli
         resources)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,8 @@ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
     add_definitions(-DTEST_BUILD_ON_WINDOWS)
 endif()
 
+add_compile_options(${SANITIZE_FLAGS})
+
 # test suite
 
 set(testsuite_SOURCES
@@ -74,7 +76,8 @@ add_executable(solvespace-testsuite
 
 target_link_libraries(solvespace-testsuite
     solvespace-headless
-    ${COVERAGE_LIBRARY})
+    ${COVERAGE_LIBRARY}
+    ${SANITIZE_FLAGS})
 
 add_dependencies(solvespace-testsuite
     resources)
@@ -132,7 +135,8 @@ add_executable(solvespace-debugtool
 
 target_link_libraries(solvespace-debugtool
     solvespace-core
-    solvespace-headless)
+    solvespace-headless
+    ${SANITIZE_FLAGS})
 
 add_dependencies(solvespace-debugtool
     resources)


### PR DESCRIPTION
Previously sanitizer flags were set unconditionally for all code, including that of external libraries.
Set them only for targets in src/, tests/ and exposed/.

Unfortunately, the linker equivalent to add_compile_options,
add_link_options, is only available for CMake version >= 3.13.
So add the sanitizer flags manually to each target's linker options.

Should help with #766 