### PR TITLE
Revert "CMake: use sanitizer flags for internal targets only"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,19 +170,23 @@ if(ENABLE_SANITIZERS)
     endif()
 
     string(REPLACE ";" "," SANITIZE_OPTIONS "${SANITIZE_OPTIONS}")
+
     if (NOT APPLE)
-        set(SANITIZE_FLAGS "-O1;-fsanitize=${SANITIZE_OPTIONS};-fno-sanitize-recover=address,undefined")
+        set(SANITIZE_FLAGS "-O1 -fsanitize=${SANITIZE_OPTIONS} -fno-sanitize-recover=address,undefined")
     else()
-        set(SANITIZE_FLAGS "-O1;-fsanitize=${SANITIZE_OPTIONS}")
+        set(SANITIZE_FLAGS "-O1 -fsanitize=${SANITIZE_OPTIONS}")
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        list(APPEND SANITIZE_FLAGS -fno-omit-frame-pointer -fno-optimize-sibling-calls)
+        set(SANITIZE_FLAGS "${SANITIZE_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        list(APPEND SANITIZE_FLAGS -fuse-ld=gold)
+        set(SANITIZE_FLAGS "${SANITIZE_FLAGS} -fuse-ld=gold")
     else()
         message(FATAL_ERROR "Sanitizers are only available when using GCC or Clang")
     endif()
+
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${SANITIZE_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS}")
 endif()
 
 # common dependencies

--- a/exposed/CMakeLists.txt
+++ b/exposed/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_compile_options(${SANITIZE_FLAGS})
-
 include_directories(
     ${CMAKE_SOURCE_DIR}/include)
 
@@ -7,5 +5,4 @@ add_executable(CDemo
     CDemo.c)
 
 target_link_libraries(CDemo
-    slvs
-    ${SANITIZE_FLAGS})
+    slvs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,10 +26,6 @@ if(APPLE)
         ${APPKIT_LIBRARY})
 endif()
 
-# sanitizers for all code in src and below
-
-add_compile_options(${SANITIZE_FLAGS})
-
 # libslvs
 
 set(libslvs_SOURCES
@@ -59,8 +55,7 @@ target_include_directories(slvs
 
 target_link_libraries(slvs
     ${util_LIBRARIES}
-    mimalloc-static
-    ${SANITIZE_FLAGS})
+    mimalloc-static)
 
 add_dependencies(slvs
     mimalloc-static)
@@ -230,8 +225,7 @@ target_link_libraries(solvespace-core
     ${PNG_LIBRARY}
     ${FREETYPE_LIBRARY}
     flatbuffers
-    mimalloc-static
-    ${SANITIZE_FLAGS})
+    mimalloc-static)
 
 if(Backtrace_FOUND)
     target_link_libraries(solvespace-core
@@ -338,8 +332,7 @@ if(ENABLE_GUI)
         solvespace-core
         ${OPENGL_LIBRARIES}
         ${platform_LIBRARIES}
-        ${COVERAGE_LIBRARY}
-        ${SANITIZE_FLAGS})
+        ${COVERAGE_LIBRARY})
 
     if(MSVC)
         set_target_properties(solvespace PROPERTIES
@@ -368,8 +361,7 @@ target_include_directories(solvespace-headless
 
 target_link_libraries(solvespace-headless
     solvespace-core
-    ${CAIRO_LIBRARIES}
-    ${SANITIZE_FLAGS})
+    ${CAIRO_LIBRARIES})
 
 target_compile_options(solvespace-headless
     PRIVATE ${COVERAGE_FLAGS})
@@ -383,8 +375,7 @@ if(ENABLE_CLI)
 
     target_link_libraries(solvespace-cli
         solvespace-core
-        solvespace-headless
-        ${SANITIZE_FLAGS})
+        solvespace-headless)
 
     add_dependencies(solvespace-cli
         resources)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,8 +11,6 @@ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
     add_definitions(-DTEST_BUILD_ON_WINDOWS)
 endif()
 
-add_compile_options(${SANITIZE_FLAGS})
-
 # test suite
 
 set(testsuite_SOURCES
@@ -76,8 +74,7 @@ add_executable(solvespace-testsuite
 
 target_link_libraries(solvespace-testsuite
     solvespace-headless
-    ${COVERAGE_LIBRARY}
-    ${SANITIZE_FLAGS})
+    ${COVERAGE_LIBRARY})
 
 add_dependencies(solvespace-testsuite
     resources)
@@ -135,8 +132,7 @@ add_executable(solvespace-debugtool
 
 target_link_libraries(solvespace-debugtool
     solvespace-core
-    solvespace-headless
-    ${SANITIZE_FLAGS})
+    solvespace-headless)
 
 add_dependencies(solvespace-debugtool
     resources)


### PR DESCRIPTION
This reverts commit 68b1abf77f5c8858659a51b8bdbf760effb53b66.

The warnings are valuable and shouldn't be cast aside.
As of 8f509f1, we special case macOS and don't set -fno-sanitize-recover
to allow CI to succeed.
In the future, this could be made stricter again by only suppressing
known bugs, which ideally should also be fixed or reported upstream.