### PR TITLE
Performance: inline the Bernstein functions

### DIFF
--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -13,8 +13,7 @@
 // and convergence should be fast by now.
 #define RATPOLY_EPS (LENGTH_EPS/(1e2))
 
-static double Bernstein(int k, int deg, double t)
-{
+static inline double Bernstein(int k, int deg, double t) {
 // indexed by [degree][k][exponent]
     static const double bernstein_coeff[4][4][4] = {
     { { 1.0,0.0,0.0,0.0 },  { 1.0,0.0,0.0,0.0 }, { 1.0,0.0,0.0,0.0 }, { 1.0,0.0,0.0,0.0 } },
@@ -22,21 +21,18 @@ static double Bernstein(int k, int deg, double t)
     { { 1.0,-2.0,1.0,0.0 }, { 0.0,2.0,-2.0,0.0 },{ 0.0,0.0,1.0,0.0 }, { 0.0,0.0,0.0,0.0 } },
     { { 1.0,-3.0,3.0,-1.0 },{ 0.0,3.0,-6.0,3.0 },{ 0.0,0.0,3.0,-3.0}, { 0.0,0.0,0.0,1.0 } } };
 
-    const double *c;
-    c = bernstein_coeff[deg][k];
+    const double *c = bernstein_coeff[deg][k];
     return (((c[3]*t+c[2])*t)+c[1])*t+c[0];
 }
 
-static double BernsteinDerivative(int k, int deg, double t)
-{
+static inline double BernsteinDerivative(int k, int deg, double t) {
     static const double bernstein_derivative_coeff[4][4][3] = {
     { { 0.0,0.0,0.0 },  { 0.0,0.0,0.0 }, { 0.0,0.0,0.0 }, { 0.0,0.0,0.0 } },
     { { -1.0,0.0,0.0 }, { 1.0,0.0,0.0 }, { 0.0,0.0,0.0 }, { 0.0,0.0,0.0 } },
     { { -2.0,2.0,0.0 }, { 2.0,-4.0,0.0 },{ 0.0,2.0,0.0 }, { 0.0,0.0,0.0 } },
     { { -3.0,6.0,-3.0 },{ 3.0,-12.0,9.0 },{ 0.0,6.0,-9.0}, { 0.0,0.0,3.0 } } };
 
-    const double *c;
-    c = bernstein_derivative_coeff[deg][k];
+    const double *c = bernstein_derivative_coeff[deg][k];
     return ((c[2]*t)+c[1])*t+c[0];
 }
 


### PR DESCRIPTION
This is another small profiling driven optimization.
Moving the initialization of `const double *c` as part of the definition also helps with the generated assembler.