### PR TITLE
Add end marker to text window and increase max rows.

### DIFF
--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -338,11 +338,22 @@ void TextWindow::ClearScreen() {
     rows = 0;
 }
 
+// This message was addded when someone had too many fonts for the text window
+// Scrolling seemed to be broken, but was actaully at the MAX_ROWS.
+static const char* endString = "    **** End of Text Screen ****";
+
 void TextWindow::Printf(bool halfLine, const char *fmt, ...) {
     if(!canvas) return;
 
     if(rows >= MAX_ROWS) return;
 
+    if(rows >= MAX_ROWS-2 && (fmt != endString)) {
+        // twice due to some half-row issues on resizing
+        Printf(halfLine, endString);
+        Printf(halfLine, endString);
+        return;
+    }
+    
     va_list vl;
     va_start(vl, fmt);
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -179,7 +179,7 @@ public:
     enum {
         MAX_COLS = 100,
         MIN_COLS = 45,
-        MAX_ROWS = 2000
+        MAX_ROWS = 4000
     };
 
     typedef struct {


### PR DESCRIPTION
Fixes issue #779 by
1) increasing max rows in the text window
2) adding a marker at the end so we know what's happening next time someone hits it.