### PR TITLE
Fix unsequenced modification and access warnings.

### DIFF
--- a/src/exportstep.cpp
+++ b/src/exportstep.cpp
@@ -282,24 +282,34 @@ void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
                 ss->color.greenF(), ss->color.blueF());
 
 /*      // This works in Kisters 3DViewStation but not in KiCAD and Horison EDA,
-		// it seems they do not support transparency so use the more verbose one below
+        // it seems they do not support transparency so use the more verbose one below
         fprintf(f, "#%d=SURFACE_STYLE_TRANSPARENT(%.2f);\n", ++id, 1.0 - ss->color.alphaF());
+        ++id;
         fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n",
-                ++id, id - 2, id - 1);
-        fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d));\n", ++id, id - 1);
+                id, id - 2, id - 1);
+        ++id;
+        fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d));\n", id, id - 1);
 */
 
         // This works in Horison EDA but is more verbose.
-        fprintf(f, "#%d=FILL_AREA_STYLE_COLOUR('',#%d);\n", ++id, id - 1);
-        fprintf(f, "#%d=FILL_AREA_STYLE('',(#%d));\n", ++id, id - 1);
-        fprintf(f, "#%d=SURFACE_STYLE_FILL_AREA(#%d);\n", ++id, id - 1);
+        ++id;
+        fprintf(f, "#%d=FILL_AREA_STYLE_COLOUR('',#%d);\n", id, id - 1);
+        ++id;
+        fprintf(f, "#%d=FILL_AREA_STYLE('',(#%d));\n", id, id - 1);
+        ++id;
+        fprintf(f, "#%d=SURFACE_STYLE_FILL_AREA(#%d);\n", id, id - 1);
         fprintf(f, "#%d=SURFACE_STYLE_TRANSPARENT(%.2f);\n", ++id, 1.0 - ss->color.alphaF());
-        fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n", ++id, id - 5, id - 1);
-        fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d, #%d));\n", ++id, id - 3, id - 1);
+        ++id;
+        fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n", id, id - 5, id - 1);
+        ++id;
+        fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d, #%d));\n", id, id - 3, id - 1);
 
-        fprintf(f, "#%d=SURFACE_STYLE_USAGE(.BOTH.,#%d);\n", ++id, id - 1);
-        fprintf(f, "#%d=PRESENTATION_STYLE_ASSIGNMENT((#%d));\n", ++id, id - 1);
-        fprintf(f, "#%d=STYLED_ITEM('',(#%d),#%d);\n", ++id, id - 1, advFaceId);
+        ++id;
+        fprintf(f, "#%d=SURFACE_STYLE_USAGE(.BOTH.,#%d);\n", id, id - 1);
+        ++id;
+        fprintf(f, "#%d=PRESENTATION_STYLE_ASSIGNMENT((#%d));\n", id, id - 1);
+        ++id;
+        fprintf(f, "#%d=STYLED_ITEM('',(#%d),#%d);\n", id, id - 1, advFaceId);
         fprintf(f, "\n");        
         
         id++;


### PR DESCRIPTION
Found by clang 11. They are a potential problem.

[ 21%] Building CXX object src/CMakeFiles/solvespace-core.dir/exportstep.cpp.obj
.\src\exportstep.cpp:293:61: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=FILL_AREA_STYLE_COLOUR('',#%d);\n", ++id, id - 1);
                                                            ^     ~~
.\src\exportstep.cpp:294:56: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=FILL_AREA_STYLE('',(#%d));\n", ++id, id - 1);
                                                       ^     ~~
.\src\exportstep.cpp:295:59: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=SURFACE_STYLE_FILL_AREA(#%d);\n", ++id, id - 1);
                                                          ^     ~~
.\src\exportstep.cpp:297:98: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=SURFACE_STYLE_RENDERING_WITH_PROPERTIES(.NORMAL_SHADING.,#%d,(#%d));\n", ++id, id - 5, id - 1);
                                                                                                 ^     ~~
.\src\exportstep.cpp:298:64: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=SURFACE_SIDE_STYLE('',(#%d, #%d));\n", ++id, id - 3, id - 1);
                                                               ^     ~~
.\src\exportstep.cpp:300:62: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=SURFACE_STYLE_USAGE(.BOTH.,#%d);\n", ++id, id - 1);
                                                             ^     ~~
.\src\exportstep.cpp:301:67: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=PRESENTATION_STYLE_ASSIGNMENT((#%d));\n", ++id, id - 1);
                                                                  ^     ~~
.\src\exportstep.cpp:302:56: warning: unsequenced modification and access to 'id'      [-Wunsequenced]
        fprintf(f, "#%d=STYLED_ITEM('',(#%d),#%d);\n", ++id, id - 1, advFaceId);
                                                       ^     ~~
8 warnings generated.