### PR TITLE
Travis: build snaps in LXD containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,18 +91,20 @@ jobs:
       name: Snap amd64
       os: linux
       arch: amd64
-      dist: bionic
+      dist: focal
       addons:
         snaps:
           - name: snapcraft
             confinement: classic
+          - name: lxd
+      install: .travis/install-snap.sh
       script: .travis/build-snap.sh
       deploy:
         - provider: script
-          script: sudo .travis/deploy-snap.sh edge
+          script: .travis/deploy-snap.sh edge
           skip_cleanup: true
         - provider: script
-          script: sudo .travis/deploy-snap.sh edge,beta
+          script: .travis/deploy-snap.sh edge,beta
           skip_cleanup: true
           on:
             tags: true
@@ -110,4 +112,4 @@ jobs:
       name: Snap arm64
       arch: arm64-graviton2
       group: edge
-      virt: lxd
+      virt: vm

--- a/.travis/build-snap.sh
+++ b/.travis/build-snap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh -xe
 
-sudo apt-get update
-sudo ./pkg/snap/build.sh --destructive-mode
+./pkg/snap/build.sh --use-lxd

--- a/.travis/deploy-snap.sh
+++ b/.travis/deploy-snap.sh
@@ -4,5 +4,5 @@ channels="$1"
 echo "$SNAP_TOKEN" | snapcraft login --with -
 
 for snap in ./pkg/snap/*.snap; do
-  snapcraft push "$snap" --release "$channels"
+  snapcraft upload "$snap" --release "$channels"
 done

--- a/.travis/install-snap.sh
+++ b/.travis/install-snap.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -xe
+
+sudo /snap/bin/lxd waitready
+sudo /snap/bin/lxd init --auto
+sudo chgrp travis /var/snap/lxd/common/lxd/unix.socket
+mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"


### PR DESCRIPTION
With arm64-graviton2 now providing full VM virtualization, LXD containers
can be used to build snaps on all architectures.

This is beneficial for us as having snapcraft manage the whole build
environment is likely to yield better/more consistent results than
running the builds on the Travis images directly.

Also use snapcraft upload instead of depreciated push.

My hope is that this gets rid of the slightly mysterious `/tmp/snapcraft-2494/run-1.sh: 88: /tmp/snapcraft-2494/run-1.sh: Syntax error: "(" unexpected` build failures.