### PR TITLE
Set the default font for text objects correctly.

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1117,7 +1117,7 @@ void GraphicsWindow::MouseLeftDown(double mx, double my, bool shiftDown, bool ct
                     AddToPending(hr);
                     Request *r = SK.GetRequest(hr);
                     r->str = "Abc";
-                    r->font = "BitstreamVeraSans-Roman-builtin.ttf";
+                    r->font = Platform::embeddedFont;
 
                     for(int i = 1; i <= 4; i++) {
                         SK.GetEntity(hr.entity(i))->PointForceTo(v);

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -17,6 +17,12 @@ std::string Narrow(const std::wstring &s);
 std::wstring Widen(const std::string &s);
 #endif
 
+#if defined(_WIN32)
+    const std::string embeddedFont = "res://fonts/BitstreamVeraSans-Roman-builtin.ttf";
+#else   // Linux and macOS
+    const std::string embeddedFont = "BitstreamVeraSans-Roman-builtin.ttf";
+#endif
+
 // A filesystem path, respecting the conventions of the current platform.
 // Transformation functions return an empty path on error.
 class Path {


### PR DESCRIPTION
The default font is BitstreamVeraSans-Roman-builtin.ttf since 94b26ddfac0c,
but the URI was incorrectly set.

Fixes: https://github.com/solvespace/solvespace/issues/821