### PR TITLE
UI: Display "err" in the property browser only if "check sketch for closed contour"

### DIFF
--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -143,7 +143,7 @@ void TextWindow::ShowListOfGroups() {
                // Link to the errors, if a problem occurred while solving
                ok ? (warn ? 'm' : (dof > 0 ? 'i' : 's')) : 'x',
                g->h.v, (&TextWindow::ScreenHowGroupSolved),
-               ok ? (warn ? "err" : sdof) : "",
+               ok ? ((warn && SS.checkClosedContour) ? "err" : sdof) : "",
                ok ? "" : "ERR",
                // Link to a screen that gives more details on the group
                g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str());


### PR DESCRIPTION
... is enabled.

"err" was first introduced in c2c26e95adb to indicate sketches that may cause
problems in the subsequent 3D groups. But is makes sense not to display the
error if the "check sketch for closed contour" option is turned off. The user
obviously does not want to be warned.

Based on a suggestion in https://github.com/solvespace/solvespace/issues/819