### PR TITLE
Swap vertical and horizontal constraints when rotating 90/270 degrees

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -245,6 +245,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
         c.reference = cc->reference;
         c.disp = cc->disp;
         c.comment = cc->comment;
+        bool removeConstraint = false;
         switch(c.type) {
             case Constraint::Type::COMMENT:
                 c.disp.offset = c.disp.offset.Plus(trans);
@@ -259,21 +260,25 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
             case Constraint::Type::HORIZONTAL:
             case Constraint::Type::VERTICAL:
                 // When rotating 90 or 270 degrees, swap the vertical / horizontal constaints
-                if (theta == PI/2 || theta == PI*1.5) {
+                dbp("Remainder: %f", fmod(theta + (PI / 2), PI));
+                if (fmod(theta + (PI/2), PI) == 0) {
                     if(c.type == Constraint::Type::HORIZONTAL) {
                         c.type = Constraint::Type::VERTICAL;
                     } else {
                         c.type = Constraint::Type::HORIZONTAL;
                     }
+                } else if (fmod(theta, PI/2) != 0) {
+                    removeConstraint = true;
                 }
                 break;
             default:
                 break;
         }
-
-        hConstraint hc = Constraint::AddConstraint(&c, /*rememberForUndo=*/false);
-        if(c.type == Constraint::Type::COMMENT) {
-            MakeSelected(hc);
+        if (!removeConstraint) {
+            hConstraint hc = Constraint::AddConstraint(&c, /*rememberForUndo=*/false);
+            if(c.type == Constraint::Type::COMMENT) {
+                MakeSelected(hc);
+            }
         }
     }
 }

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -227,7 +227,6 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
             MakeSelected(hr.entity(j));
         }
     }
-
     Constraint *cc;
     for(cc = SS.clipboard.c.First(); cc; cc = SS.clipboard.c.NextAfter(cc)) {
         Constraint c = {};
@@ -257,7 +256,17 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
             case Constraint::Type::DIAMETER:
                 c.valA *= fabs(scale);
                 break;
-
+            case Constraint::Type::HORIZONTAL:
+            case Constraint::Type::VERTICAL:
+                // When rotating 90 or 270 degrees, swap the vertical / horizontal constaints
+                if (theta == PI/2 || theta == PI*1.5) {
+                    if(c.type == Constraint::Type::HORIZONTAL) {
+                        c.type = Constraint::Type::VERTICAL;
+                    } else {
+                        c.type = Constraint::Type::HORIZONTAL;
+                    }
+                }
+                break;
             default:
                 break;
         }

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -260,8 +260,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
             case Constraint::Type::HORIZONTAL:
             case Constraint::Type::VERTICAL:
                 // When rotating 90 or 270 degrees, swap the vertical / horizontal constaints
-                dbp("Remainder: %f", fmod(theta + (PI / 2), PI));
-                if (fmod(theta + (PI/2), PI) == 0) {
+                if (EXACT(fmod(theta + (PI/2), PI) == 0)) {
                     if(c.type == Constraint::Type::HORIZONTAL) {
                         c.type = Constraint::Type::VERTICAL;
                     } else {


### PR DESCRIPTION
I noticed, when paste-rotating my sketch at 90 degrees, that the vertical and horizontal constraints didn't get updated.
This fixes it.

Should we also take multiples of "X" in: `90+(X*180)`? and negative numbers? (sorry, couldn't explain it better).