### PR TITLE
Clipboard fixes

### DIFF
--- a/src/sketch.h
+++ b/src/sketch.h
@@ -790,6 +790,9 @@ public:
     static hConstraint TryConstrain(Constraint::Type type, hEntity ptA, hEntity ptB,
                                     hEntity entityA, hEntity entityB = Entity::NO_ENTITY,
                                     bool other = false, bool other2 = false);
+    static void ConstrainArcLineTangent(Constraint *c, Entity *line, Entity *arc);
+    static void ConstrainCubicLineTangent(Constraint *c, Entity *line, Entity *cubic);
+    static void ConstrainCurveCurveTangent(Constraint *c, Entity *eA, Entity *eB);
 };
 
 class hEquation {


### PR DESCRIPTION
I found some more oddities with paste transformed.

I am hoping I can solve them and am planning to add some new tests for these as well.

~~The first thing I noticed is that rotating happens in counter clockwise direction (at least in the workplane that is opened by default when starting a new sketch)~~ stupid me, scrap that.

The second thing I noticed is that when flipping an arc with tangent constraints, the arc gets inverted, removing the constraints fixes this, but there should be a better way to actually invert the arc which I haven't found yet.

Here is a little sketch to try out.

[rotate-and-flip-me.slvs.zip](https://github.com/solvespace/solvespace/files/5621762/rotate-and-flip-me.slvs.zip)
