### PR TITLE
Fix Save As shortcut

### DIFF
--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -904,6 +904,9 @@ void SolveSpaceUI::MenuAnalyze(Command id) {
             break;
 
         case Command::STOP_TRACING: {
+            if (SS.traced.point == Entity::NO_ENTITY) {
+                break;
+            }
             Platform::FileDialogRef dialog = Platform::CreateSaveFileDialog(SS.GW.window);
             dialog->AddFilters(Platform::CsvFileFilters);
             dialog->ThawChoices(settings, "Trace");


### PR DESCRIPTION
This removes the shortcut for Stop tracing, and maps it to Save As instead.

I have been modelling a lot yesterday and actually lost 2 models because I am used to use the Cmd+Shift+S shortcut for Save As.

However, (very unnoticeable) it actually prompts to save a CSV for the trace.
The result, you are left with an empty CSV file in stead of the model.

I removed the Stop Tracing shortcut (maybe we can assign something else to it?)

**Save As** is now `Ctrl ` + `Shift` + `S` for Linux, `Cmd` + `Shift` + `S` and macOS, and `Ctrl` + `F12` on Windows