### PR TITLE
Fix selection bugs

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -207,8 +207,8 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
 //-----------------------------------------------------------------------------
 void GraphicsWindow::SelectByMarquee() {
     Point2d marqueePoint = ProjectPoint(orig.marqueePoint);
-    BBox marqueeBBox = BBox::From(Vector::From(marqueePoint.x, marqueePoint.y, -1),
-                                  Vector::From(orig.mouse.x,   orig.mouse.y,    1));
+    BBox marqueeBBox = BBox::From(Vector::From(marqueePoint.x, marqueePoint.y, VERY_NEGATIVE),
+                                  Vector::From(orig.mouse.x,   orig.mouse.y,   VERY_POSITIVE));
 
     Entity *e;
     for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -64,7 +64,7 @@ BBox Entity::GetOrGenerateScreenBBox(bool *hasBBox) {
         Vector proj = SS.GW.ProjectPoint3(PointGetNum());
         screenBBox = BBox::From(proj, proj);
     } else if(IsNormal()) {
-        Vector proj = SK.GetEntity(point[0])->PointGetNum();
+        Vector proj = SS.GW.ProjectPoint3(SK.GetEntity(point[0])->PointGetNum());
         screenBBox = BBox::From(proj, proj);
     } else if(!sbl->l.IsEmpty()) {
         Vector first = SS.GW.ProjectPoint3(sbl->l[0].ctrl[0]);

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -70,7 +70,7 @@ BBox Entity::GetOrGenerateScreenBBox(bool *hasBBox) {
         Vector first = SS.GW.ProjectPoint3(sbl->l[0].ctrl[0]);
         screenBBox = BBox::From(first, first);
         for(auto &sb : sbl->l) {
-            for(int i = 0; i < sb.deg; ++i) { screenBBox.Include(SS.GW.ProjectPoint3(sb.ctrl[i])); }
+            for(int i = 0; i <= sb.deg; ++i) { screenBBox.Include(SS.GW.ProjectPoint3(sb.ctrl[i])); }
         }
     } else
         ssassert(false, "Expected entity to be a point or have beziers");


### PR DESCRIPTION
I noticed that sometimes normals would get selected even when I didn't select them.
So I added some code to visualise the bounding boxes, which showed me this:

<img width="3200" alt="Screenshot 2020-12-16 at 17 21 16" src="https://user-images.githubusercontent.com/876117/102377706-41348400-3fc5-11eb-9163-504fc749e143.png">

Notice the little yellow dots around the center of the drawing, these are the normals of the arcs.

I then also noticed that when in "3d view", the selection didn't work sometimes, this was caused by the selection marquee only having a "depth" of 1 ... "unit" ?

This PR fixes both of these things, I wonder though, if for the BBox we should add a "FlatOverlap / Overlap2d" check that ignores the Z value, right now I am using the VERY_NEGATIVE and VERY_POSITIVE values for the Z range which is not optimal.

Here is the code for drawing the BBoxes by the way if anyone is interested:

```
+        // Draw the bboxes
+        Entity *e;
+        for(e = SK.entity.First(); e; e = SK.entity.NextAfter(e)) {
+            if(e->group != SS.GW.activeGroup) continue;
+            if(e->IsFace() || e->IsDistance()) continue;
+            if(!e->IsVisible()) continue;
+            bool entityHasBBox;
+            BBox entityBBox = e->GetOrGenerateScreenBBox(&entityHasBBox);
+            if (entityHasBBox) {
+                uiCanvas.DrawRect((int)(entityBBox.minp.x - 1) + (int)camera.width / 2,
+                    (int)(entityBBox.maxp.x + 1) + (int)camera.width / 2,
+                    (int)(entityBBox.minp.y - 1) + (int)camera.height / 2,
+                    (int)(entityBBox.maxp.y + 1) + (int)camera.height / 2,
+                    /*fillColor=*/Style::Color(Style::HOVERED).WithAlpha(25),
+                    /*outlineColor=*/Style::Color(Style::HOVERED));
+            }
+        }
```

I added that code right underneath the following code in draw.cpp:

```
    // If a marquee selection is in progress, then draw the selection
    // rectangle, as an outline and a transparent fill.
    if(pending.operation == Pending::DRAGGING_MARQUEE) {
        Point2d begin = ProjectPoint(orig.marqueePoint);
        uiCanvas.DrawRect((int)orig.mouse.x + (int)camera.width / 2,
                          (int)begin.x + (int)camera.width / 2,
                          (int)orig.mouse.y + (int)camera.height / 2,
                          (int)begin.y + (int)camera.height / 2,
                          /*fillColor=*/Style::Color(Style::HOVERED).WithAlpha(25),
                          /*outlineColor=*/Style::Color(Style::HOVERED));
```

I wonder if the Z range was intentional to not select "all the way through". However, If that was the case I guess it would be better to only select visible things in stead of only selecting things around Z=0