### PR TITLE
Fix snap to grid not working in some situations

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -1175,10 +1175,7 @@ void GraphicsWindow::MenuEdit(Command id) {
             }
             // Regenerate, with these points marked as dragged so that they
             // get placed as close as possible to our snap grid.
-            SS.GW.ClearPending();
-
             SS.GW.ClearSelection();
-            SS.GW.Invalidate();
             break;
         }
 


### PR DESCRIPTION
I found that snap to grid was still not working in some cases, looking at the code, I think this line:

```
SS.GW.ClearPending()
```

Got added unintentionally.

Also, `SS.GW.ClearSelection();` already seems to call `SS.GW.Invalidate();`, so I removed the `SS.GW.Invalidate();` call as well.

After this change snap to grid seems to be working fine.

I wonder if the pending list should still be cleared though, perhaps after the call to ClearSelection.

Will look into this.

To test the broken snap to grid, turn the grid on, draw a rectangle, try to snap each corner, some (might) fail.
