### PR TITLE
Add menu checkbox Dim Solid for Sketch Groups. Makes shadowing the sol…

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -92,6 +92,7 @@ const MenuEntry Menu[] = {
 { 1, N_("&Center View At Point"),       Command::CENTER_VIEW,      F|4,     KN, mView  },
 { 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
 { 1, N_("Show Snap &Grid"),             Command::SHOW_GRID,        '>',     KC, mView  },
+{ 1, N_("Dim Solid for Sketch Groups"), Command::DIM_SOLID_MODEL,  0,       KC, mView  },
 { 1, N_("Use &Perspective Projection"), Command::PERSPECTIVE_PROJ, '`',     KC, mView  },
 { 1, N_("Dimension &Units"),            Command::NONE,             0,       KN, NULL  },
 { 2, N_("Dimensions in &Millimeters"),  Command::UNITS_MM,         0,       KR, mView },
@@ -312,6 +313,8 @@ void GraphicsWindow::PopulateMainMenu() {
 
             if(Menu[i].cmd == Command::SHOW_GRID) {
                 showGridMenuItem = menuItem;
+            } else if(Menu[i].cmd == Command::DIM_SOLID_MODEL) {
+                dimSolidModelMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::PERSPECTIVE_PROJ) {
                 perspectiveProjMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::SHOW_TOOLBAR) {
@@ -406,6 +409,7 @@ void GraphicsWindow::Init() {
     showTextWindow = true;
 
     showSnapGrid = false;
+    dimSolidModel = true;
     context.active = false;
     toolbarHovered = Command::NONE;
 
@@ -722,6 +726,12 @@ void GraphicsWindow::MenuView(Command id) {
             }
             break;
 
+        case Command::DIM_SOLID_MODEL:
+            SS.GW.dimSolidModel = !SS.GW.dimSolidModel;
+            SS.GW.EnsureValidActives();
+            SS.GW.Invalidate(/*clearPersistent=*/true);
+            break;
+
         case Command::PERSPECTIVE_PROJ:
             SS.usePerspectiveProj = !SS.usePerspectiveProj;
             SS.GW.EnsureValidActives();
@@ -923,6 +933,7 @@ void GraphicsWindow::EnsureValidActives() {
     showTextWndMenuItem->SetActive(SS.GW.showTextWindow);
 
     showGridMenuItem->SetActive(SS.GW.showSnapGrid);
+    dimSolidModelMenuItem->SetActive(SS.GW.dimSolidModel);
     perspectiveProjMenuItem->SetActive(SS.usePerspectiveProj);
     showToolbarMenuItem->SetActive(SS.showToolbar);
     fullScreenMenuItem->SetActive(SS.GW.window->IsFullScreen());

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -569,7 +569,8 @@ void Group::DrawMesh(DrawMeshAs how, Canvas *canvas) {
             if(!SS.GW.showShaded) {
                 fillFront.layer = Canvas::Layer::DEPTH_ONLY;
             }
-            if(type == Type::DRAWING_3D || type == Type::DRAWING_WORKPLANE) {
+            if((type == Type::DRAWING_3D || type == Type::DRAWING_WORKPLANE)
+               && SS.GW.dimSolidModel) {
                 fillFront.color = Style::Color(Style::DIM_SOLID);
             }
             Canvas::hFill hcfFront = canvas->GetFill(fillFront);

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -1018,6 +1018,7 @@ void SolveSpaceUI::Clear() {
     GW.openRecentMenu = NULL;
     GW.linkRecentMenu = NULL;
     GW.showGridMenuItem = NULL;
+    GW.dimSolidModelMenuItem = NULL;
     GW.perspectiveProjMenuItem = NULL;
     GW.showToolbarMenuItem = NULL;
     GW.showTextWndMenuItem = NULL;

--- a/src/ui.h
+++ b/src/ui.h
@@ -80,6 +80,7 @@ enum class Command : uint32_t {
     ZOOM_OUT,
     ZOOM_TO_FIT,
     SHOW_GRID,
+    DIM_SOLID_MODEL,
     PERSPECTIVE_PROJ,
     ONTO_WORKPLANE,
     NEAREST_ORTHO,
@@ -532,6 +533,7 @@ public:
     Platform::MenuRef linkRecentMenu;
 
     Platform::MenuItemRef showGridMenuItem;
+    Platform::MenuItemRef dimSolidModelMenuItem;
     Platform::MenuItemRef perspectiveProjMenuItem;
     Platform::MenuItemRef showToolbarMenuItem;
     Platform::MenuItemRef showTextWndMenuItem;
@@ -803,6 +805,7 @@ public:
     DrawOccludedAs drawOccludedAs;
 
     bool    showSnapGrid;
+    bool    dimSolidModel;
     void DrawSnapGrid(Canvas *canvas);
 
     void AddPointToDraggedList(hEntity hp);


### PR DESCRIPTION
…id optional for sketch in 2d/3d groups. Handy for making dimensioned drawings by putting dims in their own group. #834

This works but the change does not take effect until we select a group or other operations. I'm not sure how to trigger the needed redrawing when the checkbox option changes. Help?