### PR TITLE
Win32: Avoid the "Default Beep" sound in "Еrror" and "Message" dialogs

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1450,7 +1450,10 @@ public:
     void SetType(Type type) override {
         switch(type) {
             case Type::INFORMATION:
-                style = MB_ICONINFORMATION;
+                style         = MB_USERICON; // Avoid beep
+                mbp.hInstance = GetModuleHandle(NULL);
+                mbp.lpszIcon  = MAKEINTRESOURCE(4000);  // Use SolveSpace icon
+                // mbp.lpszIcon = IDI_INFORMATION;
                 break;
 
             case Type::QUESTION:
@@ -1462,7 +1465,10 @@ public:
                 break;
 
             case Type::ERROR:
-                style = MB_ICONERROR;
+                style         = MB_USERICON; // Avoid beep
+                mbp.hInstance = GetModuleHandle(NULL);
+                mbp.lpszIcon  = MAKEINTRESOURCE(4000); // Use SolveSpace icon
+                // mbp.lpszIcon = IDI_ERROR;
                 break;
         }
     }


### PR DESCRIPTION
On Windows SolveSpace 2.3 uses a plain dialog for `SolveSpace::Error` and
`SolveSpace::Message` with no icon and no system beep. After the GUI
abstraction was reworked this changed to the default system message boxes
(using MessageBoxIndirectW) that play the "Default Beep" sound and show
red "X" and blue "i" icons respectively.

The beep is annoying since the error and message dialogs are used often to
show required conditions for constraints, new groups and other behaviors.

This disables the beep and uses the SolveSpace icon.

Fixes: 719