### PR TITLE
WIP: Don't show small values as 0.0

### DIFF
--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -331,7 +331,13 @@ const char *SolveSpaceUI::UnitName() {
 
 std::string SolveSpaceUI::MmToString(double v) {
     v /= MmPerUnit();
-    return ssprintf("%.*f", UnitDigitsAfterDecimal(), v);
+    int digits = UnitDigitsAfterDecimal();
+    double minimum = 0.5 * pow(10,-digits);
+    while ((v < minimum) && (v > LENGTH_EPS)) {
+        digits++;
+        minimum *= 0.1;
+    }
+    return ssprintf("%.*f", digits, v);
 }
 static const char *DimToString(int dim) {
     switch(dim) {


### PR DESCRIPTION
Looking for feedback on this one. It relates to issue #835. I don't know if "0..." is a good thing. We could also figure out the minimum number of digits to display a non-zero value and override the setting (I think that's preferable).

Thoughts?