### PR TITLE
Correct toolbar height calculation

### DIFF
--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -615,7 +615,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
                     double w = 60 - camera.width  / 2.0;
                     // Shift the axis to the right if they would overlap with the toolbar.
                     if(SS.showToolbar) {
-                        if(h + 30 > -(34*16 + 3*16 + 8) / 2)
+                        if(h + 30 > -(32*18 + 3*16 + 8) / 2)
                             w += 60;
                     }
                     tail = camera.projRight.ScaledBy(w/s).Plus(

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -157,7 +157,7 @@ bool GraphicsWindow::ToolbarDrawOrHitTest(int mx, int my, UiCanvas *canvas,
 
     // When changing these values, also change the asReference drawing code in drawentity.cpp.
     int fudge = 8;
-    int h = 36*16 + 3*16 + fudge;
+    int h = 32*18 + 3*16 + fudge;
     int aleft = 0, aright = 66, atop = y+16+fudge/2, abot = y+16-h;
 
     bool withinToolbar =


### PR DESCRIPTION
The toolbar height is

`int fudge = 8;`
`int h = 32*18 + 3*16 + fudge;`

It means 18 icons 32 pixels each and 3 separators 16 pixels each.

`32*18 + 3*16 + 8 = 632`
`36*16 + 3*16 + 8 = 632`

See these correct increases of the toolbar height:
https://github.com/ruevs/solvespace/blame/bf4de993cbc752cd063bd7dbaa8ef44b36ec13e4/toolbar.cpp#L97
https://github.com/ruevs/solvespace/blame/fe2ea5d5e1c0a361c78248521fc3cff06ab322a9/toolbar.cpp#L103
https://github.com/ruevs/solvespace/blame/ef5db2132e871e12c667bc2147e94c2cabf37729/src/toolbar.cpp#L112
https://github.com/ruevs/solvespace/blame/ca2aad7fea14b09cd4df39b9a4628781f76624c7/src/toolbar.cpp#L145

And then these incorrect ones:
https://github.com/ruevs/solvespace/blame/3e3ccdca8d6c66080078c46c274cbde645f43cf4/src/toolbar.cpp#L156
https://github.com/ruevs/solvespace/blame/master/src/toolbar.cpp#L160

In addition
https://github.com/ruevs/solvespace/blob/master/src/drawentity.cpp#L618
the point at which the XYZ axis are shifted right so that they do not
overlap with the toolbar is corrected.

The original discussion is here: https://github.com/ruevs/solvespace/commit/d45e2c4c2e814146a11d261f75a5c091162f77f9