### PR TITLE
rate-limit WM_MOUSEMOVE messages so event loop can keep up

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -513,6 +513,7 @@ public:
     HWND hTooltip = NULL;
     HWND hEditor  = NULL;
     WNDPROC editorWndProc = NULL;
+    LONG lastMoveTime = 0;
 
 #if HAVE_OPENGL == 1
     HGLRC hGlRc = NULL;
@@ -937,6 +938,14 @@ public:
                         event.type = MouseEvent::Type::LEAVE;
                         break;
                     case WM_MOUSEMOVE: {
+                        // rate limit mouse move messages to no faster than one per 20ms
+                        LONG mt = GetMessageTime();
+                        if(mt - window->lastMoveTime > 20) {
+                            window->lastMoveTime = mt;
+                        } else {
+                            consumed = true;
+                        }
+
                         event.type = MouseEvent::Type::MOTION;
 
                         if(wParam & MK_LBUTTON) {


### PR DESCRIPTION
This fixes Issue #720 by rate limiting the WM_MOUSEMOVE messages to no faster than one per 20ms.  On my machine this allowed the event loop to keep up and be able to process WM_PAINT messages.  I am not sure if this is the best or even simplest solution.  This should be reviewed by a Windows SS Dev.