### PR TITLE
PeekMessage WM_TIMER in message pump to increase timer reliability

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1699,6 +1699,10 @@ void RunGui() {
     while(GetMessage(&msg, NULL, 0, 0)) {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
+
+        // look for WM_TIMER to boost their priority
+        MSG timer_msg;
+        PeekMessage(&timer_msg, nullptr, WM_TIMER, WM_TIMER, PM_NOREMOVE);
     }
 }
 


### PR DESCRIPTION
@ruevs this synthesizes WM_TIMER messages and inserts them into the message queue.  Windows otherwise will only dispatch these when there queue is empty.  This allows generateAllTimer to fire while drawing new requests.

#720 