### PR TITLE
do not Invalidate() dragging new points to prevent Windows refresh glitches

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -305,7 +305,6 @@ void GraphicsWindow::MouseMoved(double x, double y, bool leftDown,
             HitTestMakeSelection(mp);
             SS.MarkGroupDirtyByEntity(pending.point);
             orig.mouse = mp;
-            Invalidate();
             break;
 
         case Pending::DRAGGING_POINTS:


### PR DESCRIPTION
@ruevs @phkahler   I don't think this Invalidate() is necessary on Windows and also fixes Issue #720.  Since this is in the SS core vs. platform can you please both review and comment on impact on Linux and Mac?