### PR TITLE
Fix a crash when opening an empty file.

### DIFF
--- a/res/locales/de_DE.po
+++ b/res/locales/de_DE.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: 2018-07-19 06:55+0000\n"
 "Last-Translator: Reini Urban <rurban@cpan.org>\n"
 "Language-Team: none\n"
@@ -619,7 +619,11 @@ msgctxt "group-name"
 msgid "#references"
 msgstr "#Referenzen"
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr "Die Datei ist leer. Es kann beschädigt sein."
+
+#: file.cpp:557
 msgid ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
@@ -627,18 +631,18 @@ msgstr ""
 "Nicht erkannte Daten in der Datei. Diese Datei könnte beschädigt sein oder "
 "von einer neueren Version des Programms stammen."
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr "Fehlende Datei"
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr "Die verlinkte Datei “%s” fehlt."
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -650,17 +654,17 @@ msgstr ""
 "Falls Sie ablehnen, wird jegliche mit der fehlenden Datei verknüpfte "
 "Geometrie verworfen."
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr "&Ja"
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr "&Nein"
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr "&Abbrechen"
@@ -1446,105 +1450,105 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr "Trennen nicht möglich; keine Überschneidung gefunden."
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr "Linientyp zuordnen"
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr "Kein Linientyp"
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr "Neu erstellter benutzerdefinierter Linientyp…"
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr "Info zu Gruppe"
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr "Info zu Linientyp"
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr "Kantenverlauf auswählen"
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr "Von/zu Referenzangabe wechseln"
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr "Anderer Komplementärwinkel"
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr "Auf Raster ausrichten"
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr "Spline-Punkt löschen"
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr "Spline-Punkt hinzufügen"
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr ""
 "Spline-Punkt kann nicht hinzugefügt werden: maximale Anzahl der Punkte "
 "erreicht."
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr "Konstruktionselement an/aus"
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr "Einschränkung \"Punkte deckungsgleich\" löschen"
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr "Kopieren"
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr "Alle auswählen"
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr "Einfügen"
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr "Einfügen und transformieren…"
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr "Löschen"
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr "Alle deselektieren"
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr "Aktive deselektieren"
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr "Zoom an Bildschirm anpassen"
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr "Klicken Sie auf den nächsten Punkt der Linie, oder drücken Sie Esc"
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1552,15 +1556,15 @@ msgstr ""
 "Ein Rechteck kann nicht in 3D erstellt werden. Aktivieren Sie zuerst eine "
 "Arbeitsebene mit \"Skizze -> In Arbeitsebene\"."
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr "Klicken Sie auf die gegenüberliegende Ecke des Rechtecks"
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr "Klicken Sie, um den Radius festzulegen"
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1568,23 +1572,23 @@ msgstr ""
 "Ein Kreisbogen kann nicht in 3D erstellt werden. Aktivieren Sie zuerst eine "
 "Arbeitsebene mit \"Skizze -> In Arbeitsebene\"."
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr "Klicken Sie, um einen Punkt zu platzieren"
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr ""
 "Klicken Sie auf den nächsten Punkt der kubischen Linie, oder drücken Sie Esc"
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr ""
 "Eine Arbeitsebene ist bereits aktiv. Skizzieren Sie in 3D, bevor Sie eine "
 "neue Arbeitsebene erstellen."
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1592,11 +1596,11 @@ msgstr ""
 "Text kann nicht in 3D erstellt werden. Aktivieren Sie zuerst eine "
 "Arbeitsebene mit \"Skizze -> In Arbeitsebene\"."
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr "Klicken Sie auf die untere rechte Ecke des Texts"
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1604,7 +1608,7 @@ msgstr ""
 "Das Bild kann nicht in 3D erstellt werden. Aktivieren Sie zuerst eine "
 "Arbeitsebene mit \"Skizze -> In Arbeitsebene\"."
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr "NEUER KOMMENTAR -- DOPPELKLICKEN ZUM BEARBEITEN"
 
@@ -1693,33 +1697,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr "Werte durch Komma getrennt (CSV)"
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr "unbenannt"
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr "Datei öffnen"
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr "_Speichern"
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr "_Öffnen"

--- a/res/locales/en_US.po
+++ b/res/locales/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: 2017-01-05 10:30+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -599,7 +599,11 @@ msgctxt "group-name"
 msgid "#references"
 msgstr "#references"
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr "The file is empty. It may be corrupt."
+
+#: file.cpp:557
 msgid ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
@@ -607,18 +611,18 @@ msgstr ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr "Missing File"
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr "The linked file “%s” is not present."
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -631,17 +635,17 @@ msgstr ""
 "If you decline, any geometry that depends on the missing file will be "
 "permanently removed."
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr "&Yes"
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr "&No"
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr "&Cancel"
@@ -1410,103 +1414,103 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr "Can't split; no intersection found."
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr "Assign to Style"
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr "No Style"
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr "Newly Created Custom Style..."
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr "Group Info"
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr "Style Info"
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr "Select Edge Chain"
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr "Toggle Reference Dimension"
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr "Other Supplementary Angle"
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr "Snap to Grid"
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr "Remove Spline Point"
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr "Add Spline Point"
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr "Cannot add spline point: maximum number of points reached."
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr "Toggle Construction"
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr "Delete Point-Coincident Constraint"
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr "Cut"
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr "Copy"
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr "Select All"
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr "Paste"
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr "Paste Transformed..."
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr "Delete"
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr "Unselect All"
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr "Unselect Hovered"
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr "Zoom to Fit"
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr "click next point of line, or press Esc"
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1514,15 +1518,15 @@ msgstr ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr "click to place other corner of rectangle"
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr "click to set radius"
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1530,21 +1534,21 @@ msgstr ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr "click to place point"
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr "click next point of cubic, or press Esc"
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1552,11 +1556,11 @@ msgstr ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr "click to place bottom right of text"
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1564,7 +1568,7 @@ msgstr ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 
@@ -1653,33 +1657,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr "Comma-separated values"
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr "untitled"
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr "Save File"
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr "Open File"
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr "_Cancel"
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr "_Save"
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr "_Open"

--- a/res/locales/fr_FR.po
+++ b/res/locales/fr_FR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: 2018-07-14 06:12+0000\n"
 "Last-Translator: whitequark <whitequark@whitequark.org>\n"
 "Language-Team: none\n"
@@ -616,7 +616,11 @@ msgctxt "group-name"
 msgid "#references"
 msgstr "#références"
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr ""
+
+#: file.cpp:557
 msgid ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
@@ -624,18 +628,18 @@ msgstr ""
 "Données non reconnues dans le fichier. Ce fichier peut être corrompu ou "
 "depuis une version plus récente du programme."
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr "Fichier manquant"
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr ""
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -644,17 +648,17 @@ msgid ""
 "permanently removed."
 msgstr ""
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr ""
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr ""
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr ""
@@ -1422,104 +1426,104 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr "Impossible de diviser; pas d'intersection trouvée."
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr "Appliquer au style"
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr "Pas de style"
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr "Style personnalisé nouvellement créé ..."
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr "Info Groupe"
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr "Info Style"
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr "Sélection Chaîne d'arêtes"
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr "Basculer cote maîtresse / cote indicative"
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr "Autre angle supplémentaire"
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr "Accrocher à la grille"
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr "Effacer le point de la Spline"
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr "Ajouter un point à la Spline"
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr ""
 "Impossible d'ajouter le point spline: nombre maximum de points atteints."
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr "Basculer en mode \"construction\"."
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr "Effacer la contraint Point-Coïncident"
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr "Couper"
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr "Copier"
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr "Sélectionner tout"
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr "Coller"
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr "Coller transformé..."
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr "Effacer"
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr "Désélectionner tout"
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr "Désélectionner survolé"
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr "Zoom pour ajuster"
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr "cliquez pou le prochain point de ligne or appuyez sur Esc"
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1527,15 +1531,15 @@ msgstr ""
 "Impossible de dessiner un rectangle en 3d; D'abord, activez un plan de "
 "travail avec \"Dessin -> Dans plan de travail\"."
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr "cliquez pour placer un autre coin de rectangle"
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr "cliquez pour ajuster le rayon"
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1543,22 +1547,22 @@ msgstr ""
 "Ne peut pas dessiner l'arc en 3d; D'abord, activez un plan de travail avec "
 "\"Dessin -> Dans plan de travail\"."
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr "cliquez pour placer un point"
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr "cliquez le prochain point cubique ou appuyez sur Esc"
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr ""
 "Vous dessinez déjà dans un plan de travail; Sélectionner \"Dessiner en 3d\" "
 "avant de créer un nouveau plan de travail."
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1566,11 +1570,11 @@ msgstr ""
 "Impossible de dessiner du texte en 3d; D'abord, activer un plan de travail "
 "avec \"Dessin -> Dans plan de travail\"."
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr ""
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
@@ -1578,7 +1582,7 @@ msgstr ""
 "Impossible de dessiner l'image en 3d; D'abord, activez un plan de travail "
 "avec \"Dessin -> Dans plan de travail\"."
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr "NOUVEAU COMMENTAIRE - DOUBLE-CLIQUE POUR EDITER"
 
@@ -1667,33 +1671,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr ""
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr "sans nom"
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr "Sauver fichier"
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr "Ouvrir Fichier"
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr "_Annuler"
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr "_Sauver"
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr ""

--- a/res/locales/ru_RU.po
+++ b/res/locales/ru_RU.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: 2021-01-22 18:50+0700\n"
 "Last-Translator: evilspirit@evilspirit.org\n"
 "Language-Team: EvilSpirit\n"
@@ -615,7 +615,11 @@ msgctxt "group-name"
 msgid "#references"
 msgstr "система-координат"
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr "Файл пуст. Возможно он поврежден."
+
+#: file.cpp:557
 msgid ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
@@ -623,18 +627,18 @@ msgstr ""
 "Некоторые данные из этого файла не распознаны. Возможно, файл поврежден или "
 "создан в более новой версии программы"
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr "Файл Отсутствует"
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr "Связанный файл “%s” отсутствует."
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -646,17 +650,17 @@ msgstr ""
 "Если вы ответите \"Нет\", то вся геометрия, которая зависит от "
 "отсутствующего файла будет удалена."
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr "Да"
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr "Нет"
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr "Отменить"
@@ -1462,159 +1466,159 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr "Невозможно разделить пересекаемые примитивы: пересечений нет."
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr "Применить Стиль"
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr "Стиль по Умолчанию"
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr "Создать Новый Стиль..."
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr "Настройки Группы"
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr "Настройки Стиля"
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr "Выделить Последовательность Примитивов"
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr "Переключить Режим Размера Для Справок"
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr "Переключить Смежный Угол"
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr "Привязать к Сетке"
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr "Удалить Точку Сплайна"
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr "Добавить Точку Сплайна"
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr ""
 "Невозможно добавить точку сплайна: достигнуто ограничение максимального "
 "количества точек для сплайна."
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr "Переключить Режим 'Дополнительные Построения'."
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr "Удалить Ограничение Совпадения Точек"
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr "Вырезать"
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr "Копировать"
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr "Выделить Все"
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr "Вставить"
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr "Вставить с Трансформацией..."
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr "Удалить"
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr "Сбросить Выделение"
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr "Снять Выделение с Выбранного"
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr "Показать Все"
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr "кликните мышью там, где хотите расположить следующую точку"
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr ""
 "Невозможно начертить прямоугольник, когда рабочая плоскость не активна."
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr "кликните мышью там, где хотите расположить другой угол прямоугольника"
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr "кликните, чтобы задать радиус"
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "Невозможно создать дугу, когда нет активной рабочей плоскости."
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr "кликните мышью там, где хотите создать точку"
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr ""
 "кликните мышью там, где хотите создать следующую точку сплайна или нажмите "
 "Esc для завершения операции."
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr ""
 "Рабочая плоскость уже активна. Перейдите в режим 3d перед созданием новой "
 "рабочей плоскости."
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "Невозможно создать текст, когда нет активной рабочей плоскости."
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr "кликните, чтобы расположить правый нижний угол текста"
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "Невозможно создать изображение. Активируйте рабочую плоскость."
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr "КОММЕНТАРИЙ -- ДВОЙНОЙ ЩЕЛЧОК ДЛЯ РЕДАКТИРОВАНИЯ"
 
@@ -1703,33 +1707,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr "CSV файлы (значения, разделенные запятой)"
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr "без имени"
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr "Сохранить Файл"
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr "Открыть Файл"
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr "Отменить"
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr "Сохранить"
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr "_Открыть"

--- a/res/locales/uk_UA.po
+++ b/res/locales/uk_UA.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: 2017-01-05 10:30+0000\n"
 "Last-Translator: appsoft@ua.fm\n"
 "Language-Team: OpenOrienteeringUkraine\n"
@@ -492,24 +492,28 @@ msgctxt "group-name"
 msgid "#references"
 msgstr ""
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr ""
+
+#: file.cpp:557
 msgid ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
 msgstr ""
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr ""
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr ""
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -518,17 +522,17 @@ msgid ""
 "permanently removed."
 msgstr ""
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr ""
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr ""
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr ""
@@ -1243,152 +1247,152 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr ""
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr "Встановити Стиль"
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr "Без Стилю"
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr "Створити Користувацький Стиль..."
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr "Параметри Групи"
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr "Параметри Стилю"
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr "Виділити Ланцюг Ребер"
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr "Перемкнути Відносність Розміру"
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr "Інший Суміжний Кут"
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr "Прикріпити до Сітки"
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr "Видалити Точку Сплайну"
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr "Додати Точку Сплайну"
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr ""
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr "Пермкнути Конструктивність"
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr "Роз'єднати З'єднання Точок"
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr "Вирізати"
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr "Копіювати"
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr "Виділити Усе"
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr "Вставити"
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr "Вставити Трансформованим..."
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr "Видалити"
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr "Зняти Виділення з Усього"
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr "Зняти Виділення з Наведеного"
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr "Умістити на Екрані"
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr ""
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr ""
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr ""
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr ""
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr ""
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr ""
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr ""
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr ""
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr ""
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr ""
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr ""
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr ""
 
@@ -1477,33 +1481,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr ""
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr ""
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr ""
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr ""
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr ""
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr ""
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr ""

--- a/res/locales/zh_CN.po
+++ b/res/locales/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: 2020-09-28 12:42+0800\n"
 "Last-Translator: lomatus@163.com\n"
 "Language-Team: none\n"
@@ -570,24 +570,28 @@ msgctxt "group-name"
 msgid "#references"
 msgstr "#参考"
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr ""
+
+#: file.cpp:557
 msgid ""
 "Unrecognized data in file. This file may be corrupt, or from a newer version "
 "of the program."
 msgstr "未识别文件内数据。该文件可能损坏，或使用新版本应用程序尝试打开。"
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr "文件丢失"
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr "连接的文件不存在：\"%s\"。"
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -596,17 +600,17 @@ msgid ""
 "permanently removed."
 msgstr "您是否想手工查找？如果是，所有基于该丢失文件的几何对象将会被全部删除."
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr "是(&Y)"
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr "否(&N)"
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr "取消(&C)"
@@ -1330,152 +1334,152 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr "无法拆分；未发现较差点。"
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr "指定样式"
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr "无样式"
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr "新组样式。"
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr "组信息"
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr "样式信息"
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr "选择边缘链"
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr "切换参考标注"
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr "其它补充角度"
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr "捕捉至轴网"
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr "删除样条线的点"
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr "增加样条线的点"
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr "无法增加样条线点：超过最大限制。"
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr "切换构造"
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr "删除点一致约束"
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr "剪切"
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr "复制"
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr "全选"
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr "粘贴"
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr "粘贴移动的..."
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr "删除"
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr "取消全选"
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr "取消覆盖区域的全选"
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr "自动缩放"
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr "点击下一个点或取消(ESC)"
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid ""
 "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "无法在3D内绘制矩形; 首先，激活工作面，草图->在工作面。"
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr "点击放置其它矩形倒角"
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr "点击设置半径"
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid ""
 "Can't draw arc in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "无法在3D空间内绘制弧线，可使用 草图->在工作面 激活工作面。"
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr "点击放置点"
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr "点击下一个点或取消(ESC)"
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid ""
 "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr "已经在工作面绘制；在新建工作面前在三维空间绘制。"
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid ""
 "Can't draw text in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "无法在三维空间内绘制文字，可使用 草图->在工作面 激活工作面。"
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr "点击文字的右下角放置"
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid ""
 "Can't draw image in 3d; first, activate a workplane with Sketch -> In "
 "Workplane."
 msgstr "无法在三维空间内绘制图片，可使用 草图->在工作面 激活工作面。"
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr "新备注 - 双击编辑"
 
@@ -1564,33 +1568,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr "逗号分隔数据"
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr "未命名"
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr "保存文件"
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr "打开文件"
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr "取消_C"
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr "保存_S"
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr "打开_O"

--- a/res/messages.pot
+++ b/res/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: SolveSpace 3.0\n"
 "Report-Msgid-Bugs-To: whitequark@whitequark.org\n"
-"POT-Creation-Date: 2021-01-17 19:54+0200\n"
+"POT-Creation-Date: 2021-02-01 15:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -473,22 +473,26 @@ msgctxt "group-name"
 msgid "#references"
 msgstr ""
 
-#: file.cpp:549
+#: file.cpp:552
+msgid "The file is empty. It may be corrupt."
+msgstr ""
+
+#: file.cpp:557
 msgid "Unrecognized data in file. This file may be corrupt, or from a newer version of the program."
 msgstr ""
 
-#: file.cpp:859
+#: file.cpp:867
 msgctxt "title"
 msgid "Missing File"
 msgstr ""
 
-#: file.cpp:860
+#: file.cpp:868
 #, c-format
 msgctxt "dialog"
 msgid "The linked file “%s” is not present."
 msgstr ""
 
-#: file.cpp:862
+#: file.cpp:870
 msgctxt "dialog"
 msgid ""
 "Do you want to locate it manually?\n"
@@ -496,17 +500,17 @@ msgid ""
 "If you decline, any geometry that depends on the missing file will be permanently removed."
 msgstr ""
 
-#: file.cpp:865
+#: file.cpp:873
 msgctxt "button"
 msgid "&Yes"
 msgstr ""
 
-#: file.cpp:867
+#: file.cpp:875
 msgctxt "button"
 msgid "&No"
 msgstr ""
 
-#: file.cpp:869 solvespace.cpp:569
+#: file.cpp:877 solvespace.cpp:569
 msgctxt "button"
 msgid "&Cancel"
 msgstr ""
@@ -1214,143 +1218,143 @@ msgstr ""
 msgid "Can't split; no intersection found."
 msgstr ""
 
-#: mouse.cpp:560
+#: mouse.cpp:559
 msgid "Assign to Style"
 msgstr ""
 
-#: mouse.cpp:576
+#: mouse.cpp:575
 msgid "No Style"
 msgstr ""
 
-#: mouse.cpp:579
+#: mouse.cpp:578
 msgid "Newly Created Custom Style..."
 msgstr ""
 
-#: mouse.cpp:586
+#: mouse.cpp:585
 msgid "Group Info"
 msgstr ""
 
-#: mouse.cpp:606
+#: mouse.cpp:605
 msgid "Style Info"
 msgstr ""
 
-#: mouse.cpp:626
+#: mouse.cpp:625
 msgid "Select Edge Chain"
 msgstr ""
 
-#: mouse.cpp:632
+#: mouse.cpp:631
 msgid "Toggle Reference Dimension"
 msgstr ""
 
-#: mouse.cpp:638
+#: mouse.cpp:637
 msgid "Other Supplementary Angle"
 msgstr ""
 
-#: mouse.cpp:643
+#: mouse.cpp:642
 msgid "Snap to Grid"
 msgstr ""
 
-#: mouse.cpp:652
+#: mouse.cpp:651
 msgid "Remove Spline Point"
 msgstr ""
 
-#: mouse.cpp:687
+#: mouse.cpp:686
 msgid "Add Spline Point"
 msgstr ""
 
-#: mouse.cpp:691
+#: mouse.cpp:690
 msgid "Cannot add spline point: maximum number of points reached."
 msgstr ""
 
-#: mouse.cpp:716
+#: mouse.cpp:715
 msgid "Toggle Construction"
 msgstr ""
 
-#: mouse.cpp:731
+#: mouse.cpp:730
 msgid "Delete Point-Coincident Constraint"
 msgstr ""
 
-#: mouse.cpp:750
+#: mouse.cpp:749
 msgid "Cut"
 msgstr ""
 
-#: mouse.cpp:752
+#: mouse.cpp:751
 msgid "Copy"
 msgstr ""
 
-#: mouse.cpp:756
+#: mouse.cpp:755
 msgid "Select All"
 msgstr ""
 
-#: mouse.cpp:761
+#: mouse.cpp:760
 msgid "Paste"
 msgstr ""
 
-#: mouse.cpp:763
+#: mouse.cpp:762
 msgid "Paste Transformed..."
 msgstr ""
 
-#: mouse.cpp:768
+#: mouse.cpp:767
 msgid "Delete"
 msgstr ""
 
-#: mouse.cpp:771
+#: mouse.cpp:770
 msgid "Unselect All"
 msgstr ""
 
-#: mouse.cpp:778
+#: mouse.cpp:777
 msgid "Unselect Hovered"
 msgstr ""
 
-#: mouse.cpp:787
+#: mouse.cpp:786
 msgid "Zoom to Fit"
 msgstr ""
 
-#: mouse.cpp:989 mouse.cpp:1276
+#: mouse.cpp:988 mouse.cpp:1275
 msgid "click next point of line, or press Esc"
 msgstr ""
 
-#: mouse.cpp:995
+#: mouse.cpp:994
 msgid "Can't draw rectangle in 3d; first, activate a workplane with Sketch -> In Workplane."
 msgstr ""
 
-#: mouse.cpp:1029
+#: mouse.cpp:1028
 msgid "click to place other corner of rectangle"
 msgstr ""
 
-#: mouse.cpp:1049
+#: mouse.cpp:1048
 msgid "click to set radius"
 msgstr ""
 
-#: mouse.cpp:1054
+#: mouse.cpp:1053
 msgid "Can't draw arc in 3d; first, activate a workplane with Sketch -> In Workplane."
 msgstr ""
 
-#: mouse.cpp:1073
+#: mouse.cpp:1072
 msgid "click to place point"
 msgstr ""
 
-#: mouse.cpp:1089
+#: mouse.cpp:1088
 msgid "click next point of cubic, or press Esc"
 msgstr ""
 
-#: mouse.cpp:1094
+#: mouse.cpp:1093
 msgid "Sketching in a workplane already; sketch in 3d before creating new workplane."
 msgstr ""
 
-#: mouse.cpp:1110
+#: mouse.cpp:1109
 msgid "Can't draw text in 3d; first, activate a workplane with Sketch -> In Workplane."
 msgstr ""
 
-#: mouse.cpp:1127
+#: mouse.cpp:1126
 msgid "click to place bottom right of text"
 msgstr ""
 
-#: mouse.cpp:1133
+#: mouse.cpp:1132
 msgid "Can't draw image in 3d; first, activate a workplane with Sketch -> In Workplane."
 msgstr ""
 
-#: mouse.cpp:1160
+#: mouse.cpp:1159
 msgid "NEW COMMENT -- DOUBLE-CLICK TO EDIT"
 msgstr ""
 
@@ -1439,33 +1443,33 @@ msgctxt "file-type"
 msgid "Comma-separated values"
 msgstr ""
 
-#: platform/guigtk.cpp:1321 platform/guimac.mm:1363 platform/guiwin.cpp:1630
+#: platform/guigtk.cpp:1324 platform/guimac.mm:1363 platform/guiwin.cpp:1639
 msgid "untitled"
 msgstr ""
 
-#: platform/guigtk.cpp:1332 platform/guigtk.cpp:1365 platform/guimac.mm:1321
-#: platform/guiwin.cpp:1573
+#: platform/guigtk.cpp:1335 platform/guigtk.cpp:1368 platform/guimac.mm:1321
+#: platform/guiwin.cpp:1582
 msgctxt "title"
 msgid "Save File"
 msgstr ""
 
-#: platform/guigtk.cpp:1333 platform/guigtk.cpp:1366 platform/guimac.mm:1304
-#: platform/guiwin.cpp:1575
+#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1369 platform/guimac.mm:1304
+#: platform/guiwin.cpp:1584
 msgctxt "title"
 msgid "Open File"
 msgstr ""
 
-#: platform/guigtk.cpp:1336 platform/guigtk.cpp:1372
+#: platform/guigtk.cpp:1339 platform/guigtk.cpp:1375
 msgctxt "button"
 msgid "_Cancel"
 msgstr ""
 
-#: platform/guigtk.cpp:1337 platform/guigtk.cpp:1370
+#: platform/guigtk.cpp:1340 platform/guigtk.cpp:1373
 msgctxt "button"
 msgid "_Save"
 msgstr ""
 
-#: platform/guigtk.cpp:1338 platform/guigtk.cpp:1371
+#: platform/guigtk.cpp:1341 platform/guigtk.cpp:1374
 msgctxt "button"
 msgid "_Open"
 msgstr ""

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -468,6 +468,7 @@ void SolveSpaceUI::LoadUsingTable(const Platform::Path &filename, char *key, cha
 }
 
 bool SolveSpaceUI::LoadFromFile(const Platform::Path &filename, bool canCancel) {
+    bool fileIsEmpty = true;
     allConsistent = false;
     fileLoadError = false;
 
@@ -485,6 +486,8 @@ bool SolveSpaceUI::LoadFromFile(const Platform::Path &filename, bool canCancel) 
 
     char line[1024];
     while(fgets(line, (int)sizeof(line), fh)) {
+        fileIsEmpty = false;
+
         char *s = strchr(line, '\n');
         if(s) *s = '\0';
         // We should never get files with \r characters in them, but mailers
@@ -544,6 +547,11 @@ bool SolveSpaceUI::LoadFromFile(const Platform::Path &filename, bool canCancel) 
     }
 
     fclose(fh);
+
+    if(fileIsEmpty) {
+        Error(_("The file is empty. It may be corrupt."));
+        NewFile();
+    }
 
     if(fileLoadError) {
         Error(_("Unrecognized data in file. This file may be corrupt, or "


### PR DESCRIPTION
Fixes: https://github.com/solvespace/solvespace/issues/918

The problem was that here:
https://github.com/solvespace/solvespace/blob/11a8a0abd5e21a0da6c818674f8b4b657a401a6c/src/file.cpp#L480
we cleared all groups. Then we tried to read an empty file and therefore this `while` exited immediately:
https://github.com/solvespace/solvespace/blob/11a8a0abd5e21a0da6c818674f8b4b657a401a6c/src/file.cpp#L487
and we came to here:
https://github.com/solvespace/solvespace/blob/11a8a0abd5e21a0da6c818674f8b4b657a401a6c/src/file.cpp#L548
where there was no `fileLoadError` and thus we were left with no groups, and so this assert failed:
https://github.com/solvespace/solvespace/blob/11a8a0abd5e21a0da6c818674f8b4b657a401a6c/src/graphicswin.cpp#L394
since is is not allowed to have no groups :-)