### PR TITLE
Permit toggling construction geometry while drawing lines

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -1304,6 +1304,14 @@ c:
             break;
 
         case Command::CONSTRUCTION: {
+            if(SS.GW.pending.operation == Pending::DRAGGING_NEW_LINE_POINT) {
+                Request* r = SK.GetRequest(SS.GW.pending.request);
+                r->construction = !r->construction;
+                SS.MarkGroupDirty(r->group);
+                SS.ScheduleShowTW();
+                SS.GW.Invalidate();
+                break;
+            }
             SS.GW.GroupSelection();
             if(SS.GW.gs.entities == 0) {
                 Error(_("No entities are selected. Select entities before "

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -513,6 +513,7 @@ public:
     HWND hTooltip = NULL;
     HWND hEditor  = NULL;
     WNDPROC editorWndProc = NULL;
+    LONG lastMoveTime = 0;
 
 #if HAVE_OPENGL == 1
     HGLRC hGlRc = NULL;
@@ -937,6 +938,14 @@ public:
                         event.type = MouseEvent::Type::LEAVE;
                         break;
                     case WM_MOUSEMOVE: {
+                        // rate limit mouse move messages to no faster than one per 20ms
+                        LONG mt = GetMessageTime();
+                        if(mt - window->lastMoveTime > 20) {
+                            window->lastMoveTime = mt;
+                        } else {
+                            consumed = true;
+                        }
+
                         event.type = MouseEvent::Type::MOTION;
 
                         if(wParam & MK_LBUTTON) {

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -513,7 +513,6 @@ public:
     HWND hTooltip = NULL;
     HWND hEditor  = NULL;
     WNDPROC editorWndProc = NULL;
-    LONG lastMoveTime = 0;
 
 #if HAVE_OPENGL == 1
     HGLRC hGlRc = NULL;
@@ -938,14 +937,6 @@ public:
                         event.type = MouseEvent::Type::LEAVE;
                         break;
                     case WM_MOUSEMOVE: {
-                        // rate limit mouse move messages to no faster than one per 20ms
-                        LONG mt = GetMessageTime();
-                        if(mt - window->lastMoveTime > 20) {
-                            window->lastMoveTime = mt;
-                        } else {
-                            consumed = true;
-                        }
-
                         event.type = MouseEvent::Type::MOTION;
 
                         if(wParam & MK_LBUTTON) {


### PR DESCRIPTION
This is for consideration for **post 3.0 release**

Currently attempting to toggle construction geometry while drawing line segments results in an error dialog.  This PR enables the construction geometry toggle command ('g' key) to work while drawing lines.  This does not affect other requests (but maybe it could)

I feel this is an improvement over the error dialog and is useful when sketching.  @phkahler I'm curious what you think of this.
