### PR TITLE
permit construction geometry toggle while drawing

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -1304,6 +1304,20 @@ c:
             break;
 
         case Command::CONSTRUCTION: {
+            // if we are drawing
+            if(SS.GW.pending.operation == Pending::DRAGGING_NEW_POINT ||
+               SS.GW.pending.operation == Pending::DRAGGING_NEW_LINE_POINT ||
+               SS.GW.pending.operation == Pending::DRAGGING_NEW_ARC_POINT ||
+               SS.GW.pending.operation == Pending::DRAGGING_NEW_CUBIC_POINT ||
+               SS.GW.pending.operation == Pending::DRAGGING_NEW_RADIUS) {
+                for(auto &hr : SS.GW.pending.requests) {
+                    Request* r = SK.GetRequest(hr);
+                    r->construction = !(r->construction);
+                    SS.MarkGroupDirty(r->group);
+                }
+                SS.GW.Invalidate();
+                break;
+            }
             SS.GW.GroupSelection();
             if(SS.GW.gs.entities == 0) {
                 Error(_("No entities are selected. Select entities before "

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1042,6 +1042,7 @@ void GraphicsWindow::MouseLeftDown(double mx, double my, bool shiftDown, bool ct
                     ConstrainPointByHovered(hr.entity(1), &mouse);
 
                     ClearSuper();
+                    AddToPending(hr);
 
                     pending.operation = Pending::DRAGGING_NEW_RADIUS;
                     pending.circle = hr.entity(0);


### PR DESCRIPTION
Currently attempting to toggle construction geometry while drawing results in an error dialog. This PR enables the construction geometry toggle command ('g' key) to work while drawing lines, rectangles, arcs, circles, and cubics.

I feel this is an improvement over the error dialog and is useful when sketching.