### PR TITLE
mark group dirty when toggling reference dimension

### DIFF
--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -47,6 +47,7 @@ void TextWindow::ScreenConstraintToggleReference(int link, uint32_t v) {
     SS.UndoRemember();
     c->reference = !c->reference;
 
+    SS.MarkGroupDirty(c->group);
     SS.ScheduleShowTW();
 }
 


### PR DESCRIPTION
This addresses #863

When toggling reference dimension for an over constrained sketch mark group dirty to force a solve.  To test this PR use the over constrained 3-4-5 right triangle  [test-over.zip](https://github.com/solvespace/solvespace/files/5939160/test-over.zip).  Select the reference dimension and toggle it back and forth using the checkbox in the property browser.  With this patch the display should refresh as expected from red to black background and back.  This works by marking the changed group dirty so SS will recheck for redundant constraints.


