### PR TITLE
Fix incorrect styling on SVG export

### DIFF
--- a/src/export.cpp
+++ b/src/export.cpp
@@ -735,25 +735,22 @@ void VectorFileWriter::OutputLinesAndMesh(SBezierLoopSetSet *sblss, SMesh *sm) {
     if(sblss) {
         SBezierLoopSet *sbls;
         for(sbls = sblss->l.First(); sbls; sbls = sblss->l.NextAfter(sbls)) {
-            SBezierLoop *sbl;
-            sbl = sbls->l.First();
-            if(!sbl) continue;
-            b = sbl->l.First();
-            if(!b || !Style::Exportable(b->auxA)) continue;
+            for(SBezierLoop *sbl = sbls->l.First(); sbl; sbl = sbls->l.NextAfter(sbl)) {
+                b = sbl->l.First();
+                if(!b || !Style::Exportable(b->auxA)) continue;
 
-            hStyle hs = { (uint32_t)b->auxA };
-            Style *stl = Style::Get(hs);
-            double lineWidth   = Style::WidthMm(b->auxA)*s;
-            RgbaColor strokeRgb = Style::Color(hs, /*forExport=*/true);
-            RgbaColor fillRgb   = Style::FillColor(hs, /*forExport=*/true);
+                hStyle hs = { (uint32_t)b->auxA };
+                Style *stl = Style::Get(hs);
+                double lineWidth   = Style::WidthMm(b->auxA)*s;
+                RgbaColor strokeRgb = Style::Color(hs, /*forExport=*/true);
+                RgbaColor fillRgb   = Style::FillColor(hs, /*forExport=*/true);
 
-            StartPath(strokeRgb, lineWidth, stl->filled, fillRgb, hs);
-            for(sbl = sbls->l.First(); sbl; sbl = sbls->l.NextAfter(sbl)) {
+                StartPath(strokeRgb, lineWidth, stl->filled, fillRgb, hs);
                 for(b = sbl->l.First(); b; b = sbl->l.NextAfter(b)) {
                     Bezier(b);
                 }
+                FinishPath(strokeRgb, lineWidth, stl->filled, fillRgb, hs);
             }
-            FinishPath(strokeRgb, lineWidth, stl->filled, fillRgb, hs);
         }
     }
     FinishAndCloseFile();

--- a/src/exportvector.cpp
+++ b/src/exportvector.cpp
@@ -1083,17 +1083,16 @@ void SvgFileWriter::StartFile() {
     double sw = max(ptMax.x - ptMin.x, ptMax.y - ptMin.y) / 1000;
     fprintf(f, "stroke-width:%f;\r\n", sw);
     fprintf(f, "}\r\n");
-    for(auto &style : SK.style) {
-        Style *s = &style;
 
-        RgbaColor strokeRgb = Style::Color(s->h, /*forExport=*/true);
-        StipplePattern pattern = Style::PatternType(s->h);
-        double stippleScale = Style::StippleScaleMm(s->h);
+    auto export_style = [&](hStyle hs) {
+        RgbaColor strokeRgb = Style::Color(hs, /*forExport=*/true);
+        StipplePattern pattern = Style::PatternType(hs);
+        double stippleScale = Style::StippleScaleMm(hs);
 
-        fprintf(f, ".s%x {\r\n", s->h.v);
+        fprintf(f, ".s%x {\r\n", hs.v);
         fprintf(f, "stroke:#%02x%02x%02x;\r\n", strokeRgb.red, strokeRgb.green, strokeRgb.blue);
         // don't know why we have to take a half of the width
-        fprintf(f, "stroke-width:%f;\r\n", Style::WidthMm(s->h.v) / 2.0);
+        fprintf(f, "stroke-width:%f;\r\n", Style::WidthMm(hs.v) / 2.0);
         fprintf(f, "stroke-linecap:round;\r\n");
         fprintf(f, "stroke-linejoin:round;\r\n");
         std::string patternStr = MakeStipplePattern(pattern, stippleScale, ',',
@@ -1103,6 +1102,12 @@ void SvgFileWriter::StartFile() {
         }
         fprintf(f, "fill:none;\r\n");
         fprintf(f, "}\r\n");
+    };
+
+    export_style({Style::NO_STYLE});
+    for(auto &style : SK.style) {
+        Style *s = &style;
+        export_style(s->h);
     }
     fprintf(f, "]]></style>\r\n");
 }


### PR DESCRIPTION
This PR fixes #904 (and maybe #518).  There were two problems:

1. There was no definition for Style::NO_STYLE in the header
2. The styling was being set at the SBezierLoopSet level vs the SBezierLoop so loops in the set were all being styled the same.