### PR TITLE
Fix tangent constraints of curves.

### DIFF
--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -127,7 +127,7 @@ hConstraint Constraint::ConstrainCoincident(hEntity ptA, hEntity ptB) {
         Entity::NO_ENTITY, Entity::NO_ENTITY, /*other=*/false, /*other2=*/false);
 }
 
-void Constraint::ConstrainArcLineTangent(Constraint *c, Entity *line, Entity *arc) {
+bool Constraint::ConstrainArcLineTangent(Constraint *c, Entity *line, Entity *arc) {
     Vector l0 = SK.GetEntity(line->point[0])->PointGetNum(),
            l1 = SK.GetEntity(line->point[1])->PointGetNum();
     Vector a1 = SK.GetEntity(arc->point[1])->PointGetNum(),
@@ -140,11 +140,12 @@ void Constraint::ConstrainArcLineTangent(Constraint *c, Entity *line, Entity *ar
         Error(_("The tangent arc and line segment must share an "
                 "endpoint. Constrain them with Constrain -> "
                 "On Point before constraining tangent."));
-        return;
+        return false;
     }
+    return true;
 }
 
-void Constraint::ConstrainCubicLineTangent(Constraint *c, Entity *line, Entity *cubic) {
+bool Constraint::ConstrainCubicLineTangent(Constraint *c, Entity *line, Entity *cubic) {
     Vector l0 = SK.GetEntity(line->point[0])->PointGetNum(),
            l1 = SK.GetEntity(line->point[1])->PointGetNum();
     Vector as = cubic->CubicGetStartNum(),
@@ -158,11 +159,12 @@ void Constraint::ConstrainCubicLineTangent(Constraint *c, Entity *line, Entity *
         Error(_("The tangent cubic and line segment must share an "
                 "endpoint. Constrain them with Constrain -> "
                 "On Point before constraining tangent."));
-        return;
+        return false;
     }
+    return true;
 }
 
-void Constraint::ConstrainCurveCurveTangent(Constraint *c, Entity *eA, Entity *eB) {
+bool Constraint::ConstrainCurveCurveTangent(Constraint *c, Entity *eA, Entity *eB) {
     Vector as = eA->EndpointStart(),
            af = eA->EndpointFinish(),
            bs = eB->EndpointStart(),
@@ -183,8 +185,9 @@ void Constraint::ConstrainCurveCurveTangent(Constraint *c, Entity *eA, Entity *e
         Error(_("The curves must share an endpoint. Constrain them "
                 "with Constrain -> On Point before constraining "
                 "tangent."));
-        return;
+        return false;
     }
+    return true;
 }
 
 void Constraint::MenuConstrain(Command id) {
@@ -690,7 +693,9 @@ void Constraint::MenuConstrain(Command id) {
                 if(line->type == Entity::Type::ARC_OF_CIRCLE) {
                     swap(line, arc);
                 }
-                ConstrainArcLineTangent(&c, line, arc);
+                if(!ConstrainArcLineTangent(&c, line, arc)) {
+                    return;
+                }
                 c.type = Type::ARC_LINE_TANGENT;
                 c.entityA = arc->h;
                 c.entityB = line->h;
@@ -700,7 +705,9 @@ void Constraint::MenuConstrain(Command id) {
                 if(line->type == Entity::Type::CUBIC) {
                     swap(line, cubic);
                 }
-                ConstrainCubicLineTangent(&c, line, cubic);
+                if(!ConstrainCubicLineTangent(&c, line, cubic)) {
+                    return;
+                }
                 c.type = Type::CUBIC_LINE_TANGENT;
                 c.entityA = cubic->h;
                 c.entityB = line->h;
@@ -711,7 +718,9 @@ void Constraint::MenuConstrain(Command id) {
                 }
                 Entity *eA = SK.GetEntity(gs.entity[0]),
                        *eB = SK.GetEntity(gs.entity[1]);
-                ConstrainCurveCurveTangent(&c, eA, eB);
+                if(!ConstrainCurveCurveTangent(&c, eA, eB)) {
+                    return;
+                }
                 c.type = Type::CURVE_CURVE_TANGENT;
                 c.entityA = eA->h;
                 c.entityB = eB->h;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -790,9 +790,9 @@ public:
     static hConstraint TryConstrain(Constraint::Type type, hEntity ptA, hEntity ptB,
                                     hEntity entityA, hEntity entityB = Entity::NO_ENTITY,
                                     bool other = false, bool other2 = false);
-    static void ConstrainArcLineTangent(Constraint *c, Entity *line, Entity *arc);
-    static void ConstrainCubicLineTangent(Constraint *c, Entity *line, Entity *cubic);
-    static void ConstrainCurveCurveTangent(Constraint *c, Entity *eA, Entity *eB);
+    static bool ConstrainArcLineTangent(Constraint *c, Entity *line, Entity *arc);
+    static bool ConstrainCubicLineTangent(Constraint *c, Entity *line, Entity *cubic);
+    static bool ConstrainCurveCurveTangent(Constraint *c, Entity *eA, Entity *eB);
 };
 
 class hEquation {


### PR DESCRIPTION
This fixes a regression introduced in  96958f466395148ee7f0a252222a2a27e7345c22 (https://github.com/solvespace/solvespace/pull/833.)
Three `return` statements got "swallowed" by the newly created functions.
(e.g .https://github.com/solvespace/solvespace/commit/96958f466395148ee7f0a252222a2a27e7345c22#diff-49abc03ed071148c0ebae0c64aafb625fa6223135f77aeecdb47dab4cf8b940cL638 )

Because of this it was possible to constrain arcs and cubics tangent to each other or line segments, without them sharing an endpoint.

This kind of worked, but always chose the "starting" points of the curves and lines. In the future this can be turned into a feature. See the discussion in #937.