### PR TITLE
Add exportable option to default styles

### DIFF
--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -462,7 +462,7 @@ void Entity::GenerateBezierCurves(SBezierList *sbl) const {
 
     // Record our style for all of the Beziers that we just created.
     for(; i < sbl->l.n; i++) {
-        sbl->l[i].auxA = style.v;
+        sbl->l[i].auxA = Style::ForEntity(h).v;
     }
 }
 

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -207,7 +207,6 @@ void SolveSpaceUI::ExportViewOrWireframeTo(const Platform::Path &filename, bool 
     for(auto &entity : SK.entity) {
         Entity *e = &entity;
         if(!e->IsVisible()) continue;
-        if(e->construction) continue;
 
         if(SS.exportPwlCurves || sm || fabs(SS.exportOffset) > LENGTH_EPS)
         {

--- a/src/exportvector.cpp
+++ b/src/exportvector.cpp
@@ -1085,7 +1085,9 @@ void SvgFileWriter::StartFile() {
     fprintf(f, "}\r\n");
 
     auto export_style = [&](hStyle hs) {
+        Style *s = Style::Get(hs);
         RgbaColor strokeRgb = Style::Color(hs, /*forExport=*/true);
+        RgbaColor fillRgb = Style::FillColor(hs, /*forExport=*/true);
         StipplePattern pattern = Style::PatternType(hs);
         double stippleScale = Style::StippleScaleMm(hs);
 
@@ -1100,7 +1102,12 @@ void SvgFileWriter::StartFile() {
         if(!patternStr.empty()) {
             fprintf(f, "stroke-dasharray:%s;\r\n", patternStr.c_str());
         }
-        fprintf(f, "fill:none;\r\n");
+        if(s->filled) {
+            fprintf(f, "fill:#%02x%02x%02x;\r\n", fillRgb.red, fillRgb.green, fillRgb.blue); 
+        }
+        else {
+            fprintf(f, "fill:none;\r\n");
+        }
         fprintf(f, "}\r\n");
     };
 

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -883,6 +883,7 @@ public:
         RgbaColor   color;
         double      width;
         int         zIndex;
+        bool        exportable;
     } Default;
     static const Default Defaults[];
 
@@ -890,6 +891,7 @@ public:
     static std::string CnfWidth(const std::string &prefix);
     static std::string CnfTextHeight(const std::string &prefix);
     static std::string CnfPrefixToName(const std::string &prefix);
+    static std::string CnfExportable(const std::string &prefix);
 
     static void CreateAllDefaultStyles();
     static void CreateDefaultStyle(hStyle h);


### PR DESCRIPTION
Primarily, this enables the user to export of construction entities in 2D views such as SVG and PDF as noted in #682. Previously construction entities were always skipped. The "export these objects" is now available for all default styles. One may turn off export of constraints or the inactive groups for example.  Because export of construction entities is no longer blocked export option for custom styles also works for them.

This also adds the exportable flag to the factory defaults (so it can be reset) and support for saving the exportable option for default styles in the configuration. Construction entities with custom styles respect this option as well.  

This also addresses a problem with missing contour fill for exported SVG.

To test this try exporting a sketch with construction entities.  The default behavior is to skip them matching how SS behaves now.  Then enable the export option for the construction entity style and re-export.  You may also turn on/off other styles.  Contour fill will now be exported for each style when exporting SVG

**NOTE**:  Running this version will add new entries to the configuration (Registry, .config etc.) on exit when testing this code.