### PR TITLE
Use better pointer cursor for link text on GTK

### DIFF
--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -963,16 +963,17 @@ public:
     }
 
     void SetCursor(Cursor cursor) override {
-        Gdk::CursorType gdkCursorType;
+        std::string cursor_name;
         switch(cursor) {
-            case Cursor::POINTER: gdkCursorType = Gdk::ARROW; break;
-            case Cursor::HAND:    gdkCursorType = Gdk::HAND1; break;
+            case Cursor::POINTER: cursor_name = "default"; break;
+            case Cursor::HAND:    cursor_name = "pointer"; break;
             default: ssassert(false, "Unexpected cursor");
         }
 
         auto gdkWindow = gtkWindow.get_gl_widget().get_window();
         if(gdkWindow) {
-            gdkWindow->set_cursor(Gdk::Cursor::create(gdkCursorType));
+            gdkWindow->set_cursor(Gdk::Cursor::create(gdkWindow->get_display(), cursor_name.c_str()));
+//        gdkWindow->get_display()
         }
     }
 


### PR DESCRIPTION
Gdk::Cursor::create(Gdk::HAND1) yields a hand cursor more appropriate for "grabbing" vs. pointing.  Use the recommended (non-deprecated) create by name API to get a "pointer" hand cursor for link text in the text window.  This more closely matches Windows and is easier to use.

"grabbing" hand
![image](https://user-images.githubusercontent.com/3731923/110226269-d5730080-7ebb-11eb-8dea-f8d60db6f8bb.png)

"pointer" hand
![image](https://user-images.githubusercontent.com/3731923/110226290-ecb1ee00-7ebb-11eb-8d28-cd488d5c9bc8.png)
