### PR TITLE
Add config option for "camera" rotation navigation

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -115,6 +115,10 @@ void TextWindow::ScreenChangeTurntableNav(int link, uint32_t v) {
     }
 }
 
+void TextWindow::ScreenChangeCameraNav(int link, uint32_t v) {
+    SS.cameraNav = !SS.cameraNav;
+}
+
 void TextWindow::ScreenChangeImmediatelyEditDimension(int link, uint32_t v) {
     SS.immediatelyEditDimension = !SS.immediatelyEditDimension;
     SS.GW.Invalidate(/*clearPersistent=*/true);
@@ -370,6 +374,8 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "  %Fd%f%Ll%s  enable automatic line constraints%E",
         &ScreenChangeAutomaticLineConstraints,
         SS.automaticLineConstraints ? CHECK_TRUE : CHECK_FALSE);
+    Printf(false, "  %Fd%f%Ll%s  use camera mouse navigation%E", &ScreenChangeCameraNav,
+        SS.cameraNav ? CHECK_TRUE : CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  use turntable mouse navigation%E", &ScreenChangeTurntableNav,
         SS.turntableNav ? CHECK_TRUE : CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  edit newly added dimensions%E",

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -134,8 +134,9 @@ void GraphicsWindow::MouseMoved(double x, double y, bool leftDown,
         double dy = (y - orig.mouse.y) / scale;
 
         if(!(shiftDown || ctrlDown)) {
-            double s = 0.3*(PI/180)*scale; // degrees per pixel
-            if(SS.turntableNav) {          // lock the Z to vertical
+            double sign = SS.cameraNav ? -1.0 : 1.0;
+            double s = 0.3*(PI/180)*scale*sign; // degrees per pixel
+            if(SS.turntableNav) {               // lock the Z to vertical
                 projRight = orig.projRight.RotatedAbout(Vector::From(0, 0, 1), -s * dx);
                 projUp    = orig.projUp.RotatedAbout(
                     Vector::From(orig.projRight.x, orig.projRight.y, orig.projRight.y), s * dy);

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -74,6 +74,8 @@ void SolveSpaceUI::Init() {
     exportBackgroundColor = settings->ThawBool("ExportBackgroundColor", false);
     // Draw back faces of triangles (when mesh is leaky/self-intersecting)
     drawBackFaces = settings->ThawBool("DrawBackFaces", true);
+    // Use camera mouse navigation
+    cameraNav = settings->ThawBool("CameraNav", false);
     // Use turntable mouse navigation
     turntableNav = settings->ThawBool("TurntableNav", false);
     // Immediately edit dimension
@@ -260,6 +262,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeBool("ShowContourAreas", showContourAreas);
     // Check that contours are closed and not self-intersecting
     settings->FreezeBool("CheckClosedContour", checkClosedContour);
+    // Use camera mouse navigation
+    settings->FreezeBool("CameraNav", cameraNav);
     // Use turntable mouse navigation
     settings->FreezeBool("TurntableNav", turntableNav);
     // Immediately edit dimensions

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -573,6 +573,7 @@ public:
     bool     drawBackFaces;
     bool     showContourAreas;
     bool     checkClosedContour;
+    bool     cameraNav;
     bool     turntableNav;
     bool     immediatelyEditDimension;
     bool     automaticLineConstraints;

--- a/src/ui.h
+++ b/src/ui.h
@@ -440,6 +440,7 @@ public:
     static void ScreenChangeBackFaces(int link, uint32_t v);
     static void ScreenChangeShowContourAreas(int link, uint32_t v);
     static void ScreenChangeCheckClosedContour(int link, uint32_t v);
+    static void ScreenChangeCameraNav(int link, uint32_t v);
     static void ScreenChangeTurntableNav(int link, uint32_t v);
     static void ScreenChangeImmediatelyEditDimension(int link, uint32_t v);
     static void ScreenChangeAutomaticLineConstraints(int link, uint32_t v);


### PR DESCRIPTION
issue #325 requests an alternative to middle-button mouse navigation/rotation.  What I think the user is asking for is an option to manipulate the camera instead of model when rotating, i.e. reversing up/down and left/right directions.  This PR implements that feature (independent of turntable navigation) as a config option called "camera mouse navigation" (name could use some work).  It drives me a little bit crazy but I think some are used to this and would welcome this option.