### PR TITLE
Hide editor window when user hits Esc on Windows

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1095,7 +1095,7 @@ public:
                         return 0;
                     }
                 } else if(wParam == VK_ESCAPE) {
-                    sscheck(SendMessageW(hWindow, msg, wParam, lParam));
+                    window->HideEditor();
                     return 0;
                 }
         }


### PR DESCRIPTION
#958 notes the hitting Esc does not cancel an edit as it does on Linux.  This PR hides the editor on Esc.