### PR TITLE
Export correct style for construction entities for when exporting edges

### DIFF
--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -26,7 +26,7 @@ void Entity::GenerateEdges(SEdgeList *el) {
         List<Vector> lv = {};
         sb->MakePwlInto(&lv);
         for(int j = 1; j < lv.n; j++) {
-            el->AddEdge(lv[j-1], lv[j], style.v, i);
+            el->AddEdge(lv[j-1], lv[j], Style::ForEntity(h).v, i);
         }
         lv.Clear();
     }


### PR DESCRIPTION
This PR is a companion to #946 which corrects unstyled construction entities when exported as Beziers.  This does the same but when exporting edges.  It partially addresses #967