### PR TITLE
Save stipple settings for default styles to config

### DIFF
--- a/src/sketch.h
+++ b/src/sketch.h
@@ -884,11 +884,14 @@ public:
         double      width;
         int         zIndex;
         bool        exportable;
+        StipplePattern stippleType;
     } Default;
     static const Default Defaults[];
 
     static std::string CnfColor(const std::string &prefix);
     static std::string CnfWidth(const std::string &prefix);
+    static std::string CnfStippleType(const std::string &prefix);
+    static std::string CnfStippleScale(const std::string &prefix);
     static std::string CnfTextHeight(const std::string &prefix);
     static std::string CnfPrefixToName(const std::string &prefix);
     static std::string CnfExportable(const std::string &prefix);
@@ -918,7 +921,10 @@ public:
     static bool Exportable(int hs);
     static hStyle ForEntity(hEntity he);
     static StipplePattern PatternType(hStyle hs);
+    static double StippleScale(hStyle hs);
     static double StippleScaleMm(hStyle hs);
+    static std::string StipplePatternName(hStyle hs);
+    static StipplePattern StipplePatternFromString(std::string name);
 
     std::string DescriptionString() const;
 

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -8,22 +8,22 @@
 #include "solvespace.h"
 
 const Style::Default Style::Defaults[] = {
-    { { ACTIVE_GRP },   "ActiveGrp",    RGBf(1.0, 1.0, 1.0), 1.5, 4, true  },
-    { { CONSTRUCTION }, "Construction", RGBf(0.1, 0.7, 0.1), 1.5, 0, false },
-    { { INACTIVE_GRP }, "InactiveGrp",  RGBf(0.5, 0.3, 0.0), 1.5, 3, true  },
-    { { DATUM },        "Datum",        RGBf(0.0, 0.8, 0.0), 1.5, 0, true  },
-    { { SOLID_EDGE },   "SolidEdge",    RGBf(0.8, 0.8, 0.8), 1.0, 2, true  },
-    { { CONSTRAINT },   "Constraint",   RGBf(1.0, 0.1, 1.0), 1.0, 0, true  },
-    { { SELECTED },     "Selected",     RGBf(1.0, 0.0, 0.0), 1.5, 0, true  },
-    { { HOVERED },      "Hovered",      RGBf(1.0, 1.0, 0.0), 1.5, 0, true  },
-    { { CONTOUR_FILL }, "ContourFill",  RGBf(0.0, 0.1, 0.1), 1.0, 0, true  },
-    { { NORMALS },      "Normals",      RGBf(0.0, 0.4, 0.4), 1.0, 0, true  },
-    { { ANALYZE },      "Analyze",      RGBf(0.0, 1.0, 1.0), 3.0, 0, true  },
-    { { DRAW_ERROR },   "DrawError",    RGBf(1.0, 0.0, 0.0), 8.0, 0, true  },
-    { { DIM_SOLID },    "DimSolid",     RGBf(0.1, 0.1, 0.1), 1.0, 0, true  },
-    { { HIDDEN_EDGE },  "HiddenEdge",   RGBf(0.8, 0.8, 0.8), 1.0, 1, true  },
-    { { OUTLINE },      "Outline",      RGBf(0.8, 0.8, 0.8), 3.0, 5, true  },
-    { { 0 },            NULL,           RGBf(0.0, 0.0, 0.0), 0.0, 0, true  }
+    { { ACTIVE_GRP },   "ActiveGrp",    RGBf(1.0, 1.0, 1.0), 1.5, 4, true,  StipplePattern::CONTINUOUS },
+    { { CONSTRUCTION }, "Construction", RGBf(0.1, 0.7, 0.1), 1.5, 0, false, StipplePattern::CONTINUOUS },
+    { { INACTIVE_GRP }, "InactiveGrp",  RGBf(0.5, 0.3, 0.0), 1.5, 3, true,  StipplePattern::CONTINUOUS },
+    { { DATUM },        "Datum",        RGBf(0.0, 0.8, 0.0), 1.5, 0, true,  StipplePattern::CONTINUOUS },
+    { { SOLID_EDGE },   "SolidEdge",    RGBf(0.8, 0.8, 0.8), 1.0, 2, true,  StipplePattern::CONTINUOUS },
+    { { CONSTRAINT },   "Constraint",   RGBf(1.0, 0.1, 1.0), 1.0, 0, true,  StipplePattern::CONTINUOUS },
+    { { SELECTED },     "Selected",     RGBf(1.0, 0.0, 0.0), 1.5, 0, true,  StipplePattern::CONTINUOUS },
+    { { HOVERED },      "Hovered",      RGBf(1.0, 1.0, 0.0), 1.5, 0, true,  StipplePattern::CONTINUOUS },
+    { { CONTOUR_FILL }, "ContourFill",  RGBf(0.0, 0.1, 0.1), 1.0, 0, true,  StipplePattern::CONTINUOUS },
+    { { NORMALS },      "Normals",      RGBf(0.0, 0.4, 0.4), 1.0, 0, true,  StipplePattern::CONTINUOUS },
+    { { ANALYZE },      "Analyze",      RGBf(0.0, 1.0, 1.0), 3.0, 0, true,  StipplePattern::CONTINUOUS },
+    { { DRAW_ERROR },   "DrawError",    RGBf(1.0, 0.0, 0.0), 8.0, 0, true,  StipplePattern::CONTINUOUS },
+    { { DIM_SOLID },    "DimSolid",     RGBf(0.1, 0.1, 0.1), 1.0, 0, true,  StipplePattern::CONTINUOUS },
+    { { HIDDEN_EDGE },  "HiddenEdge",   RGBf(0.8, 0.8, 0.8), 1.0, 1, true,  StipplePattern::DASH },
+    { { OUTLINE },      "Outline",      RGBf(0.8, 0.8, 0.8), 3.0, 5, true,  StipplePattern::CONTINUOUS },
+    { { 0 },            NULL,           RGBf(0.0, 0.0, 0.0), 0.0, 0, true,  StipplePattern::CONTINUOUS }
 };
 
 std::string Style::CnfColor(const std::string &prefix) {
@@ -31,6 +31,12 @@ std::string Style::CnfColor(const std::string &prefix) {
 }
 std::string Style::CnfWidth(const std::string &prefix) {
     return "Style_" + prefix + "_Width";
+}
+std::string Style::CnfStippleType(const std::string &prefix) {
+    return "Style_" + prefix + "_StippleType";
+}
+std::string Style::CnfStippleScale(const std::string &prefix) {
+    return "Style_" + prefix + "_StippleScale";
 }
 std::string Style::CnfTextHeight(const std::string &prefix) {
     return "Style_" + prefix + "_TextHeight";
@@ -105,9 +111,13 @@ void Style::FillDefaultStyle(Style *s, const Default *d, bool factory) {
                         : settings->ThawBool(CnfExportable(d->cnfPrefix), d->exportable);
     s->filled        = false;
     s->fillColor     = RGBf(0.3, 0.3, 0.3);
-    s->stippleType   = (d->h.v == Style::HIDDEN_EDGE) ? StipplePattern::DASH
-                                                      : StipplePattern::CONTINUOUS;
-    s->stippleScale  = 15.0;
+    s->stippleType   = (factory)
+                        ? d->stippleType
+                        : Style::StipplePatternFromString(
+                            settings->ThawString(CnfStippleType(d->cnfPrefix), ""));
+    s->stippleScale  = (factory)
+                        ? 15.0
+                        : settings->ThawFloat(CnfStippleScale(d->cnfPrefix), 15.0);
     s->zIndex        = d->zIndex;
 }
 
@@ -125,6 +135,8 @@ void Style::FreezeDefaultStyles(Platform::SettingsRef settings) {
     for(d = &(Defaults[0]); d->h.v; d++) {
         settings->FreezeColor(CnfColor(d->cnfPrefix), Color(d->h));
         settings->FreezeFloat(CnfWidth(d->cnfPrefix), (float)Width(d->h));
+        settings->FreezeString(CnfStippleType(d->cnfPrefix), StipplePatternName(d->h));
+        settings->FreezeFloat(CnfStippleScale(d->cnfPrefix), (float)StippleScale(d->h));
         settings->FreezeFloat(CnfTextHeight(d->cnfPrefix), (float)TextHeight(d->h));
         settings->FreezeBool(CnfExportable(d->cnfPrefix), Exportable(d->h.v));
     }
@@ -353,9 +365,57 @@ hStyle Style::ForEntity(hEntity he) {
     return hs;
 }
 
+StipplePattern Style::StipplePatternFromString(std::string name) {
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    if(name == "continuous") {
+        return StipplePattern::CONTINUOUS;
+    } else if(name == "shortdash") {
+        return StipplePattern::SHORT_DASH;
+    } else if(name == "dash") {
+        return StipplePattern::DASH;
+    } else if(name == "longdash") {
+        return StipplePattern::LONG_DASH;
+    } else if(name == "dashdot") {
+        return StipplePattern::DASH_DOT;
+    } else if(name == "dashdotdot") {
+        return StipplePattern::DASH_DOT_DOT;
+    } else if(name == "dot") {
+        return StipplePattern::DOT;
+    } else if(name == "freehand") {
+        return StipplePattern::FREEHAND;
+    } else if(name == "zigzag") {
+        return StipplePattern::ZIGZAG;
+    }
+
+    return StipplePattern::CONTINUOUS;
+}
+
 StipplePattern Style::PatternType(hStyle hs) {
     Style *s = Get(hs);
     return s->stippleType;
+}
+
+std::string Style::StipplePatternName(hStyle hs) {
+    Style *s = Get(hs);
+    switch(s->stippleType) {
+        case StipplePattern::CONTINUOUS:   return "Continuous";
+        case StipplePattern::SHORT_DASH:   return "ShortDash";
+        case StipplePattern::DASH:         return "Dash";
+        case StipplePattern::LONG_DASH:    return "LongDash";
+        case StipplePattern::DASH_DOT:     return "DashDot";
+        case StipplePattern::DASH_DOT_DOT: return "DashDotDot";
+        case StipplePattern::DOT:          return "Dot";
+        case StipplePattern::FREEHAND:     return "FreeHand";
+        case StipplePattern::ZIGZAG:       return "ZigZag";
+    }
+
+    return "CONTINUOUS";
+}
+
+
+double Style::StippleScale(hStyle hs) {
+    Style *s = Get(hs);
+    return s->stippleScale;
 }
 
 double Style::StippleScaleMm(hStyle hs) {


### PR DESCRIPTION
This PR saves the stipple settings for default styles to the configuration and closes #957.