### PR TITLE
Trigger redraw on load factory default styles

### DIFF
--- a/src/style.cpp
+++ b/src/style.cpp
@@ -389,6 +389,7 @@ void TextWindow::ScreenShowStyleInfo(int link, uint32_t v) {
 void TextWindow::ScreenLoadFactoryDefaultStyles(int link, uint32_t v) {
     Style::LoadFactoryDefaults();
     SS.TW.GoToScreen(Screen::LIST_OF_STYLES);
+    SS.GW.persistentDirty = true;
 }
 
 void TextWindow::ScreenCreateCustomStyle(int link, uint32_t v) {


### PR DESCRIPTION
When reloading factory default styles redraw the graphics window.  This was noted in a comment to #682, 