### PR TITLE
Allow right click to end sketching of all entities

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -526,11 +526,16 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
     }
 
     if(pending.operation == Pending::DRAGGING_NEW_LINE_POINT ||
-       pending.operation == Pending::DRAGGING_NEW_CUBIC_POINT)
+       pending.operation == Pending::DRAGGING_NEW_CUBIC_POINT ||
+       pending.operation == Pending::DRAGGING_NEW_ARC_POINT ||
+       pending.operation == Pending::DRAGGING_NEW_RADIUS ||
+       pending.operation == Pending::DRAGGING_NEW_POINT
+       )
     {
         // Special case; use a right click to stop drawing lines, since
         // a left click would draw another one. This is quicker and more
-        // intuitive than hitting escape. Likewise for new cubic segments.
+        // intuitive than hitting escape. Likewise for other entities
+        // for consistency.
         ClearPending();
         return;
     }


### PR DESCRIPTION
Right click can be used to end sketching of new lines and cubics as a convenient alternative to ESC.  This PR extends this feature to work when sketching rectangles, circles, arcs, ttf text and images as well.  Currently right clicking while sketching, say a rectangle, just pops up a context menu with one option, "Select All".  While choosing Select All does work I can't figure out why that would be useful in the middle of sketching.

I've been sitting on this for a while because I wasn't sure if this was of general interest.  My fingers have gotten very used to the right click feature for lines and cubics so I thought I would submit to see others think.