### PR TITLE
CI: Lock qemu version to known working

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
     - uses: actions/checkout@v2
     - name: Set Up Source
       run: rsync --filter=":- .gitignore" -r ./ pkg/snap/solvespace-snap-src


### PR DESCRIPTION
ARM64 builds in GitHub Actions fail with 

```shell
error: cannot pack "/data/prime": mksquashfs call failed: signal: illegal instruction (core dumped)
```

Lock the qemu image to a specific version that is known to work. Inspired by https://github.com/diddlesnaps/snapcraft-multiarch-action/commit/3fa0c51286443a8dad3be126d1f348bb01c17042