### PR TITLE
minor fix open/save dialogue on windows

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1621,16 +1621,16 @@ public:
     }
 
     bool RunModal() override {
-	if(isSaveDialog) {
-	    SetTitle(C_("title", "Save File"));
-	    if(GetFilename().IsEmpty()) {
-		SetFilename(Path::From(_("untitled")));
-	    }
-	    return GetSaveFileNameW(&ofn) == TRUE;
-	} else {
-	    SetTitle(C_("title", "Open File"));
-	    return GetOpenFileNameW(&ofn) == TRUE;
-	}
+        if(isSaveDialog) {
+            SetTitle(C_("title", "Save File"));
+            if(GetFilename().IsEmpty()) {
+                SetFilename(Path::From(_("untitled")));
+            }
+            return GetSaveFileNameW(&ofn) == TRUE;
+        } else {
+            SetTitle(C_("title", "Open File"));
+            return GetOpenFileNameW(&ofn) == TRUE;
+        }
     }
 };
 

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1569,11 +1569,6 @@ public:
         ofn.nMaxFile    = sizeof(filenameWC) / sizeof(wchar_t);
         ofn.Flags       = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY |
                           OFN_OVERWRITEPROMPT;
-        if(isSaveDialog) {
-            SetTitle(C_("title", "Save File"));
-        } else {
-            SetTitle(C_("title", "Open File"));
-        }
     }
 
     void SetTitle(std::string title) override {
@@ -1626,15 +1621,16 @@ public:
     }
 
     bool RunModal() override {
-        if(GetFilename().IsEmpty()) {
-            SetFilename(Path::From(_("untitled")));
-        }
-
-        if(isSaveDialog) {
-            return GetSaveFileNameW(&ofn) == TRUE;
-        } else {
-            return GetOpenFileNameW(&ofn) == TRUE;
-        }
+	if(isSaveDialog) {
+	    SetTitle(C_("title", "Save File"));
+	    if(GetFilename().IsEmpty()) {
+		SetFilename(Path::From(_("untitled")));
+	    }
+	    return GetSaveFileNameW(&ofn) == TRUE;
+	} else {
+	    SetTitle(C_("title", "Open File"));
+	    return GetOpenFileNameW(&ofn) == TRUE;
+	}
     }
 };
 


### PR DESCRIPTION
On windows 10 the open/save dialogue box has an minor error, and I believe I fixed it. 

When "Open" is selected from the menu, the title of the dialogue box says "SolveSpace - Save File" and the entered file name is "united". My fix correctly titles the dialoged box, and leaves the address bar blank when a file is being opened because "united" is only needed as a default name when a file being saved. 

I found that class FileDialogImplWin32 from guiwin.cpp contains two if statements for "isSaveDialog". This is redundant. I removed the first where the title was originally set, but not working. I then set the title in the second if statement and moved the 'if isEmpty'' to this section.