### PR TITLE
Clamp lighting value on export to fix flat colors

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -236,9 +236,7 @@ void TextWindow::ShowConfiguration() {
             CO(SS.lightDir[i]), i, &ScreenChangeLightDirection,
             SS.lightIntensity[i], i, &ScreenChangeLightIntensity);
     }
-    Printf(false, "%Bp         ambient lighting     "
-                  "%2 %Fl%D%f%Ll[c]%E",
-            (i & 1) ? 'd' : 'a', i,
+    Printf(false, "%Ba         ambient lighting     %2 %Fl%f%Ll[c]%E",
         SS.ambientIntensity, &ScreenChangeLightAmbient);
 
     Printf(false, "");

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -366,9 +366,9 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
 
             // And calculate lighting for the triangle
             Vector n = tt.Normal().WithMagnitude(1);
-            double lighting = SS.ambientIntensity +
+            double lighting = min(1.0, SS.ambientIntensity +
                                   max(0.0, (SS.lightIntensity[0])*(n.Dot(l0))) +
-                                  max(0.0, (SS.lightIntensity[1])*(n.Dot(l1)));
+                                  max(0.0, (SS.lightIntensity[1])*(n.Dot(l1))));
             double r = min(1.0, tt.meta.color.redF()   * lighting),
                    g = min(1.0, tt.meta.color.greenF() * lighting),
                    b = min(1.0, tt.meta.color.blueF()  * lighting);


### PR DESCRIPTION
This closes #986.  The computed lighting value when ambient lighting value == 1.0 needed to be clamped to 1.0 in order to achieve flat shading as expected.

Also, this fixes the Printf format for the ambient lighting entry on the configuration screen.  This was causing strange behavior when attempting to edit the ambient lighting value on Windows.  Oddly this didn't seem
to affect Linux.