### PR TITLE
Copy path to avoid it being invalidated by OkayToStartNewFile()

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -369,8 +369,11 @@ static void PopulateMenuWithPathnames(Platform::MenuRef menu,
 
 void GraphicsWindow::PopulateRecentFiles() {
     PopulateMenuWithPathnames(openRecentMenu, SS.recentFiles, [](const Platform::Path &path) {
+        // OkayToStartNewFile could mutate recentFiles, which will invalidate path (which is a
+        // refererence into the recentFiles vector), so take a copy of it here.
+        Platform::Path pathCopy(path);
         if(!SS.OkayToStartNewFile()) return;
-        SS.Load(path);
+        SS.Load(pathCopy);
     });
 
     PopulateMenuWithPathnames(linkRecentMenu, SS.recentFiles, [](const Platform::Path &path) {


### PR DESCRIPTION
Fixes issue #495

I had a 100% reliable repro locally (as described [here](https://github.com/solvespace/solvespace/issues/495#issuecomment-813023035)) and this change fixes it for me, I am no longer able to reproduce the assertion. There might be a better way to fix it that could avoid similar problems in the future (change how the lambdas capture, rework how PopulateMenuWithPathnames and onTrigger work?) but I'm not familiar enough with the codebase to make that judgement, and this seems to do the trick!