### PR TITLE
Correct libomp.dylib path in sign-macos.sh script

### DIFF
--- a/.github/scripts/sign-macos.sh
+++ b/.github/scripts/sign-macos.sh
@@ -16,7 +16,7 @@ lipo \
 
 cd build
 
-openmp="bin/SolveSpace.app/Contents/Resources/lib/libomp.dylib"
+openmp="bin/SolveSpace.app/Contents/Resources/libomp.dylib"
 app="bin/SolveSpace.app"
 dmg="bin/SolveSpace.dmg"
 bundle_id="com.solvespace.solvespace"


### PR DESCRIPTION
Looks like I forgot to update this path, and that is causing the CI to fail at the moment.

@phkahler I also looked at the libpng patch, but that already seems to only be applied on macOS, so I think you can go into the submodule and run `git stash` or something to get rid of the changes that were made there