### PR TITLE
Combine arm64 and x86_64 libomp libraries

### DIFF
--- a/.github/scripts/sign-macos.sh
+++ b/.github/scripts/sign-macos.sh
@@ -2,6 +2,13 @@
 
 lipo \
     -create \
+        build/bin/SolveSpace.app/Contents/Resources/libomp.dylib \
+        build-arm64/bin/SolveSpace.app/Contents/Resources/libomp.dylib \
+    -output \
+        build/bin/SolveSpace.app/Contents/Resources/libomp.dylib
+
+lipo \
+    -create \
         build/bin/SolveSpace.app/Contents/MacOS/SolveSpace \
         build-arm64/bin/SolveSpace.app/Contents/MacOS/SolveSpace \
     -output \


### PR DESCRIPTION
I cannot test the `sign-macos.sh` script locally unfortunately (I am out of code-signing certificates).
I just downloaded the last build and it crashes on my M1, because the libomp library is of the wrong architecture, this should combine the 2 architectures.