### PR TITLE
Add an exploded view to sketches

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -68,6 +68,11 @@ void TextWindow::ScreenChangeGridSpacing(int link, uint32_t v) {
     SS.TW.edit.meaning = Edit::GRID_SPACING;
 }
 
+void TextWindow::ScreenChangeExplodeDistance(int link, uint32_t v) {
+    SS.TW.ShowEditControl(3, SS.MmToString(SS.explodeDistance, true));
+    SS.TW.edit.meaning = Edit::EXPLODE_DISTANCE;
+}
+
 void TextWindow::ScreenChangeDigitsAfterDecimal(int link, uint32_t v) {
     SS.TW.ShowEditControl(14, ssprintf("%d", SS.UnitDigitsAfterDecimal()));
     SS.TW.edit.meaning = Edit::DIGITS_AFTER_DECIMAL;
@@ -269,6 +274,10 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "%Ba   %s %Fl%Ll%f%D[change]%E",
         SS.MmToString(SS.gridSpacing).c_str(),
         &ScreenChangeGridSpacing, 0);
+    Printf(false, "%Ft explode distance%E");
+    Printf(false, "%Ba   %s %Fl%Ll%f%D[change]%E",
+        SS.MmToString(SS.explodeDistance).c_str(),
+        &ScreenChangeExplodeDistance, 0);
 
     Printf(false, "");
     Printf(false, "%Ft digits after decimal point to show%E");
@@ -457,6 +466,11 @@ bool TextWindow::EditControlDoneForConfiguration(const std::string &s) {
         case Edit::GRID_SPACING: {
             SS.gridSpacing = (float)min(1e4, max(1e-3, SS.StringToMm(s)));
             SS.GW.Invalidate();
+            break;
+        }
+        case Edit::EXPLODE_DISTANCE: {
+            SS.explodeDistance = min(1e4, max(-1e4, SS.StringToMm(s)));
+            SS.MarkGroupDirty(SS.GW.activeGroup, true);
             break;
         }
         case Edit::DIGITS_AFTER_DECIMAL: {

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -267,7 +267,7 @@ void Constraint::DoEqualRadiusTicks(Canvas *canvas, Canvas::hStroke hcs,
     const Camera &camera = canvas->GetCamera();
     Entity *circ = SK.GetEntity(he);
 
-    Vector center = SK.GetEntity(circ->point[0])->PointGetNum();
+    Vector center = SK.GetEntity(circ->point[0])->PointGetDrawNum();
     double r = circ->CircleGetRadiusNum();
     Quaternion q = circ->Normal()->NormalGetNum();
     Vector u = q.RotationU(), v = q.RotationV();
@@ -291,7 +291,8 @@ void Constraint::DoEqualRadiusTicks(Canvas *canvas, Canvas::hStroke hcs,
 
 void Constraint::DoArcForAngle(Canvas *canvas, Canvas::hStroke hcs,
                                Vector a0, Vector da, Vector b0, Vector db,
-                               Vector offset, Vector *ref, bool trim)
+                               Vector offset, Vector *ref, bool trim,
+                               Vector explodeOffset)
 {
     const Camera &camera = canvas->GetCamera();
     double pixels = 1.0 / camera.scale;
@@ -304,6 +305,9 @@ void Constraint::DoArcForAngle(Canvas *canvas, Canvas::hStroke hcs,
         da = da.ProjectVectorInto(workplane);
         db = db.ProjectVectorInto(workplane);
     }
+
+    a0 = a0.Plus(explodeOffset);
+    b0 = b0.Plus(explodeOffset);
 
     Vector a1 = a0.Plus(da);
     Vector b1 = b0.Plus(db);
@@ -534,6 +538,15 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 DoProjectedPoint(canvas, hcs, &bp);
             }
 
+            if(ShouldDrawExploded()) {
+                // Offset A and B by the same offset so the constraint is drawn
+                // in the plane of one of the exploded points (rather than at an
+                // angle)
+                Vector offset = SK.GetEntity(ptA)->ExplodeOffset();
+                ap = ap.Plus(offset);
+                bp = bp.Plus(offset);
+            }
+
             Vector ref = ((ap.Plus(bp)).ScaledBy(0.5)).Plus(disp.offset);
             if(refs) refs->push_back(ref);
 
@@ -547,6 +560,19 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                    bp = SK.GetEntity(ptB)->PointGetNum(),
                    dp = (bp.Minus(ap)),
                    pp = SK.GetEntity(entityA)->VectorGetNum();
+
+            if(ShouldDrawExploded()) {
+                // explode for whichever point is in the workplane (or the first if both are) 
+                Entity *pt = SK.GetEntity(ptA);
+                if(pt->group != group) {
+                    pt = SK.GetEntity(ptB);
+                }
+                if(pt->group == group) {
+                    Vector offset = pt->ExplodeOffset();
+                    ap = ap.Plus(offset);
+                    bp = bp.Plus(offset);
+                }
+            }
 
             Vector ref = ((ap.Plus(bp)).ScaledBy(0.5)).Plus(disp.offset);
             if(refs) refs->push_back(ref);
@@ -564,7 +590,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
 
         case Type::PT_FACE_DISTANCE:
         case Type::PT_PLANE_DISTANCE: {
-            Vector pt = SK.GetEntity(ptA)->PointGetNum();
+            Vector pt = SK.GetEntity(ptA)->PointGetDrawNum();
             Entity *enta = SK.GetEntity(entityA);
             Vector n, p;
             if(type == Type::PT_PLANE_DISTANCE) {
@@ -590,7 +616,8 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
         }
 
         case Type::PT_LINE_DISTANCE: {
-            Vector pt = SK.GetEntity(ptA)->PointGetNum();
+            Entity *ptEntity = SK.GetEntity(ptA);
+            Vector pt = ptEntity->PointGetNum();
             Entity *line = SK.GetEntity(entityA);
             Vector lA = SK.GetEntity(line->point[0])->PointGetNum();
             Vector lB = SK.GetEntity(line->point[1])->PointGetNum();
@@ -600,6 +627,19 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 lA = lA.ProjectInto(workplane);
                 lB = lB.ProjectInto(workplane);
                 DoProjectedPoint(canvas, hcs, &pt);
+            }
+
+            // Only explode if the point and line are in the same group (and that group is a sketch
+            // with explode enabled) otherwise it's too visually confusing to figure out what the
+            // correct projections should be.
+            bool shouldExplode = ShouldDrawExploded()
+                && ptEntity->group == group
+                && line->group == group;
+            if(shouldExplode) {
+                Vector explodeOffset = ptEntity->ExplodeOffset();
+                pt = pt.Plus(explodeOffset);
+                lA = lA.Plus(explodeOffset);
+                lB = lB.Plus(explodeOffset);
             }
 
             // Find the closest point on the line
@@ -655,7 +695,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
 
         case Type::DIAMETER: {
             Entity *circle = SK.GetEntity(entityA);
-            Vector center = SK.GetEntity(circle->point[0])->PointGetNum();
+            Vector center = SK.GetEntity(circle->point[0])->PointGetDrawNum();
             Quaternion q = SK.GetEntity(circle->normal)->NormalGetNum();
             Vector n = q.RotationN().WithMagnitude(1);
             double r = circle->CircleGetRadiusNum();
@@ -697,7 +737,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 Vector r = camera.projRight.ScaledBy((a+1)/camera.scale);
                 Vector d = camera.projUp.ScaledBy((2-a)/camera.scale);
                 for(int i = 0; i < 2; i++) {
-                    Vector p = SK.GetEntity(i == 0 ? ptA : ptB)-> PointGetNum();
+                    Vector p = SK.GetEntity(i == 0 ? ptA : ptB)->PointGetDrawNum();
                     if(refs) refs->push_back(p);
                     canvas->DrawQuad(p.Plus (r).Plus (d),
                                      p.Plus (r).Minus(d),
@@ -715,7 +755,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
         case Type::PT_ON_FACE:
         case Type::PT_IN_PLANE: {
             double s = 8/camera.scale;
-            Vector p = SK.GetEntity(ptA)->PointGetNum();
+            Vector p = SK.GetEntity(ptA)->PointGetDrawNum();
             if(refs) refs->push_back(p);
             Vector r, d;
             if(type == Type::PT_ON_FACE) {
@@ -740,7 +780,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
         }
 
         case Type::WHERE_DRAGGED: {
-            Vector p = SK.GetEntity(ptA)->PointGetNum();
+            Vector p = SK.GetEntity(ptA)->PointGetDrawNum();
             if(refs) refs->push_back(p);
             Vector u = p.Plus(gu.WithMagnitude(8/camera.scale)).Plus(
                               gr.WithMagnitude(8/camera.scale)),
@@ -797,10 +837,10 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             }
 
             DoArcForAngle(canvas, hcs, a0, da, b0, db,
-                da.WithMagnitude(40/camera.scale), &ref, /*trim=*/false);
+                da.WithMagnitude(40/camera.scale), &ref, /*trim=*/false, a->ExplodeOffset());
             if(refs) refs->push_back(ref);
             DoArcForAngle(canvas, hcs, c0, dc, d0, dd,
-                dc.WithMagnitude(40/camera.scale), &ref, /*trim=*/false);
+                dc.WithMagnitude(40/camera.scale), &ref, /*trim=*/false, c->ExplodeOffset());
             if(refs) refs->push_back(ref);
 
             return;
@@ -820,7 +860,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             }
 
             Vector ref;
-            DoArcForAngle(canvas, hcs, a0, da, b0, db, disp.offset, &ref, /*trim=*/true);
+            DoArcForAngle(canvas, hcs, a0, da, b0, db, disp.offset, &ref, /*trim=*/true, a->ExplodeOffset());
             DoLabel(canvas, hcs, ref, labelPos, gr, gu);
             if(refs) refs->push_back(ref);
             return;
@@ -855,7 +895,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                     if(u.Dot(ru) < 0) u = u.ScaledBy(-1);
                 }
 
-                Vector p = e->VectorGetRefPoint();
+                Vector p = e->VectorGetRefPoint().Plus(e->ExplodeOffset());
                 Vector s = p.Plus(u).Plus(v);
                 DoLine(canvas, hcs, s, s.Plus(v));
                 Vector m = s.Plus(v.ScaledBy(0.5));
@@ -873,9 +913,9 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             if(type == Type::ARC_LINE_TANGENT) {
                 Entity *arc = SK.GetEntity(entityA);
                 Entity *norm = SK.GetEntity(arc->normal);
-                Vector c = SK.GetEntity(arc->point[0])->PointGetNum();
+                Vector c = SK.GetEntity(arc->point[0])->PointGetDrawNum();
                 Vector p =
-                    SK.GetEntity(arc->point[other ? 2 : 1])->PointGetNum();
+                    SK.GetEntity(arc->point[other ? 2 : 1])->PointGetDrawNum();
                 Vector r = p.Minus(c);
                 textAt = p.Plus(r.WithMagnitude(14/camera.scale));
                 u = norm->NormalU();
@@ -896,6 +936,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 Entity *cubic = SK.GetEntity(entityA);
                 Vector p = other ? cubic->CubicGetFinishNum() :
                                    cubic->CubicGetStartNum();
+                p = p.Plus(cubic->ExplodeOffset());
                 Vector dir = SK.GetEntity(entityB)->VectorGetNum();
                 Vector out = n.Cross(dir);
                 textAt = p.Plus(out.WithMagnitude(14/camera.scale));
@@ -905,12 +946,12 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 u = wn->NormalU();
                 v = wn->NormalV();
                 n = wn->NormalN();
-                EntityBase *eA = SK.GetEntity(entityA);
+                Entity *eA = SK.GetEntity(entityA);
                 // Big pain; we have to get a vector tangent to the curve
                 // at the shared point, which could be from either a cubic
                 // or an arc.
                 if(other) {
-                    textAt = eA->EndpointFinish();
+                    textAt = eA->EndpointFinish().Plus(eA->ExplodeOffset());
                     if(eA->type == Entity::Type::CUBIC) {
                         dir = eA->CubicGetFinishTangentNum();
                     } else {
@@ -919,7 +960,7 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                         dir = n.Cross(dir);
                     }
                 } else {
-                    textAt = eA->EndpointStart();
+                    textAt = eA->EndpointStart().Plus(eA->ExplodeOffset());
                     if(eA->type == Entity::Type::CUBIC) {
                         dir = eA->CubicGetStartTangentNum();
                     } else {
@@ -947,6 +988,10 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 Vector u = (gn.Cross(n)).WithMagnitude(4/camera.scale);
                 Vector p = e->VectorGetRefPoint();
 
+                if(ShouldDrawExploded()) {
+                    p = p.Plus(e->ExplodeOffset());
+                }
+
                 DoLine(canvas, hcs, p.Plus(u), p.Plus(u).Plus(n));
                 DoLine(canvas, hcs, p.Minus(u), p.Minus(u).Plus(n));
                 if(refs) refs->push_back(p.Plus(n.ScaledBy(0.5)));
@@ -967,8 +1012,8 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             Entity *line = SK.GetEntity(entityA);
             Vector ref;
             DoEqualLenTicks(canvas, hcs,
-                SK.GetEntity(line->point[0])->PointGetNum(),
-                SK.GetEntity(line->point[1])->PointGetNum(),
+                SK.GetEntity(line->point[0])->PointGetDrawNum(),
+                SK.GetEntity(line->point[1])->PointGetDrawNum(),
                 gn, &ref);
             if(refs) refs->push_back(ref);
             DoEqualRadiusTicks(canvas, hcs, entityB, &ref);
@@ -988,6 +1033,12 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 if(workplane != Entity::FREE_IN_3D) {
                     DoProjectedPoint(canvas, hcs, &a);
                     DoProjectedPoint(canvas, hcs, &b);
+                }
+
+                if(ShouldDrawExploded()) {
+                    Vector offset = e->ExplodeOffset();
+                    a = a.Plus(offset);
+                    b = b.Plus(offset);
                 }
 
                 Vector ref;
@@ -1044,6 +1095,11 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 DoProjectedPoint(canvas, hcs, &a);
                 DoProjectedPoint(canvas, hcs, &b);
             }
+            if(ShouldDrawExploded()) {
+                Vector offset = forLen->ExplodeOffset();
+                a = a.Plus(offset);
+                b = b.Plus(offset);
+            }
             Vector refa;
             DoEqualLenTicks(canvas, hcs, a, b, gn, &refa);
             if(refs) refs->push_back(refa);
@@ -1059,6 +1115,11 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             }
 
             Vector closest = pt.ClosestPointOnLine(la, lb.Minus(la));
+            if(ShouldDrawExploded()) {
+                Vector offset = SK.GetEntity(ptA)->ExplodeOffset();
+                pt = pt.Plus(offset);
+                closest = closest.Plus(offset);
+            }
             DoLine(canvas, hcs, pt, closest);
             Vector refb;
             DoEqualLenTicks(canvas, hcs, pt, closest, gn, &refb);
@@ -1081,6 +1142,11 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
                 }
 
                 Vector closest = pt.ClosestPointOnLine(la, lb.Minus(la));
+                if(ShouldDrawExploded()) {
+                    Vector offset = pte->ExplodeOffset();
+                    pt = pt.Plus(offset);
+                    closest = closest.Plus(offset);
+                }
                 DoLine(canvas, hcs, pt, closest);
 
                 Vector ref;
@@ -1110,8 +1176,8 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             goto s;
         }
 s:
-            Vector a = SK.GetEntity(ptA)->PointGetNum();
-            Vector b = SK.GetEntity(ptB)->PointGetNum();
+            Vector a = SK.GetEntity(ptA)->PointGetDrawNum();
+            Vector b = SK.GetEntity(ptB)->PointGetDrawNum();
 
             for(int i = 0; i < 2; i++) {
                 Vector tail = (i == 0) ? a : b;
@@ -1148,8 +1214,8 @@ s:
                 }
                 // For "at midpoint", this branch is always taken.
                 Entity *e = SK.GetEntity(entityA);
-                Vector a = SK.GetEntity(e->point[0])->PointGetNum();
-                Vector b = SK.GetEntity(e->point[1])->PointGetNum();
+                Vector a = SK.GetEntity(e->point[0])->PointGetDrawNum();
+                Vector b = SK.GetEntity(e->point[1])->PointGetDrawNum();
                 Vector m = (a.ScaledBy(0.5)).Plus(b.ScaledBy(0.5));
                 Vector offset = (a.Minus(b)).Cross(n);
                 offset = offset.WithMagnitude(textHeight);
@@ -1173,8 +1239,8 @@ s:
                                        r.WithMagnitude(1), u.WithMagnitude(1), hcs);
                 if(refs) refs->push_back(o);
             } else {
-                Vector a = SK.GetEntity(ptA)->PointGetNum();
-                Vector b = SK.GetEntity(ptB)->PointGetNum();
+                Vector a = SK.GetEntity(ptA)->PointGetDrawNum();
+                Vector b = SK.GetEntity(ptB)->PointGetDrawNum();
 
                 Entity *w = SK.GetEntity(workplane);
                 Vector cu = w->Normal()->NormalU();
@@ -1290,4 +1356,8 @@ bool Constraint::HasLabel() const {
         default:
             return false;
     }
+}
+
+bool Constraint::ShouldDrawExploded() const {
+    return SK.GetGroup(group)->ShouldDrawExploded();
 }

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -224,9 +224,11 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
         if(PruneGroups(hg))
             goto pruned;
 
+        int groupRequestIndex = 0;
         for(auto &req : SK.request) {
             Request *r = &req;
             if(r->group != hg) continue;
+            r->groupRequestIndex = groupRequestIndex++;
 
             r->Generate(&(SK.entity), &(SK.param));
         }

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -94,6 +94,7 @@ const MenuEntry Menu[] = {
 { 1, N_("Show Snap &Grid"),             Command::SHOW_GRID,        '>',     KC, mView  },
 { 1, N_("Darken Inactive Solids"),      Command::DIM_SOLID_MODEL,  0,       KC, mView  },
 { 1, N_("Use &Perspective Projection"), Command::PERSPECTIVE_PROJ, '`',     KC, mView  },
+{ 1, N_("Show E&xploded View"),         Command::EXPLODE_SKETCH,   '\\',    KC, mView  },
 { 1, N_("Dimension &Units"),            Command::NONE,             0,       KN, NULL  },
 { 2, N_("Dimensions in &Millimeters"),  Command::UNITS_MM,         0,       KR, mView },
 { 2, N_("Dimensions in M&eters"),       Command::UNITS_METERS,     0,       KR, mView },
@@ -318,6 +319,8 @@ void GraphicsWindow::PopulateMainMenu() {
                 dimSolidModelMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::PERSPECTIVE_PROJ) {
                 perspectiveProjMenuItem = menuItem;
+            } else if(Menu[i].cmd == Command::EXPLODE_SKETCH) {
+                explodeMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::SHOW_TOOLBAR) {
                 showToolbarMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::SHOW_TEXT_WND) {
@@ -753,6 +756,12 @@ void GraphicsWindow::MenuView(Command id) {
             }
             break;
 
+        case Command::EXPLODE_SKETCH:
+            SS.explode = !SS.explode;
+            SS.GW.EnsureValidActives();
+            SS.MarkGroupDirty(SS.GW.activeGroup, true);
+            break;
+
         case Command::ONTO_WORKPLANE:
             if(SS.GW.LockedInWorkplane()) {
                 SS.GW.AnimateOntoWorkplane();
@@ -951,6 +960,7 @@ void GraphicsWindow::EnsureValidActives() {
     showGridMenuItem->SetActive(SS.GW.showSnapGrid);
     dimSolidModelMenuItem->SetActive(SS.GW.dimSolidModel);
     perspectiveProjMenuItem->SetActive(SS.usePerspectiveProj);
+    explodeMenuItem->SetActive(SS.explode);
     showToolbarMenuItem->SetActive(SS.showToolbar);
     fullScreenMenuItem->SetActive(SS.GW.window->IsFullScreen());
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1190,3 +1190,6 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
     el->Add(&en);
 }
 
+bool Group::ShouldDrawExploded() const {
+    return SS.explode && h == SS.GW.activeGroup && type == Type::DRAWING_WORKPLANE && !SS.exportMode;
+}

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -326,6 +326,7 @@ public:
     void DrawPolyError(Canvas *canvas);
     void DrawFilledPaths(Canvas *canvas);
     void DrawContourAreaLabels(Canvas *canvas);
+    bool ShouldDrawExploded() const;
 
     SPolygon GetPolygon();
 
@@ -371,6 +372,7 @@ public:
     std::string font;
     Platform::Path file;
     double      aspectRatio;
+    int groupRequestIndex;
 
     static hParam AddParam(ParamList *param, hParam hp);
     void Generate(EntityList *entity, ParamList *param);
@@ -594,6 +596,10 @@ public:
         beziers.l.Clear();
         edges.l.Clear();
     }
+
+    bool ShouldDrawExploded() const;
+    Vector ExplodeOffset() const;
+    Vector PointGetDrawNum() const;
 };
 
 class EntReqTable {
@@ -763,7 +769,7 @@ public:
                       Vector p0, Vector p1, Vector pt, double salient);
     void DoArcForAngle(Canvas *canvas, Canvas::hStroke hcs,
                        Vector a0, Vector da, Vector b0, Vector db,
-                       Vector offset, Vector *ref, bool trim);
+                       Vector offset, Vector *ref, bool trim, Vector explodeOffset);
     void DoArrow(Canvas *canvas, Canvas::hStroke hcs,
                  Vector p, Vector dir, Vector n, double width, double angle, double da);
     void DoLineWithArrows(Canvas *canvas, Canvas::hStroke hcs,
@@ -784,6 +790,8 @@ public:
                             hEntity he, Vector *refp);
 
     std::string DescriptionString() const;
+
+    bool ShouldDrawExploded() const;
 
     static hConstraint AddConstraint(Constraint *c, bool rememberForUndo = true);
     static void MenuConstrain(Command id);

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -19,6 +19,7 @@ void SolveSpaceUI::Init() {
     Platform::SettingsRef settings = Platform::GetSettings();
 
     SS.tangentArcRadius = 10.0;
+    SS.explodeDistance = 1.0;
 
     // Then, load the registry settings.
     // Default list of colors for the model material
@@ -1070,6 +1071,7 @@ void SolveSpaceUI::Clear() {
     GW.showGridMenuItem = NULL;
     GW.dimSolidModelMenuItem = NULL;
     GW.perspectiveProjMenuItem = NULL;
+    GW.explodeMenuItem = NULL;
     GW.showToolbarMenuItem = NULL;
     GW.showTextWndMenuItem = NULL;
     GW.fullScreenMenuItem = NULL;

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -609,6 +609,8 @@ public:
     int      afterDecimalDegree;
     bool     useSIPrefixes;
     int      autosaveInterval; // in minutes
+    bool     explode;
+    double   explodeDistance;
 
     std::string MmToString(double v, bool editable=false);
     std::string MmToStringSI(double v, int dim = 0);

--- a/src/ui.h
+++ b/src/ui.h
@@ -82,6 +82,7 @@ enum class Command : uint32_t {
     SHOW_GRID,
     DIM_SOLID_MODEL,
     PERSPECTIVE_PROJ,
+    EXPLODE_SKETCH,
     ONTO_WORKPLANE,
     NEAREST_ORTHO,
     NEAREST_ISO,
@@ -319,6 +320,7 @@ public:
         AUTOSAVE_INTERVAL     = 116,
         LIGHT_AMBIENT         = 117,
         FIND_CONSTRAINT_TIMEOUT = 118,
+        EXPLODE_DISTANCE      = 119,
         // For TTF text
         TTF_TEXT              = 300,
         // For the step dimension screen
@@ -488,6 +490,7 @@ public:
     static void ScreenChangeExportMaxSegments(int link, uint32_t v);
     static void ScreenChangeCameraTangent(int link, uint32_t v);
     static void ScreenChangeGridSpacing(int link, uint32_t v);
+    static void ScreenChangeExplodeDistance(int link, uint32_t v);
     static void ScreenChangeDigitsAfterDecimal(int link, uint32_t v);
     static void ScreenChangeDigitsAfterDecimalDegree(int link, uint32_t v);
     static void ScreenChangeUseSIPrefixes(int link, uint32_t v);
@@ -540,6 +543,7 @@ public:
     Platform::MenuItemRef showGridMenuItem;
     Platform::MenuItemRef dimSolidModelMenuItem;
     Platform::MenuItemRef perspectiveProjMenuItem;
+    Platform::MenuItemRef explodeMenuItem;
     Platform::MenuItemRef showToolbarMenuItem;
     Platform::MenuItemRef showTextWndMenuItem;
     Platform::MenuItemRef fullScreenMenuItem;


### PR DESCRIPTION
This PR adds an option to workplane sketches to draw all the entities in the sketch "exploded" normal to the workplane. The reason for doing this is that it makes it much easier to select lines and points which entirely overlap with other lines/points. I've found that when drawing a sketch from scratch in SolveSpace, I can usually use the "requests in group" list to find what I just added, but when importing complex DXFs created by other tools, that have all kinds of weird unexpected lines and constraints, it can be very difficult to figure out what constraints violations the import has created.

For example, here's a really basic sketch with a construction line hidden under the top line of the rect:
![Screenshot 2021-04-05 at 5 02 46 pm](https://user-images.githubusercontent.com/2305420/113597585-d53d6080-9633-11eb-9dfb-9a9cacfea1ff.png)
Here's the same sketch rotated (obviously, this doesn't help identify the construction line):
![Screenshot 2021-04-05 at 5 02 41 pm](https://user-images.githubusercontent.com/2305420/113597714-04ec6880-9634-11eb-95a4-bc805166b1f9.png)
But now if we enable the new "explode" option:
![Screenshot 2021-04-05 at 5 03 44 pm](https://user-images.githubusercontent.com/2305420/113597174-387ac300-9633-11eb-80b1-1f5c76ba83bc.png)

It's now really obvious where that line is:
![Screenshot 2021-04-05 at 5 02 35 pm](https://user-images.githubusercontent.com/2305420/113596953-e5a10b80-9632-11eb-961b-12ebd0aba7f2.png)

Enabling the "explode" option does not affect the underlying data, the plane adjustment is only made when rendering, and only when the sketch is active, so it wouldn't show up in any exported view. ~~Hmm now I try it thought, I may need to tweak that because constraints _do_ show up in their exploded positions...~~ Edit: now fixed, exploded coords are now never exported.

I've tried to update all the constraints drawing code to put the constraints in the same plane as the entity they're constraining, although I gave up on some of the more complex constraints that aren't solely in the workplane to start with. I figured it might be more misleading to mess with projected points and lines and such, and also my geometry skills were starting to struggle to figure out how to actually code it. If anyone else wanted to fix that, be my guest.

The "explode sketch when active" checkbox and the `explodeDistance` is per-Group, but I haven't updated the file format to persist the choice. I wasn't sure whether to, or not. It'd be convenient to remember it, but updating the file format looks like it introduces a warning dialog if anyone opens a newer file with an older version of SolveSpace, so I wasn't sure if it'd be a good idea to introduce that for such a minor feature. Feedback welcome on how best to do that! Or whether to just not bother, of course.