### PR TITLE
CI: Never skip cancel_previous_runs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,6 @@ jobs:
   cancel_previous_runs:
     runs-on: ubuntu-latest
     name: Cancel Previous Runs
-    if: github.event_name == 'push'
     steps:
     - uses: styfle/cancel-workflow-action@0.8.0
       with:
@@ -22,7 +21,6 @@ jobs:
     needs: [cancel_previous_runs]
     runs-on: ubuntu-18.04
     name: Test Ubuntu
-    if: "!cancelled()"
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
@@ -34,7 +32,6 @@ jobs:
     needs: [cancel_previous_runs]
     runs-on: windows-2019
     name: Test Windows
-    if: "!cancelled()"
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
@@ -48,7 +45,6 @@ jobs:
     needs: [cancel_previous_runs]
     runs-on: macos-10.15
     name: Test macOS
-    if: "!cancelled()"
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies


### PR DESCRIPTION
The if condition was nonsensical and did not serve any
practical purpose; removing it allows the succeeding jobs
to run in any case without additional code.

Test for release event: https://github.com/ppd/solvespace/actions/runs/760219571

@phkahler We could re-create the release on this commit, or I could upload the assets manually and build the snaps locally. What do you prefer?