### PR TITLE
Fix lookup of stipple pattern before config is available

### DIFF
--- a/src/sketch.h
+++ b/src/sketch.h
@@ -924,6 +924,7 @@ public:
     static double StippleScale(hStyle hs);
     static double StippleScaleMm(hStyle hs);
     static std::string StipplePatternName(hStyle hs);
+    static std::string StipplePatternName(StipplePattern stippleType);
     static StipplePattern StipplePatternFromString(std::string name);
 
     std::string DescriptionString() const;

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -114,7 +114,8 @@ void Style::FillDefaultStyle(Style *s, const Default *d, bool factory) {
     s->stippleType   = (factory)
                         ? d->stippleType
                         : Style::StipplePatternFromString(
-                            settings->ThawString(CnfStippleType(d->cnfPrefix), ""));
+                            settings->ThawString(CnfStippleType(d->cnfPrefix),
+                            StipplePatternName(d->stippleType)));
     s->stippleScale  = (factory)
                         ? 15.0
                         : settings->ThawFloat(CnfStippleScale(d->cnfPrefix), 15.0);
@@ -397,7 +398,11 @@ StipplePattern Style::PatternType(hStyle hs) {
 
 std::string Style::StipplePatternName(hStyle hs) {
     Style *s = Get(hs);
-    switch(s->stippleType) {
+    return StipplePatternName(s->stippleType);
+}
+
+std::string Style::StipplePatternName(StipplePattern stippleType) {
+    switch(stippleType) {
         case StipplePattern::CONTINUOUS:   return "Continuous";
         case StipplePattern::SHORT_DASH:   return "ShortDash";
         case StipplePattern::DASH:         return "Dash";
@@ -411,7 +416,6 @@ std::string Style::StipplePatternName(hStyle hs) {
 
     return "CONTINUOUS";
 }
-
 
 double Style::StippleScale(hStyle hs) {
     Style *s = Get(hs);

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -414,7 +414,7 @@ std::string Style::StipplePatternName(StipplePattern stippleType) {
         case StipplePattern::ZIGZAG:       return "ZigZag";
     }
 
-    return "CONTINUOUS";
+    return "Continuous";
 }
 
 double Style::StippleScale(hStyle hs) {


### PR DESCRIPTION
Fix a bug with the lookup of stipple pattern for default styles when the config settings are not yet available (install/upgrade/first run). This caused hidden lines to display as continuous rather than dashed.

This fixes #1027