### PR TITLE
Allow comments to be associated with point entities

### DIFF
--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -767,10 +767,19 @@ void Constraint::MenuConstrain(Command id) {
             break;
 
         case Command::COMMENT:
-            SS.GW.pending.operation = GraphicsWindow::Pending::COMMAND;
-            SS.GW.pending.command = Command::COMMENT;
-            SS.GW.pending.description = _("click center of comment text");
-            SS.ScheduleShowTW();
+            if(gs.points == 1 && gs.n == 1) {
+                c.type = Type::COMMENT;
+                c.ptA = gs.point[0];
+                c.group       = SS.GW.activeGroup;
+                c.workplane   = SS.GW.ActiveWorkplane();
+                c.comment     = _("NEW COMMENT -- DOUBLE-CLICK TO EDIT");
+                AddConstraint(&c);
+            } else {
+                SS.GW.pending.operation = GraphicsWindow::Pending::COMMAND;
+                SS.GW.pending.command = Command::COMMENT;
+                SS.GW.pending.description = _("click center of comment text");
+                SS.ScheduleShowTW();
+            }
             break;
 
         default: ssassert(false, "Unexpected menu ID");

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -1189,8 +1189,13 @@ s:
                 }
                 hcs = canvas->GetStroke(stroke);
             }
-            DoLabel(canvas, hcs, disp.offset, labelPos, u, v);
-            if(refs) refs->push_back(disp.offset);
+            Vector ref = disp.offset;
+            if(ptA.v) {
+                Vector a = SK.GetEntity(ptA)->PointGetNum();
+                ref = a.Plus(disp.offset);
+            }
+            DoLabel(canvas, hcs, ref, labelPos, u, v);
+            if(refs) refs->push_back(ref);
             return;
         }
     }


### PR DESCRIPTION
If a single point is selected when a "Constrain | Comment" (`;`) is added
then the comment is associated with the point and its position becomes
relative to the point. In this way the comment will move with the point.

If nothing is selected or more than a single point is selected then
the behaviour is as before and the comment is "floating".

Closes #1032

Alternative to https://github.com/solvespace/solvespace/pull/1034