### PR TITLE
Add mirror groups. WIP.

### DIFF
--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -171,6 +171,8 @@ void TextWindow::DescribeSelection() {
             case Entity::Type::FACE_N_ROT_TRANS:
             case Entity::Type::FACE_N_ROT_AA:
             case Entity::Type::FACE_N_TRANS:
+            case Entity::Type::FACE_MIRROR:
+            case Entity::Type::FACE_N_COPY:
                 Printf(false, "%FtPLANE FACE%E");
                 p = e->FaceGetNormalNum();
                 Printf(true,  "   normal = " PT_AS_NUM, CO(p));

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -86,6 +86,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::POINT_N_ROT_TRANS:
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
+        case Type::POINT_MIRROR:
         case Type::POINT_IN_3D:
         case Type::POINT_IN_2D:
             refs->push_back(PointGetNum());
@@ -96,6 +97,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::NORMAL_N_ROT_AA:
         case Type::NORMAL_IN_3D:
         case Type::NORMAL_IN_2D:
+        case Type::NORMAL_MIRROR:
         case Type::WORKPLANE:
         case Type::CIRCLE:
         case Type::ARC_OF_CIRCLE:
@@ -121,6 +123,8 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_MIRROR:
+        case Type::FACE_N_COPY:
         case Type::FACE_N_ROT_AXIS_TRANS:
             break;
     }
@@ -529,7 +533,8 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
         case Type::POINT_IN_3D:
-        case Type::POINT_IN_2D: {
+        case Type::POINT_IN_2D:
+        case Type::POINT_MIRROR: {
             if(how == DrawAs::HIDDEN) return;
 
             // If we're analyzing the sketch to show the degrees of freedom,
@@ -573,6 +578,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::NORMAL_N_COPY:
         case Type::NORMAL_N_ROT:
         case Type::NORMAL_N_ROT_AA:
+        case Type::NORMAL_MIRROR:
         case Type::NORMAL_IN_3D:
         case Type::NORMAL_IN_2D: {
             const Camera &camera = canvas->GetCamera();
@@ -783,7 +789,9 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::FACE_N_TRANS:
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
+        case Type::FACE_MIRROR:
         case Type::FACE_N_ROT_AXIS_TRANS:
+        case Type::FACE_N_COPY:
             // Do nothing; these are drawn with the triangle mesh
             return;
     }

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -246,6 +246,7 @@ bool EntityBase::IsPoint() const {
         case Type::POINT_N_ROT_TRANS:
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
+        case Type::POINT_MIRROR:
             return true;
 
         default:
@@ -260,6 +261,7 @@ bool EntityBase::IsNormal() const {
         case Type::NORMAL_N_COPY:
         case Type::NORMAL_N_ROT:
         case Type::NORMAL_N_ROT_AA:
+        case Type::NORMAL_MIRROR:
             return true;
 
         default:           return false;
@@ -293,7 +295,18 @@ Quaternion EntityBase::NormalGetNum() const {
             q = q.Times(numNormal);
             break;
         }
-
+        
+        case Type::NORMAL_MIRROR: {
+            Vector orig = numNormal.RotationN().WithMagnitude(1.0);
+            Vector n = Vector::From(
+                        SK.GetParam(param[0])->val,
+                        SK.GetParam(param[1])->val,
+                        SK.GetParam(param[2])->val);
+            Vector cp = orig.Cross(n);
+            q = numNormal.Times(Quaternion::From(n.Dot(orig), cp.x, cp.y, cp.z));
+            break;
+        }
+ 
         default: ssassert(false, "Unexpected entity type");
     }
     return q;
@@ -323,6 +336,7 @@ void EntityBase::NormalForceTo(Quaternion q) {
         }
 
         case Type::NORMAL_N_ROT_AA:
+        case Type::NORMAL_MIRROR:
             // Not sure if I'll bother implementing this one
             break;
 
@@ -381,6 +395,19 @@ ExprQuaternion EntityBase::NormalGetExprs() const {
             q = q.Times(orig);
             break;
         }
+        
+        case Type::NORMAL_MIRROR: {
+            ExprVector orig = ExprVector::From(numNormal.RotationN());
+            ExprVector n = ExprVector::From(
+                Expr::From(param[0]), Expr::From(param[1]), Expr::From(param[2]));
+            ExprVector cp = orig.Cross(n);
+            Expr *W = cp.Dot(n);
+            
+            ExprQuaternion r = ExprQuaternion::From(W,
+                     Expr::From(param[0]), Expr::From(param[1]), Expr::From(param[2]));
+            q = ExprQuaternion::From(numNormal).Times(r);
+            break;
+        }
 
         default: ssassert(false, "Unexpected entity type");
     }
@@ -417,6 +444,15 @@ void EntityBase::PointForceTo(Vector p) {
             p = p.Minus(c->WorkplaneGetOffset());
             SK.GetParam(param[0])->val = p.Dot(c->Normal()->NormalU());
             SK.GetParam(param[1])->val = p.Dot(c->Normal()->NormalV());
+            break;
+        }
+
+        case Type::POINT_MIRROR: {
+            Vector trans = p.Minus(numPoint).WithMagnitude(1.0);
+            SK.GetParam(param[0])->val = trans.x;
+            SK.GetParam(param[1])->val = trans.y;
+            SK.GetParam(param[2])->val = trans.z;
+            SK.GetParam(param[3])->val = p.Plus(numPoint).ScaledBy(0.5).Dot(trans);
             break;
         }
 
@@ -511,6 +547,13 @@ Vector EntityBase::PointGetNum() const {
             p = p.Plus(c->WorkplaneGetOffset());
             break;
         }
+        
+        case Type::POINT_MIRROR: {
+            Vector norm = Vector::From(param[0], param[1], param[2]);
+            double dist = SK.GetParam(param[3])->val;
+            p = numPoint.Plus(norm.ScaledBy(dist*2 - 2*numPoint.Dot(norm)));
+            break;
+        }
 
         case Type::POINT_N_TRANS: {
             Vector trans = Vector::From(param[0], param[1], param[2]);
@@ -569,6 +612,14 @@ ExprVector EntityBase::PointGetExprs() const {
             r = c->WorkplaneGetOffsetExprs();
             r = r.Plus(u.ScaledBy(Expr::From(param[0])));
             r = r.Plus(v.ScaledBy(Expr::From(param[1])));
+            break;
+        }
+        case Type::POINT_MIRROR:{
+            ExprVector orig = ExprVector::From(numPoint);
+            ExprVector norm = ExprVector::From(param[0], param[1], param[2]);
+            Expr *dist = Expr::From(param[3]);
+            r = orig.Plus(norm.ScaledBy(
+                dist->Minus(orig.Dot(norm))->Times(Expr::From(2.0))));
             break;
         }
         case Type::POINT_N_TRANS: {
@@ -703,6 +754,8 @@ bool EntityBase::IsFace() const {
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
         case Type::FACE_N_ROT_AXIS_TRANS:
+        case Type::FACE_MIRROR:
+        case Type::FACE_N_COPY:
             return true;
         default:
             return false;
@@ -711,9 +764,15 @@ bool EntityBase::IsFace() const {
 
 ExprVector EntityBase::FaceGetNormalExprs() const {
     ExprVector r;
-    if(type == Type::FACE_NORMAL_PT) {
+    if(type == Type::FACE_NORMAL_PT || type == Type::FACE_N_COPY) {
         Vector v = Vector::From(numNormal.vx, numNormal.vy, numNormal.vz);
         r = ExprVector::From(v.WithMagnitude(1));
+    } else if(type == Type::FACE_MIRROR) {
+        Vector v = Vector::From(numNormal.vx, numNormal.vy, numNormal.vz).ScaledBy(-1.0);
+        r = ExprVector::From(v.WithMagnitude(1));
+        ExprQuaternion q = ExprQuaternion::From( Expr::From(0.0),
+            Expr::From(param[0]), Expr::From(param[1]), Expr::From(param[2]) );
+        r = q.Rotate(r);
     } else if(type == Type::FACE_XPROD) {
         ExprVector vc = ExprVector::From(param[0], param[1], param[2]);
         ExprVector vn =
@@ -740,8 +799,16 @@ ExprVector EntityBase::FaceGetNormalExprs() const {
 
 Vector EntityBase::FaceGetNormalNum() const {
     Vector r;
-    if(type == Type::FACE_NORMAL_PT) {
+    if(type == Type::FACE_NORMAL_PT || type == Type::FACE_N_COPY) {
         r = Vector::From(numNormal.vx, numNormal.vy, numNormal.vz);
+    } else if(type == Type::FACE_MIRROR) {
+        r = Vector::From(numNormal.vx, numNormal.vy, numNormal.vz)
+            .ScaledBy(-1.0).WithMagnitude(1.0);
+        Quaternion q = Quaternion::From(0.0,
+                                SK.GetParam(param[0])->val,
+                                SK.GetParam(param[1])->val,
+                                SK.GetParam(param[2])->val);
+        r = q.Rotate(r);
     } else if(type == Type::FACE_XPROD) {
         Vector vc = Vector::From(param[0], param[1], param[2]);
         Vector vn = Vector::From(numNormal.vx, numNormal.vy, numNormal.vz);
@@ -763,8 +830,11 @@ Vector EntityBase::FaceGetNormalNum() const {
 
 ExprVector EntityBase::FaceGetPointExprs() const {
     ExprVector r;
-    if((type == Type::FACE_NORMAL_PT) || (type==Type::FACE_ROT_NORMAL_PT)) {
+    if((type == Type::FACE_NORMAL_PT) || (type==Type::FACE_ROT_NORMAL_PT)
+        || (type == Type::FACE_MIRROR)) {
         r = SK.GetEntity(point[0])->PointGetExprs();
+    } else if(type == Type::FACE_N_COPY) {
+        r = ExprVector::From(numPoint);
     } else if(type == Type::FACE_XPROD) {
         r = ExprVector::From(numPoint);
     } else if(type == Type::FACE_N_ROT_TRANS) {
@@ -803,6 +873,14 @@ Vector EntityBase::FaceGetPointNum() const {
     Vector r;
     if((type == Type::FACE_NORMAL_PT) || (type==Type::FACE_ROT_NORMAL_PT)) {
         r = SK.GetEntity(point[0])->PointGetNum();
+    } else if(type == Type::FACE_N_COPY) {
+        r = numPoint;
+    } else if(type == Type::FACE_MIRROR) {
+        Vector norm = Vector::From(param[0], param[1], param[2]);
+        double dist = SK.GetParam(param[3])->val;
+//        Vector p = SK.GetEntity(point[0])->PointGetNum();
+        Vector p = numPoint;
+        r = p.Plus(norm.ScaledBy(dist*2 - 2*p.Dot(norm)));
     } else if(type == Type::FACE_XPROD) {
         r = numPoint;
     } else if(type == Type::FACE_N_ROT_TRANS) {

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -115,6 +115,7 @@ const MenuEntry Menu[] = {
 { 1, N_("&Helix"),                      Command::GROUP_HELIX,      S|'h',   KN, mGrp   },
 { 1, N_("&Lathe"),                      Command::GROUP_LATHE,      S|'l',   KN, mGrp   },
 { 1, N_("Re&volve"),                    Command::GROUP_REVOLVE,    S|'v',   KN, mGrp   },
+{ 1, N_("&Mirror"),                     Command::GROUP_MIRROR ,    S|'m',   KN, mGrp   },
 { 1, NULL,                              Command::NONE,             0,       KN, NULL   },
 { 1, N_("Link / Assemble..."),          Command::GROUP_LINK,       S|'i',   KN, mGrp   },
 { 1, N_("Link Recent"),                 Command::GROUP_RECENT,     0,       KN, mGrp   },

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -152,6 +152,7 @@ public:
         N_ROT_AA,
         N_ROT_TRANS,
         N_ROT_AXIS_TRANS,
+        MIRROR,
     };
 
     enum class Type : uint32_t {
@@ -163,6 +164,7 @@ public:
         HELIX                         = 5103,
         ROTATE                        = 5200,
         TRANSLATE                     = 5201,
+        MIRROR                        = 5202,
         LINKED                        = 5300
     };
     Group::Type type;
@@ -315,6 +317,7 @@ public:
     void GenerateShellAndMesh();
     template<class T> void GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat);
     template<class T> void GenerateForBoolean(T *a, T *b, T *o, Group::CombineAs how);
+    template<class T> void GenerateForMirror(T *steps, T *outs, Group::CombineAs forWhat);
     void GenerateDisplayItems();
 
     enum class DrawMeshAs { DEFAULT, HOVERED, SELECTED };
@@ -395,12 +398,14 @@ public:
         POINT_N_COPY           =  2012,
         POINT_N_ROT_AA         =  2013,
         POINT_N_ROT_AXIS_TRANS =  2014,
+        POINT_MIRROR           =  2015,
 
         NORMAL_IN_3D           =  3000,
         NORMAL_IN_2D           =  3001,
         NORMAL_N_COPY          =  3010,
         NORMAL_N_ROT           =  3011,
         NORMAL_N_ROT_AA        =  3012,
+        NORMAL_MIRROR          =  3013,
 
         DISTANCE               =  4000,
         DISTANCE_N_COPY        =  4001,
@@ -412,7 +417,9 @@ public:
         FACE_N_ROT_AA          =  5004,
         FACE_ROT_NORMAL_PT     =  5005,
         FACE_N_ROT_AXIS_TRANS  =  5006,
-
+        FACE_MIRROR            =  5007,
+        FACE_N_COPY            =  5008,
+        
         WORKPLANE              = 10000,
         LINE_SEGMENT           = 11000,
         CUBIC                  = 12000,

--- a/src/ui.h
+++ b/src/ui.h
@@ -131,6 +131,7 @@ enum class Command : uint32_t {
     GROUP_EXTRUDE,
     GROUP_HELIX,
     GROUP_LATHE,
+    GROUP_MIRROR,
     GROUP_REVOLVE,
     GROUP_ROT,
     GROUP_TRANS,


### PR DESCRIPTION
This is my 4th try at mirror groups. Face entites are not working, normals may not either. Other entities work. The shell works, but faces can not be selected yet. Plans are to include options to mirror the group across selected points and to have it work in 2D as well.

Shift->M will create the new group.