### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Sketching:
 
 MISC:
 
-* When linking circuit boards (IDF .emn files) show keepout regions as construction entites.
+* When linking circuit boards (IDF .emn files) show keepout regions as construction entities.
 
 Performance:
 

--- a/developer_docs/IdLists_Entities_and_Remap.txt
+++ b/developer_docs/IdLists_Entities_and_Remap.txt
@@ -9,25 +9,25 @@ by pointers from the entity (font, extra points, etc...)
 
 Entities in a sketch are kept in a global array (IdList) referenced by a unique
 Id (handle) and can be looked up by Id in log(n) time via binary search. In
-order to use binary seach the array must be kept in order sorted by Id. One
+order to use binary search the array must be kept in order sorted by Id. One
 problem is that insertion takes O(n) time because half the list (on average)
 must be shifted to make room for a new item.
 
-The IdList class is a template and is used for more than entites.
+The IdList class is a template and is used for more than entities.
 
 EntityMap:
 ==========
 Another important structure is the EntityMap and EntityKey defined in sketch.h
 This is what allows SovleSpace to update groups when earlier groups in the
 sketch are changed. If a rectangle is extruded to a box and items are
-constrained to entites on that box, the user can go back to the sketch and
-modify it. Entites can be added, modified an even deleted. So long as the
-entites that are later used to build upon are kept the later extrude group will
+constrained to entities on that box, the user can go back to the sketch and
+modify it. Entities can be added, modified an even deleted. So long as the
+entities that are later used to build upon are kept the later extrude group will
 pick up the changes from the 2D sketch and anything build on it will remain.
 
 The way this works is that each group has a member called remap, which is one of
 these maps. This is where my understanding is fuzzy. At the end of Group.cpp is
-a function called Group::CopyEntity() which is used to make new sketch entites
+a function called Group::CopyEntity() which is used to make new sketch entities
 when a group is created. These are generally copies of entities in the previous
 group, but there are exceptions. A point will be used to generate a line when
 extruding a 2D sketch. A point will also be "copied" to a circle for a Lathe
@@ -35,7 +35,7 @@ group. For this reason, the entity key is derived by combining its previous key
 with something often called the CopyNumber or just remap (unfortunate).
 
 When a group is regenerated (the first time, or after a previous one is
-modified) entites are copied from the old group to the new one. For Step
+modified) entities are copied from the old group to the new one. For Step
 Translating and Rotating there may be many copies, and the copy number is
 literally N for the Nth copy except for the last one which gets an enum - it is
 common to constrain the last item, so it gets a large unique number so that
@@ -45,5 +45,5 @@ Remap that was created the same way. This is how constructions are preserved
 across underlying changes.
 
 There are some hard limits used in the hash table for the remap mechanism which
-limit the number of entites in a group (but not the global sketch).
+limit the number of entities in a group (but not the global sketch).
 

--- a/developer_docs/Solver_Transforms.txt
+++ b/developer_docs/Solver_Transforms.txt
@@ -46,7 +46,7 @@ POINT_N_ROT_TRANS: Rotates a point via quaternion param[3],param[4],param[5],par
 
 POINT_N_COPY:      A non-transformed copy of a point - numeric copy?
 
-POINT_N_ROT_AA:    A point rotated arount point param[0],param[1],param[2] Where the
+POINT_N_ROT_AA:    A point rotated around point param[0],param[1],param[2] Where the
                    angle is given by param[3]*timesApplied (times 2?) and the axis
                    of rotation defined by param[4],param[5],param[6]
 
@@ -130,7 +130,7 @@ the entity itself.
 The ForceTo() functions are shortcuts for using the solver. They are passed the
 desired location of a point (or orientation of a normal...) and have the opportunity
 to back-calculate what the group parameters should be to place it there. This is
-used for mouse dragging of copied entites. It is notable that the constraints will
+used for mouse dragging of copied entities. It is notable that the constraints will
 still be applied afterward, but this is a good shortcut.
 
 When creating a new entity transformation, the first thing to do is define the

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -281,7 +281,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
             }
             case Constraint::Type::HORIZONTAL:
             case Constraint::Type::VERTICAL:
-                // When rotating 90 or 270 degrees, swap the vertical / horizontal constaints
+                // When rotating 90 or 270 degrees, swap the vertical / horizontal constraints
                 if (EXACT(fmod(theta + (PI/2), PI) == 0)) {
                     if(c.type == Constraint::Type::HORIZONTAL) {
                         c.type = Constraint::Type::VERTICAL;

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -370,7 +370,7 @@ static void PopulateMenuWithPathnames(Platform::MenuRef menu,
 void GraphicsWindow::PopulateRecentFiles() {
     PopulateMenuWithPathnames(openRecentMenu, SS.recentFiles, [](const Platform::Path &path) {
         // OkayToStartNewFile could mutate recentFiles, which will invalidate path (which is a
-        // refererence into the recentFiles vector), so take a copy of it here.
+        // reference into the recentFiles vector), so take a copy of it here.
         Platform::Path pathCopy(path);
         if(!SS.OkayToStartNewFile()) return;
         SS.Load(pathCopy);

--- a/src/importidf.cpp
+++ b/src/importidf.cpp
@@ -54,7 +54,7 @@ static std::vector <std::string> splitString(const std::string line) {
 }
 
 //////////////////////////////////////////////////////////////////////////////
-// Functions for linking an IDF file - we need to create entites that
+// Functions for linking an IDF file - we need to create entities that
 // get remapped into a linked group similar to linking .slvs files
 //////////////////////////////////////////////////////////////////////////////
 
@@ -291,9 +291,9 @@ static void MakeBeziersForArcs(SBezierList *sbl, Vector center, Vector pa, Vecto
 namespace SolveSpace {
 
 // Here we read the important section of an IDF file. SolveSpace Entities are directly created by
-// the funcions above, which is only OK because of the way linking works. For example points do
+// the functions above, which is only OK because of the way linking works. For example points do
 // not have handles for solver parameters (coordinates), they only have their actPoint values
-// set (or actNormal or actDistance). These are incompete entites and would be a problem if
+// set (or actNormal or actDistance). These are incomplete entities and would be a problem if
 // they were part of the sketch, but they are not. After making a list of them here, a new group
 // gets created from copies of these. Those copies are complete and part of the sketch group.
 bool LinkIDF(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *sh) {

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1229,7 +1229,7 @@ public:
         sscheck(GetMonitorInfo(MonitorFromRect(&rc, MONITOR_DEFAULTTONEAREST), &mi));
 
         // If it somehow ended up off-screen, then put it back.
-        // and make it visible by at least this portion of the scrren
+        // and make it visible by at least this portion of the screen
         const LONG movein = 40;
 
         RECT mrc = mi.rcMonitor;

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -349,7 +349,7 @@ static const char *DimToString(int dim) {
 }
 static std::pair<int, std::string> SelectSIPrefixMm(int ord, int dim) {
 // decide what units to use depending on the order of magnitude of the
-// measure in meters and the dimmension (1,2,3 lenear, area, volume)
+// measure in meters and the dimension (1,2,3 lenear, area, volume)
     switch(dim) {
         case 0:
         case 1:

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -29,7 +29,7 @@ void SCurve::GetAxisAlignedBounding(Vector *ptMax, Vector *ptMin) const {
     }
 }
 
-// We will be inserting other curve verticies into our curves to split them.
+// We will be inserting other curve vertices into our curves to split them.
 // This is helpful when curved surfaces become tangent along a trim and the
 // usual tests for curve-surface intersection don't split the curve at a vertex.
 // This is faster than the previous version that split at surface corners and
@@ -796,7 +796,7 @@ void SShell::MakeFromBoolean(SShell *a, SShell *b, SSurface::CombineAs type) {
     b->MakeClassifyingBsps(NULL);
 
     // Copy over all the original curves, splitting them so that a
-    // piecwise linear segment never crosses a surface from the other
+    // piecewise linear segment never crosses a surface from the other
     // shell.
     a->CopyCurvesSplitAgainst(/*opA=*/true,  b, this);
     b->CopyCurvesSplitAgainst(/*opA=*/false, a, this);

--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -817,7 +817,7 @@ void SCurve::RemoveShortSegments(SSurface *srfA, SSurface *srfB) {
             continue;
         }
 
-        // if the curve is exact and points are >0.05 appart wrt t, point is there
+        // if the curve is exact and points are >0.05 apart wrt t, point is there
         // deliberately regardless of chord tolerance (ex: small circles)
         tprev = t = tnext = 0;
         if (isExact) {

--- a/src/srf/triangulate.cpp
+++ b/src/srf/triangulate.cpp
@@ -426,7 +426,7 @@ void SContour::UvTriangulateInto(SMesh *m, SSurface *srf) {
             if (i == l.n-1) {
                 end = true;
             }
-            if (end) {  // triangulate the fan and tag the verticies
+            if (end) {  // triangulate the fan and tag the vertices
                 if (j > 3) {
                     Vector center = l[pstart+1].p.Plus(l[pstart+j-1].p).ScaledBy(0.5);
                     for (int x=0; x<j; x++) {
@@ -597,11 +597,11 @@ void SPolygon::UvGridTriangulateInto(SMesh *mesh, SSurface *srf) {
     srf->MakeTriangulationGridInto(&lj, 0, 1, /*swapped=*/false, 0);
 
     // force 2nd order grid to have at least 4 segments in each direction
-    if ((li.n < 5) && (srf->degm>1)) { // 4 segments minimun
+    if ((li.n < 5) && (srf->degm>1)) { // 4 segments minimum
         li.Clear();
         li.Add(&v[0]);li.Add(&v[1]);li.Add(&v[2]);li.Add(&v[3]);li.Add(&v[4]);
     }
-    if ((lj.n < 5) && (srf->degn>1)) { // 4 segments minimun
+    if ((lj.n < 5) && (srf->degn>1)) { // 4 segments minimum
         lj.Clear();
         lj.Add(&v[0]);lj.Add(&v[1]);lj.Add(&v[2]);lj.Add(&v[3]);lj.Add(&v[4]);
     }
@@ -681,7 +681,7 @@ void SPolygon::UvGridTriangulateInto(SMesh *mesh, SSurface *srf) {
                     if (!bottom[j]) // add our own bottom edge
                         holes.AddEdge(a, b);
                 } else {
-                    if (prev_flag) // add our left neighbots right edge
+                    if (prev_flag) // add our left neighbors right edge
                         holes.AddEdge(a, d);
                     if (bottom[j]) // add our bottom neighbors top edge
                         holes.AddEdge(b, a);

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -579,7 +579,7 @@ void TextWindow::ShowGroupSolveInfo() {
     }
 
     if(g->solved.timeout) {
-        Printf(true,  "%FxSome items in list have been ommitted%Fd");
+        Printf(true,  "%FxSome items in list have been omitted%Fd");
         Printf(false,  "%Fxbecause the operation timed out.%Fd");
     }
 

--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -348,8 +348,8 @@ void TextWindow::ClearScreen() {
     rows = 0;
 }
 
-// This message was addded when someone had too many fonts for the text window
-// Scrolling seemed to be broken, but was actaully at the MAX_ROWS.
+// This message was added when someone had too many fonts for the text window
+// Scrolling seemed to be broken, but was actually at the MAX_ROWS.
 static const char* endString = "    **** End of Text Screen ****";
 
 void TextWindow::Printf(bool halfLine, const char *fmt, ...) {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./res/locales,./extlib -L asign,ba,hsi,mata,tothe`