### PR TITLE
Don't reset showFaces every time a group is activated

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -407,6 +407,8 @@ void GraphicsWindow::Init() {
     showEdges = true;
     showMesh = false;
     showOutlines = false;
+    showFacesDrawing = false;
+    showFacesNonDrawing = true;
     drawOccludedAs = DrawOccludedAs::INVISIBLE;
 
     showTextWindow = true;
@@ -1364,6 +1366,14 @@ void GraphicsWindow::ToggleBool(bool *v) {
     Group *g = SK.GetGroup(SS.GW.activeGroup);
     if(*v && (g->displayOutlines.l.IsEmpty() && (v == &showEdges || v == &showOutlines))) {
         SS.GenerateAll(SolveSpaceUI::Generate::UNTIL_ACTIVE);
+    }
+
+    if(v == &showFaces) {
+        if(g->type == Group::Type::DRAWING_WORKPLANE || g->type == Group::Type::DRAWING_3D) {
+            showFacesDrawing = showFaces;
+        } else {
+            showFacesNonDrawing = showFaces;
+        }
     }
 
     Invalidate(/*clearPersistent=*/true);

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -416,11 +416,10 @@ std::string Group::DescriptionString() {
 }
 
 void Group::Activate() {
-    if(type == Type::EXTRUDE || type == Type::LINKED || type == Type::LATHE ||
-       type == Type::REVOLVE || type == Type::HELIX || type == Type::TRANSLATE || type == Type::ROTATE) {
-        SS.GW.showFaces = true;
+    if(type == Type::DRAWING_WORKPLANE || type == Type::DRAWING_3D) {
+        SS.GW.showFaces = SS.GW.showFacesDrawing;
     } else {
-        SS.GW.showFaces = false;
+        SS.GW.showFaces = SS.GW.showFacesNonDrawing;
     }
     SS.MarkGroupDirty(h); // for good measure; shouldn't be needed
     SS.ScheduleShowTW();

--- a/src/ui.h
+++ b/src/ui.h
@@ -798,6 +798,8 @@ public:
     bool    showEdges;
     bool    showOutlines;
     bool    showFaces;
+    bool    showFacesDrawing;
+    bool    showFacesNonDrawing;
     bool    showMesh;
     void ToggleBool(bool *v);
 


### PR DESCRIPTION
I prefer not to have showFaces set and it really bugs me that it is reset to true every time a non-drawing group is activated.

Assuming that most people want the current behaviour (show faces for non-drawings, hide for drawings) I've added 2 booleans, `showFacesDrawing` and `showFacesNonDrawing`, and clicking the show faces button updates whichever of those is appropriate for the current group type, so that showFaces is preserved independently between drawing and non-drawing groups.

The current behaviour will be preserved if you never touch the show faces button (because of the `showFacesNonDrawing = true` in `Init()`), but if you eg untick it when a non-drawing group is active, showFaces will stay disabled whenever a non-drawing group is activated (and vice versa).
