### PR TITLE
Add option for displaying dimensions in feet and inches

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -64,7 +64,7 @@ void TextWindow::ScreenChangeCameraTangent(int link, uint32_t v) {
 }
 
 void TextWindow::ScreenChangeGridSpacing(int link, uint32_t v) {
-    SS.TW.ShowEditControl(3, SS.MmToString(SS.gridSpacing));
+    SS.TW.ShowEditControl(3, SS.MmToString(SS.gridSpacing, true));
     SS.TW.edit.meaning = Edit::GRID_SPACING;
 }
 
@@ -89,7 +89,7 @@ void TextWindow::ScreenChangeExportScale(int link, uint32_t v) {
 }
 
 void TextWindow::ScreenChangeExportOffset(int link, uint32_t v) {
-    SS.TW.ShowEditControl(3, SS.MmToString(SS.exportOffset));
+    SS.TW.ShowEditControl(3, SS.MmToString(SS.exportOffset, true));
     SS.TW.edit.meaning = Edit::EXPORT_OFFSET;
 }
 
@@ -171,7 +171,7 @@ void TextWindow::ScreenChangeCanvasSize(int link, uint32_t v) {
     }
     int col = 13;
     if(v < 10) col = 11;
-    SS.TW.ShowEditControl(col, SS.MmToString(d));
+    SS.TW.ShowEditControl(col, SS.MmToString(d, true));
     SS.TW.edit.meaning = Edit::CANVAS_SIZE;
     SS.TW.edit.i = v;
 }
@@ -181,7 +181,7 @@ void TextWindow::ScreenChangeGCodeParameter(int link, uint32_t v) {
     switch(link) {
         case 'd':
             SS.TW.edit.meaning = Edit::G_CODE_DEPTH;
-            buf += SS.MmToString(SS.gCode.depth);
+            buf += SS.MmToString(SS.gCode.depth, true);
             break;
 
         case 's':
@@ -191,12 +191,12 @@ void TextWindow::ScreenChangeGCodeParameter(int link, uint32_t v) {
 
         case 'F':
             SS.TW.edit.meaning = Edit::G_CODE_FEED;
-            buf += SS.MmToString(SS.gCode.feed);
+            buf += SS.MmToString(SS.gCode.feed, true);
             break;
 
         case 'P':
             SS.TW.edit.meaning = Edit::G_CODE_PLUNGE_FEED;
-            buf += SS.MmToString(SS.gCode.plungeFeed);
+            buf += SS.MmToString(SS.gCode.plungeFeed, true);
             break;
     }
     SS.TW.ShowEditControl(14, buf);

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -98,6 +98,7 @@ const MenuEntry Menu[] = {
 { 2, N_("Dimensions in &Millimeters"),  Command::UNITS_MM,         0,       KR, mView },
 { 2, N_("Dimensions in M&eters"),       Command::UNITS_METERS,     0,       KR, mView },
 { 2, N_("Dimensions in &Inches"),       Command::UNITS_INCHES,     0,       KR, mView },
+{ 2, N_("Dimensions in &Feet and Inches"), Command::UNITS_FEET_INCHES, 0,   KR, mView },
 { 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
 { 1, N_("Show &Toolbar"),               Command::SHOW_TOOLBAR,     0,       KC, mView  },
 { 1, N_("Show Property Bro&wser"),      Command::SHOW_TEXT_WND,    '\t',    KC, mView  },
@@ -329,6 +330,8 @@ void GraphicsWindow::PopulateMainMenu() {
                 unitsMetersMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::UNITS_INCHES) {
                 unitsInchesMenuItem = menuItem;
+            } else if(Menu[i].cmd == Command::UNITS_FEET_INCHES) {
+                unitsFeetInchesMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::SEL_WORKPLANE) {
                 inWorkplaneMenuItem = menuItem;
             } else if(Menu[i].cmd == Command::FREE_IN_3D) {
@@ -843,6 +846,12 @@ void GraphicsWindow::MenuView(Command id) {
             SS.GW.EnsureValidActives();
             break;
 
+        case Command::UNITS_FEET_INCHES:
+            SS.viewUnits = Unit::FEET_INCHES;
+            SS.ScheduleShowTW();
+            SS.GW.EnsureValidActives();
+            break;
+
         case Command::UNITS_MM:
             SS.viewUnits = Unit::MM;
             SS.ScheduleShowTW();
@@ -925,6 +934,7 @@ void GraphicsWindow::EnsureValidActives() {
         case Unit::MM:
         case Unit::METERS:
         case Unit::INCHES:
+        case Unit::FEET_INCHES:
             break;
         default:
             SS.viewUnits = Unit::MM;
@@ -933,6 +943,7 @@ void GraphicsWindow::EnsureValidActives() {
     unitsMmMenuItem->SetActive(SS.viewUnits == Unit::MM);
     unitsMetersMenuItem->SetActive(SS.viewUnits == Unit::METERS);
     unitsInchesMenuItem->SetActive(SS.viewUnits == Unit::INCHES);
+    unitsFeetInchesMenuItem->SetActive(SS.viewUnits == Unit::FEET_INCHES);
 
     if(SS.TW.window) SS.TW.window->SetVisible(SS.GW.showTextWindow);
     showTextWndMenuItem->SetActive(SS.GW.showTextWindow);

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1378,7 +1378,7 @@ void GraphicsWindow::EditConstraint(hConstraint constraint) {
             } else if(c->type == Constraint::Type::ANGLE) {
                 editValue = SS.DegreeToString(value);
             } else {
-                editValue = SS.MmToString(value);
+                editValue = SS.MmToString(value, true);
                 value /= SS.MmPerUnit();
             }
             // If that's not enough to represent it exactly, show the value with as many

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -352,7 +352,7 @@ std::string SolveSpaceUI::MmToString(double v, bool editable) {
         }
         std::ostringstream str;
         if(feet != 0) {
-            str << feet << "' ";
+            str << feet << "'-";
         }
         // For something like 0.5, show 1/2" rather than 0 1/2"
         if(!(feet == 0 && inches == 0 && numerator != 0)) {

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -138,7 +138,8 @@ enum class Command : uint32_t;
 enum class Unit : uint32_t {
     MM = 0,
     INCHES,
-    METERS
+    METERS,
+    FEET_INCHES
 };
 
 template<class Key, class T>
@@ -609,7 +610,7 @@ public:
     bool     useSIPrefixes;
     int      autosaveInterval; // in minutes
 
-    std::string MmToString(double v);
+    std::string MmToString(double v, bool editable=false);
     std::string MmToStringSI(double v, int dim = 0);
     std::string DegreeToString(double v);
     double ExprToMm(Expr *e);

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -563,7 +563,7 @@ void TextWindow::ScreenChangeStyleMetric(int link, uint32_t v) {
     if(units == Style::UnitsAs::PIXELS) {
         edit_value = ssprintf("%.2f", val);
     } else {
-        edit_value = SS.MmToString(val);
+        edit_value = SS.MmToString(val, true);
     }
     SS.TW.ShowEditControl(col, edit_value);
     SS.TW.edit.style = hs;

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -640,7 +640,7 @@ void TextWindow::ScreenStepDimFinish(int link, uint32_t v) {
     SS.TW.edit.meaning = Edit::STEP_DIM_FINISH;
     std::string edit_value;
     if(SS.TW.stepDim.isDistance) {
-        edit_value = SS.MmToString(SS.TW.stepDim.finish);
+        edit_value = SS.MmToString(SS.TW.stepDim.finish, true);
     } else {
         edit_value = ssprintf("%.3f", SS.TW.stepDim.finish);
     }
@@ -727,7 +727,7 @@ void TextWindow::ScreenChangeTangentArc(int link, uint32_t v) {
     switch(link) {
         case 'r': {
             SS.TW.edit.meaning = Edit::TANGENT_ARC_RADIUS;
-            SS.TW.ShowEditControl(3, SS.MmToString(SS.tangentArcRadius));
+            SS.TW.ShowEditControl(3, SS.MmToString(SS.tangentArcRadius, true));
             break;
         }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -89,6 +89,7 @@ enum class Command : uint32_t {
     SHOW_TOOLBAR,
     SHOW_TEXT_WND,
     UNITS_INCHES,
+    UNITS_FEET_INCHES,
     UNITS_MM,
     UNITS_METERS,
     FULL_SCREEN,
@@ -546,6 +547,7 @@ public:
     Platform::MenuItemRef unitsMmMenuItem;
     Platform::MenuItemRef unitsMetersMenuItem;
     Platform::MenuItemRef unitsInchesMenuItem;
+    Platform::MenuItemRef unitsFeetInchesMenuItem;
 
     Platform::MenuItemRef inWorkplaneMenuItem;
     Platform::MenuItemRef in3dMenuItem;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -51,9 +51,9 @@ void TextWindow::ScreenChangeViewToFullScale(int link, uint32_t v) {
 void TextWindow::ScreenChangeViewOrigin(int link, uint32_t v) {
     std::string edit_value =
         ssprintf("%s, %s, %s",
-            SS.MmToString(-SS.GW.offset.x).c_str(),
-            SS.MmToString(-SS.GW.offset.y).c_str(),
-            SS.MmToString(-SS.GW.offset.z).c_str());
+            SS.MmToString(-SS.GW.offset.x, true).c_str(),
+            SS.MmToString(-SS.GW.offset.y, true).c_str(),
+            SS.MmToString(-SS.GW.offset.z, true).c_str());
 
     SS.TW.edit.meaning = Edit::VIEW_ORIGIN;
     SS.TW.ShowEditControl(3, edit_value);


### PR DESCRIPTION
So that eg 30 inches is shown as `2' 6"`.

The rationale for this additional display mode is that I found myself transcribing a blueprint in feet and inches and while entering eg `2*12+6` for "2 feet 6 inches" was easy enough, not being able to see the dimensions in the constraints in the same format as the original made it difficult to go back and verify that everything had been entered correctly.

When editing, the text field still shows the value in inches, eg `30.00` in this example. In other words `Unit::FEET_INCHES` behaves mostly the same as `Unit::INCHES`. I did debate having the editable value match the display value, but that would require modifying `LexNumber()` and `StringToMm()` to understand the `xx' yy"` syntax and it felt like that might be a bit too invasive a change for something that maybe only I would ever use. Especially given that specifying specific units while editing is not something that's allowed for anything else.

That being said, if there's a demand for the ability to do that I don't mind looking at adding an awareness of units to the expression parser. For eg I have occasionally found myself needing to enter a value in inches into a predominantly mm-based model and having to remember to switch dimension units before setting the constraint, and then switching back again (compared to simply writing "0.3in" and having that translated for me into mm) is a little tedious. But maybe that should be a separate PR?