### PR TITLE
Fix/silence mac build warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ if(WIN32)
         ${SPACEWARE_LIBRARIES})
 elseif(APPLE)
     add_compile_options(
+        -DGL_SILENCE_DEPRECATION
         -fobjc-arc)
 
     list(APPEND platform_SOURCES

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -1006,7 +1006,6 @@ void Constraint::DoLayout(DrawAs how, Canvas *canvas,
             Vector center = SK.GetEntity(circle->point[0])->PointGetNum();
             Quaternion q = SK.GetEntity(circle->normal)->NormalGetNum();
             Vector n = q.RotationN().WithMagnitude(1);
-            double r = circle->CircleGetRadiusNum();
 
             Vector ref2;
             DoEqualRadiusTicks(canvas, hcs, entityA, &ref2);

--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -286,7 +286,8 @@ public:
     }
 
     void PopUp() override {
-        [NSMenu popUpContextMenu:nsMenu withEvent:[NSApp currentEvent] forView:nil];
+        NSEvent* event = [NSApp currentEvent];
+        [NSMenu popUpContextMenu:nsMenu withEvent:event forView:event.window.contentView];
     }
 
     void Clear() override {


### PR DESCRIPTION
As per Xcode 12.4 you can at least do a warning-free incremental build
with these changes. There are still plenty of warnings in a full build
(mostly from thirdparty components) but with these changes you can at
least develop on mac and see if/when you've added any new warnings when
doing incremental builds.

This PR ended up mostly being to add `-DGL_SILENCE_DEPRECATION`. The fact that OpenGL is deprecated in the first place on macOS is concerning, but other projects seem to be OK with [ignoring that](https://www.sublimetext.com/blog/articles/hardware-accelerated-rendering)...
