### PR TITLE
Set OSX minimum supported version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
+if (APPLE)
+    # Docs say this must be set before the first project() call
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "macOS minimum supported version")
+endif()
+
 # project
 
 # NOTE TO PACKAGERS: The embedded git commit hash is critical for rapid bug triage when the builds


### PR DESCRIPTION
As per [cmake docs](https://cmake.org/cmake/help/v3.21/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html#variable:CMAKE_OSX_DEPLOYMENT_TARGET) this is how you configure `-mmacosx-version-min` in cmake land.

To my surprise this is all that was needed to get a binary compiled on 11.5.1 to launch on 10.12.6, which is as far back as I can test. 10.12.6 is supported on macs at least as far back as mid 2012.

Fixes #1086.

It did cause some build warnings from libomp:

    ld: warning: dylib (/usr/local/lib/libomp.dylib) was built for newer macOS version (11.0) than being linked (10.12)

But again to my surprise this didn't seem to actually cause any problems (although different/future libomp versions may behave differently). In my very limited testing this change doesn't appear to have any noticeable impact when running on recent macOS versions.

cc @ruevs