### PR TITLE
Show suppressed groups in gray in the text window

### DIFF
--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -129,7 +129,7 @@ void TextWindow::ShowListOfGroups() {
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
                "%Fp%D%f%s%Ll%s%E "
-               "%Fl%Ll%D%f%s",
+               "%Fp%Ll%D%f%s",
                // Alternate between light and dark backgrounds, for readability
                backgroundParity ? 'd' : 'a',
                // Link that activates the group
@@ -146,6 +146,7 @@ void TextWindow::ShowListOfGroups() {
                ok ? ((warn && SS.checkClosedContour) ? "err" : sdof) : "",
                ok ? "" : "ERR",
                // Link to a screen that gives more details on the group
+               g->suppress ? 'g' : 'l',
                g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str());
 
         if(active) afterActive = true;

--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -203,7 +203,7 @@ const TextWindow::Color TextWindow::fgColors[] = {
     { 'r', RGBi(  0,   0,   0) },  // Reverse   : black
     { 'x', RGBi(255,  20,  20) },  // Error     : red
     { 'i', RGBi(  0, 255, 255) },  // Info      : cyan
-    { 'g', RGBi(160, 160, 160) },
+    { 'g', RGBi(128, 128, 128) },  // Disabled  : gray
     { 'b', RGBi(200, 200, 200) },
     { 0,   RGBi(  0,   0,   0) }
 };


### PR DESCRIPTION
Throwing this one out there to see what people think.

I often lose track of which bits of a model I've temporarily hidden via the "suppress this group's solid model" tickbox. I could really do with a way to see what's suppressed and what's not in the main text window. So I made a simple patch to show suppressed groups in gray rather than the usual link blue:

![image](https://user-images.githubusercontent.com/2305420/130274696-8db070b0-479f-4812-9625-f050f72ab4ca.png)
