### PR TITLE
Add a "∆" suffix to groups which have "force to triangle mesh" ticked.

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -404,7 +404,11 @@ bool Group::IsForcedToMeshBySource() const {
 }
 
 bool Group::IsForcedToMesh() const {
-    return forceToMesh || IsForcedToMeshBySource();
+    return forceToMesh || IsTriangleMeshAssembly() || IsForcedToMeshBySource();
+}
+
+bool Group::IsTriangleMeshAssembly() const {
+    return type == Type::LINKED && linkFile.Extension() == "stl";
 }
 
 std::string Group::DescriptionString() {

--- a/src/importmesh.cpp
+++ b/src/importmesh.cpp
@@ -171,7 +171,6 @@ bool LinkStl(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *s
         addUnique(verts, tr.b, normal);
         addUnique(verts, tr.c, normal);
     }
-    SK.GetGroup(SS.GW.activeGroup)->forceToMesh = true;
     dbp("%d verticies", verts.size());
 
     BBox box = {};

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -269,6 +269,7 @@ public:
     void Generate(EntityList *entity, ParamList *param);
     bool IsSolvedOkay();
     void TransformImportedBy(Vector t, Quaternion q);
+    bool IsTriangleMeshAssembly() const;
     bool IsForcedToMeshBySource() const;
     bool IsForcedToMesh() const;
     // When a request generates entities from entities, and the source

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -123,13 +123,18 @@ void TextWindow::ShowListOfGroups() {
               sprintf(sdof, "%-3d", dof);
             }
         }
+        std::string suffix;
+        if(g->forceToMesh) {
+            suffix = " (∆)";
+        }
+
         bool ref = (g->h == Group::HGROUP_REFERENCES);
         Printf(false,
                "%Bp%Fd "
                "%Ft%s%Fb%D%f%Ll%s%E "
                "%Fb%s%D%f%Ll%s%E  "
                "%Fp%D%f%s%Ll%s%E "
-               "%Fp%Ll%D%f%s",
+               "%Fp%Ll%D%f%s%E%s",
                // Alternate between light and dark backgrounds, for readability
                backgroundParity ? 'd' : 'a',
                // Link that activates the group
@@ -147,7 +152,8 @@ void TextWindow::ShowListOfGroups() {
                ok ? "" : "ERR",
                // Link to a screen that gives more details on the group
                g->suppress ? 'g' : 'l',
-               g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str());
+               g->h.v, (&TextWindow::ScreenSelectGroup), s.c_str(),
+               suffix.c_str());
 
         if(active) afterActive = true;
         backgroundParity = !backgroundParity;

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -124,7 +124,7 @@ void TextWindow::ShowListOfGroups() {
             }
         }
         std::string suffix;
-        if(g->forceToMesh) {
+        if(g->forceToMesh || g->IsTriangleMeshAssembly()) {
             suffix = " (∆)";
         }
 
@@ -495,7 +495,7 @@ void TextWindow::ShowGroupInfo() {
         &TextWindow::ScreenChangeGroupOption,
         g->visible ? CHECK_TRUE : CHECK_FALSE);
 
-    if(!g->IsForcedToMeshBySource()) {
+    if(!g->IsForcedToMeshBySource() && !g->IsTriangleMeshAssembly()) {
         Printf(false, " %f%Lf%Fd%s  force NURBS surfaces to triangle mesh",
             &TextWindow::ScreenChangeGroupOption,
             g->forceToMesh ? CHECK_TRUE : CHECK_FALSE);


### PR DESCRIPTION
Following on from comments by @Symbian9 https://github.com/solvespace/solvespace/pull/1095#issuecomment-903062126 I thought I'd try adding a `∆` indicator on groups that have 'force to triangle mesh' ticked, since that's also something that sometimes you need to scan down the entire group list to find (in my case, usually when trying different things to fix a NURBS issue).

I didn't go the whole way to adding identifiers for different group types, as @ruevs mentioned there's a point where you're making things less clear rather than more, if your group names are all prefixed with a string of punctuation. I did like the idea of using a `∆` character to indicate `forceToMesh` is set though, and I added it as a suffix in parentheses outside of the link colouration instead, to make it clearer it's an annotation rather than actually being part of the group name.

I think going for the modest change of just showing `forceToMesh` is a better plan, rather than attempting something more sweeping that not everyone will agree on, although I don't particularly mind if you don't want to take this one into master. It may well be something that not many other people really need to see. I just thought I should see how it looks given the interesting suggestions @Symbian9 proposed, and I think it actually looks pretty useful :-)

![image](https://user-images.githubusercontent.com/2305420/130356193-f81a7d16-759a-466f-9dd6-3165c14bcf90.png)

In case anyone is wondering, the triangle character is U+2206 INCREMENT from the "mathematical operators" category, and not a repurposed greek capital delta. It looked better than some of the most obscure triangle options. I've checked it will render right on macOS and Windows, haven't checked linux because my ubuntu VM is busy updating itself (very slowly).