### PR TITLE
mac: Remove spurious view menu items

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -1621,6 +1621,14 @@ std::vector<std::string> InitGui(int argc, char **argv) {
     ssDelegate = [[SSApplicationDelegate alloc] init];
     NSApplication.sharedApplication.delegate = ssDelegate;
 
+    // Setting this prevents "Show Tab Bar" and "Show All Tabs" items from being
+    // automagically added to the View menu
+    NSWindow.allowsAutomaticWindowTabbing = NO;
+
+    // And this prevents the duplicate "Enter Full Screen" menu item, see
+    // https://stackoverflow.com/questions/52154977/how-to-get-rid-of-enter-full-screen-menu-item
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"NSFullScreenMenuItemEverywhere"];
+
     [NSBundle.mainBundle loadNibNamed:@"MainMenu" owner:nil topLevelObjects:nil];
 
     NSArray *languages = NSLocale.preferredLanguages;


### PR DESCRIPTION
Which are either not applicable for SolveSpace (the tabs ones) or are
already handled in the platform-independent code (the fullscreen item).

@vespakoen would you mind looking over this? I assume support for tabbed windows is unlikely to be needed any time soon :-)

(given `SS` and `SK` are globals thus preventing you ever having multiple sketches loaded in a single process, I actually started thinking about how to support opening multiple windows in the same process, and quickly gave up...)