### PR TITLE
snap: Fetch tags for snap builds in CI & mention stable channel in README

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -118,6 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch Tags
+      run: git fetch --force --tags
     - name: Set Up Source
       run: rsync --filter=":- .gitignore" -r ./ pkg/snap/solvespace-snap-src
     - name: Build Snap
@@ -149,6 +151,8 @@ jobs:
       with:
         image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
     - uses: actions/checkout@v2
+    - name: Fetch Tags
+      run: git fetch --force --tags
     - name: Set Up Source
       run: rsync --filter=":- .gitignore" -r ./ pkg/snap/solvespace-snap-src
     - name: Build Snap

--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ the SolveSpace maintainers for each stable release.
 
 ### Via Snap Store
 
-Builds from master are automatically released to the `edge` channel in the Snap Store. Those packages contain the latest improvements, but receive less testing than release builds.
+Official releases can be installed from the `stable` channel.
 
-Future official releases will appear in the `stable` channel.
+Builds from master are automatically released to the `edge` channel in the Snap Store. Those packages contain the latest improvements, but receive less testing than release builds.
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/solvespace)
 
 Or install from a terminal:
 
 ```
-snap install --edge solvespace
+# for the latest stable release:
+snap install solvespace 
+# for the bleeding edge builds from master:
+snap install solvespace --edge
 ```
 
 ### Via third-party binary packages


### PR DESCRIPTION
The snaps use git describe to determine
their grade (stable/devel). Fetch the tags to
make this possible.

Point users to the official release in the stable channel in README.md.