### PR TITLE
mac: Don't interpret single-touch scroll events as pan gestures

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -372,6 +372,7 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
     double             rotationGestureCurrent;
     Point2d            trackpadPositionShift;
     bool               inTrackpadScrollGesture;
+    int                numTouches;
     Platform::Window::Kind kind;
 }
 
@@ -397,6 +398,8 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
         editor.action = @selector(didEdit:);
 
         inTrackpadScrollGesture = false;
+        numTouches = 0;
+        self.acceptsTouchEvents = YES;
         kind = aKind;
         if(kind == Platform::Window::Kind::TOPLEVEL) {
             NSGestureRecognizer *mag = [[NSMagnificationGestureRecognizer alloc] initWithTarget:self
@@ -573,7 +576,9 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
     using Platform::MouseEvent;
 
     MouseEvent event = [self convertMouseEvent:nsEvent];
-    if(nsEvent.subtype == NSEventSubtypeTabletPoint && kind == Platform::Window::Kind::TOPLEVEL) {
+    // Check for number of touches to exclude single-finger scrolling on Magic Mouse
+    bool isTrackpadEvent = numTouches >= 2 && nsEvent.subtype == NSEventSubtypeTabletPoint;
+    if(isTrackpadEvent && kind == Platform::Window::Kind::TOPLEVEL) {
         // This is how Cocoa represents 2 finger trackpad drag gestures, rather than going via
         // NSPanGestureRecognizer which is how you might expect this to work... We complicate this
         // further by also handling shift-two-finger-drag to mean rotate. Fortunately we're using
@@ -624,6 +629,23 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
     event.scrollDelta = [nsEvent scrollingDeltaY] / (isPrecise ? 50 : 5);
 
     receiver->onMouseEvent(event);
+}
+
+- (void)touchesBeganWithEvent:(NSEvent *)event {
+    numTouches = [event touchesMatchingPhase:NSTouchPhaseTouching inView:self].count;
+    [super touchesBeganWithEvent:event];
+}
+- (void)touchesMovedWithEvent:(NSEvent *)event {
+    numTouches = [event touchesMatchingPhase:NSTouchPhaseTouching inView:self].count;
+    [super touchesMovedWithEvent:event];
+}
+- (void)touchesEndedWithEvent:(NSEvent *)event {
+    numTouches = [event touchesMatchingPhase:NSTouchPhaseTouching inView:self].count;
+    [super touchesEndedWithEvent:event];
+}
+- (void)touchesCancelledWithEvent:(NSEvent *)event {
+    numTouches = 0;
+    [super touchesCancelledWithEvent:event];
 }
 
 - (void)mouseExited:(NSEvent *)nsEvent {


### PR DESCRIPTION
To handle the Magic Mouse, whose single-finger touch gestures should be interpreted as scrollwheel events rather than pan gestures.

fixes #1106

@vespakoen does this look ok to you? Having to track the current number of active touches as an independent bit of state is slightly messy, but it does seem to do the trick without breaking actual trackpad support. Providing someone doesn't try zooming with a Magic Mouse single-finger gesture at the same time as panning with two fingers on a trackpad, I suppose...