### PR TITLE
Implement basic mirror groups.

### DIFF
--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -171,6 +171,8 @@ void TextWindow::DescribeSelection() {
             case Entity::Type::FACE_N_ROT_TRANS:
             case Entity::Type::FACE_N_ROT_AA:
             case Entity::Type::FACE_N_TRANS:
+            case Entity::Type::FACE_N_MIRROR:
+            case Entity::Type::FACE_N_COPY:
                 Printf(false, "%FtPLANE FACE%E");
                 p = e->FaceGetNormalNum();
                 Printf(true,  "   normal = " PT_AS_NUM, CO(p));

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -86,6 +86,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::POINT_N_ROT_TRANS:
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
+        case Type::POINT_N_MIRROR:
         case Type::POINT_IN_3D:
         case Type::POINT_IN_2D:
             refs->push_back(PointGetDrawNum());
@@ -96,6 +97,7 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::NORMAL_N_ROT_AA:
         case Type::NORMAL_IN_3D:
         case Type::NORMAL_IN_2D:
+        case Type::NORMAL_N_MIRROR:
         case Type::WORKPLANE:
         case Type::CIRCLE:
         case Type::ARC_OF_CIRCLE:
@@ -122,6 +124,8 @@ void Entity::GetReferencePoints(std::vector<Vector> *refs) {
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
         case Type::FACE_N_ROT_AXIS_TRANS:
+        case Type::FACE_N_MIRROR:
+        case Type::FACE_N_COPY:
             break;
     }
 }
@@ -549,7 +553,8 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::POINT_N_ROT_AA:
         case Type::POINT_N_ROT_AXIS_TRANS:
         case Type::POINT_IN_3D:
-        case Type::POINT_IN_2D: {
+        case Type::POINT_IN_2D:
+        case Type::POINT_N_MIRROR: {
             if(how == DrawAs::HIDDEN) return;
 
             // If we're analyzing the sketch to show the degrees of freedom,
@@ -594,6 +599,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::NORMAL_N_COPY:
         case Type::NORMAL_N_ROT:
         case Type::NORMAL_N_ROT_AA:
+        case Type::NORMAL_N_MIRROR:
         case Type::NORMAL_IN_3D:
         case Type::NORMAL_IN_2D: {
             const Camera &camera = canvas->GetCamera();
@@ -831,6 +837,8 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
         case Type::FACE_N_ROT_AA:
         case Type::FACE_ROT_NORMAL_PT:
         case Type::FACE_N_ROT_AXIS_TRANS:
+        case Type::FACE_N_MIRROR:
+        case Type::FACE_N_COPY:
             // Do nothing; these are drawn with the triangle mesh
             return;
     }

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -117,6 +117,7 @@ const MenuEntry Menu[] = {
 { 1, N_("&Helix"),                      Command::GROUP_HELIX,      S|'h',   KN, mGrp   },
 { 1, N_("&Lathe"),                      Command::GROUP_LATHE,      S|'l',   KN, mGrp   },
 { 1, N_("Re&volve"),                    Command::GROUP_REVOLVE,    S|'v',   KN, mGrp   },
+{ 1, N_("&Mirror"),                     Command::GROUP_MIRROR ,    S|'m',   KN, mGrp   },
 { 1, NULL,                              Command::NONE,             0,       KN, NULL   },
 { 1, N_("Link / Assemble..."),          Command::GROUP_LINK,       S|'i',   KN, mGrp   },
 { 1, N_("Link Recent"),                 Command::GROUP_RECENT,     0,       KN, mGrp   },

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -175,6 +175,23 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
             g.name = C_("group-name", "extrude");
             break;
 
+        case Command::GROUP_MIRROR:
+            g.predef.entityB = SS.GW.ActiveWorkplane();
+/*
+            // If entities are selected we will constrain the mirror plane to them later
+            if(gs.points == 1 && gs.vectors == 1 && gs.n == 2) {
+                g.predef.origin = gs.point[0];
+                g.predef.entityB = gs.vector[0];
+            } else if(gs.lineSegments == 1 && gs.n == 1) {
+                g.predef.origin = SK.GetEntity(gs.entity[0])->point[0];
+                g.predef.entityB = gs.entity[0];
+            }
+*/
+            g.type = Type::MIRROR;
+            g.opA = SS.GW.activeGroup;
+            g.name = C_("group-name", "mirror");
+            break;
+
         case Command::GROUP_LATHE:
             if(!SS.GW.LockedInWorkplane()) {
                 Error(_("Lathe operation can only be applied to planar sketches."));
@@ -528,6 +545,38 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
             return;
         }
 
+        case Type::MIRROR: {
+            // inherit meshCombine from source group
+            Group *srcg = SK.GetGroup(opA);
+            meshCombine = srcg->meshCombine;
+
+            Vector norm = gp.WithMagnitude(1.0);
+            AddParam(param, h.param(0), norm.x);
+            AddParam(param, h.param(1), norm.y);
+            AddParam(param, h.param(2), norm.z);
+            AddParam(param, h.param(3), 25.0);
+
+            // Not using range-for here because we're changing the size of entity in the loop.
+            for(i = 0; i < entity->n; i++) {
+                Entity *e = &(entity->Get(i));
+                if(e->group != opA) continue;
+
+                e->CalculateNumerical(/*forExport=*/false);
+                hEntity he = e->h;
+                // As soon as I call CopyEntity, e may become invalid! That
+                // adds entities, which may cause a realloc.
+                CopyEntity(entity, SK.GetEntity(he), 0, 0,
+                    h.param(0), h.param(1), h.param(2),
+                    h.param(3), NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM,
+                    CopyAs::NUMERIC);
+                CopyEntity(entity, SK.GetEntity(he), 1, 1,
+                    h.param(0), h.param(1), h.param(2),
+                    h.param(3), NO_PARAM, NO_PARAM, NO_PARAM, NO_PARAM,
+                    CopyAs::N_MIRROR);
+            }
+            return;
+        }
+
         case Type::LATHE: {
             Vector axis_pos = SK.GetEntity(predef.origin)->PointGetNum();
             Vector axis_dir = SK.GetEntity(predef.entityB)->VectorGetNum();
@@ -837,7 +886,22 @@ void Group::GenerateEquations(IdList<Equation,hEquation> *l) {
             AddEq(l, u.Dot(extruden), 0);
             AddEq(l, v.Dot(extruden), 1);
         }
-    } else if(type == Type::TRANSLATE) {
+    } else if(type == Type::MIRROR) {
+        // Normalize the mirror normal
+        ExprVector n = {
+            Expr::From(h.param(0)),
+            Expr::From(h.param(1)),
+            Expr::From(h.param(2)) };
+        AddEq(l, (n.Magnitude())->Minus(Expr::From(1)), 0);
+
+        if (predef.entityB != Entity::FREE_IN_3D) {
+            // to reflect in plane, mirror normal must be perpendicular to the sketch normal
+            Entity *w = SK.GetEntity(predef.entityB);
+            ExprVector u = w->Normal()->NormalExprsU();
+            ExprVector v = w->Normal()->NormalExprsV();
+            AddEq(l, (n.Dot(u.Cross(v))), 1);
+        }
+     } else if(type == Type::TRANSLATE) {
         if(predef.entityB != Entity::FREE_IN_3D) {
             Entity *w = SK.GetEntity(predef.entityB);
             ExprVector n = w->Normal()->NormalExprsN();
@@ -1068,6 +1132,7 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::POINT_N_ROT_TRANS:
         case Entity::Type::POINT_N_ROT_AA:
         case Entity::Type::POINT_N_ROT_AXIS_TRANS:
+        case Entity::Type::POINT_N_MIRROR:
         case Entity::Type::POINT_IN_3D:
         case Entity::Type::POINT_IN_2D:
             if(as == CopyAs::N_TRANS) {
@@ -1077,6 +1142,12 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
                 en.param[2] = dz;
             } else if(as == CopyAs::NUMERIC) {
                 en.type = Entity::Type::POINT_N_COPY;
+            } else if(as == CopyAs::N_MIRROR) {
+                en.type = Entity::Type::POINT_N_MIRROR;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
             } else {
                 if(as == CopyAs::N_ROT_AA) {
                     en.type = Entity::Type::POINT_N_ROT_AA;
@@ -1102,10 +1173,17 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::NORMAL_N_COPY:
         case Entity::Type::NORMAL_N_ROT:
         case Entity::Type::NORMAL_N_ROT_AA:
+        case Entity::Type::NORMAL_N_MIRROR:
         case Entity::Type::NORMAL_IN_3D:
         case Entity::Type::NORMAL_IN_2D:
             if(as == CopyAs::N_TRANS || as == CopyAs::NUMERIC) {
                 en.type = Entity::Type::NORMAL_N_COPY;
+            } else if (as == CopyAs::N_MIRROR) {
+                en.type = Entity::Type::NORMAL_N_MIRROR;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
             } else {  // N_ROT_AXIS_TRANS probably doesn't warrant a new entity Type
                 if(as == CopyAs::N_ROT_AA || as == CopyAs::N_ROT_AXIS_TRANS) {
                     en.type = Entity::Type::NORMAL_N_ROT_AA;
@@ -1135,6 +1213,8 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
         case Entity::Type::FACE_N_TRANS:
         case Entity::Type::FACE_N_ROT_AA:
         case Entity::Type::FACE_ROT_NORMAL_PT:
+        case Entity::Type::FACE_N_MIRROR:
+        case Entity::Type::FACE_N_COPY:
         case Entity::Type::FACE_N_ROT_AXIS_TRANS:
             if(as == CopyAs::N_TRANS) {
                 en.type = Entity::Type::FACE_N_TRANS;
@@ -1142,7 +1222,13 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
                 en.param[1] = dy;
                 en.param[2] = dz;
             } else if (as == CopyAs::NUMERIC) {
-                en.type = Entity::Type::FACE_NORMAL_PT;
+                en.type = Entity::Type::FACE_N_COPY;
+            } else if (as == CopyAs::N_MIRROR) {
+                en.type = Entity::Type::FACE_N_MIRROR;
+                en.param[0] = dx;
+                en.param[1] = dy;
+                en.param[2] = dz;
+                en.param[3] = qw;
             } else if (as == CopyAs::N_ROT_AXIS_TRANS) {
                 en.type = Entity::Type::FACE_N_ROT_AXIS_TRANS;
                 en.param[0] = dx;

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -177,6 +177,33 @@ void Group::GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat
 }
 
 template<class T>
+void Group::GenerateForMirror(T *source, T *outs, Group::CombineAs forWhat) {
+    T original, transd, combined;
+    original = {};
+    transd = {};
+    combined = {};
+    original.MakeFromCopyOf(source);
+    original.RemapFaces(this, 0);
+    Vector axis = Vector::From(h.param(0), h.param(1), h.param(2));
+    transd.MakeFromTransformationOf(source,
+        axis.ScaledBy(SK.GetParam(h.param(3))->val * 2),
+        Quaternion::From(axis, PI),-1.0);
+    // We need to rewrite any plane face entities to the transformed ones.
+    transd.RemapFaces(this, 1);
+
+    // Combine the transformed and original.
+    if (forWhat == CombineAs::ASSEMBLE) {
+        combined.MakeFromAssemblyOf(&original, &transd);
+    } else {
+        combined.MakeFromUnionOf(&original, &transd);
+    }
+
+    original.Clear();
+    transd.Clear();
+    *outs = combined;
+}
+
+template<class T>
 void Group::GenerateForBoolean(T *prevs, T *thiss, T *outs, Group::CombineAs how) {
     // If this group contributes no new mesh, then our running mesh is the
     // same as last time, no combining required. Likewise if we have a mesh
@@ -221,7 +248,8 @@ void Group::GenerateShellAndMesh() {
     // Don't attempt a lathe or extrusion unless the source section is good:
     // planar and not self-intersecting.
     bool haveSrc = true;
-    if(type == Type::EXTRUDE || type == Type::LATHE || type == Type::REVOLVE) {
+    if(type == Type::EXTRUDE || type == Type::LATHE || type == Type::REVOLVE
+        || type == Type::MIRROR) {
         Group *src = SK.GetGroup(opA);
         if(src->polyError.how != PolyError::GOOD) {
             haveSrc = false;
@@ -387,6 +415,37 @@ void Group::GenerateShellAndMesh() {
 
         thisShell.MakeFromTransformationOf(&impShell, offset, q, scale);
         thisShell.RemapFaces(this, 0);
+    } else if(type == Type::MIRROR && haveSrc) {
+        // A mirror gets merged against the group's previous group,
+        // not our own previous group.
+        srcg = SK.GetGroup(opA);
+
+        if(!srcg->suppress) {
+            if(!IsForcedToMesh()) {
+                GenerateForMirror<SShell>(&(srcg->thisShell), &thisShell, srcg->meshCombine);
+            } else {
+                SMesh prevm = {};
+                prevm.MakeFromCopyOf(&srcg->thisMesh);
+                srcg->thisShell.TriangulateInto(&prevm);
+                GenerateForMirror<SMesh>(&prevm, &thisMesh, srcg->meshCombine);
+            }
+        }
+/*
+        Vector offset = {
+            SK.GetParam(h.param(0))->val,
+            SK.GetParam(h.param(1))->val,
+            SK.GetParam(h.param(2))->val };
+        Quaternion q = { 0.0,
+            SK.GetParam(h.param(0))->val,
+            SK.GetParam(h.param(1))->val,
+            SK.GetParam(h.param(2))->val };
+        thisMesh.MakeFromTransformationOf(&impMesh, offset.ScaledBy(
+            SK.GetParam(h.param(3))->val * 2), q, -1.0);
+        thisMesh.RemapFaces(this, 0);
+        thisShell.MakeFromTransformationOf(&impShell, offset.ScaledBy(
+            SK.GetParam(h.param(3))->val * 2), q, -1.0);
+        thisShell.RemapFaces(this, 0);
+*/
     }
 
     if(srcg->meshCombine != CombineAs::ASSEMBLE) {

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -152,6 +152,7 @@ public:
         N_ROT_AA,
         N_ROT_TRANS,
         N_ROT_AXIS_TRANS,
+        N_MIRROR,
     };
 
     enum class Type : uint32_t {
@@ -163,6 +164,7 @@ public:
         HELIX                         = 5103,
         ROTATE                        = 5200,
         TRANSLATE                     = 5201,
+        MIRROR                        = 5202,
         LINKED                        = 5300
     };
     Group::Type type;
@@ -319,6 +321,7 @@ public:
     void GenerateShellAndMesh();
     template<class T> void GenerateForStepAndRepeat(T *steps, T *outs, Group::CombineAs forWhat);
     template<class T> void GenerateForBoolean(T *a, T *b, T *o, Group::CombineAs how);
+    template<class T> void GenerateForMirror(T *steps, T *outs, Group::CombineAs forWhat);
     void GenerateDisplayItems();
 
     enum class DrawMeshAs { DEFAULT, HOVERED, SELECTED };
@@ -401,12 +404,14 @@ public:
         POINT_N_COPY           =  2012,
         POINT_N_ROT_AA         =  2013,
         POINT_N_ROT_AXIS_TRANS =  2014,
+        POINT_N_MIRROR         =  2015,
 
         NORMAL_IN_3D           =  3000,
         NORMAL_IN_2D           =  3001,
         NORMAL_N_COPY          =  3010,
         NORMAL_N_ROT           =  3011,
         NORMAL_N_ROT_AA        =  3012,
+        NORMAL_N_MIRROR        =  3013,
 
         DISTANCE               =  4000,
         DISTANCE_N_COPY        =  4001,
@@ -418,6 +423,8 @@ public:
         FACE_N_ROT_AA          =  5004,
         FACE_ROT_NORMAL_PT     =  5005,
         FACE_N_ROT_AXIS_TRANS  =  5006,
+        FACE_N_MIRROR          =  5007,
+        FACE_N_COPY            =  5008,
 
         WORKPLANE              = 10000,
         LINE_SEGMENT           = 11000,

--- a/src/ui.h
+++ b/src/ui.h
@@ -133,6 +133,7 @@ enum class Command : uint32_t {
     GROUP_EXTRUDE,
     GROUP_HELIX,
     GROUP_LATHE,
+    GROUP_MIRROR,
     GROUP_REVOLVE,
     GROUP_ROT,
     GROUP_TRANS,


### PR DESCRIPTION
This seems to work for both 2d and 3d groups. I'd still like to get more options added for creating the mirror based on selection. It probably also wants an option to not use the parent group as part of the mirrored group.