### PR TITLE
modify the spaceware code to also work on wayland

### DIFF
--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -33,6 +33,7 @@
 
 #if defined(HAVE_SPACEWARE)
 #   include <spnav.h>
+#   include <gdk/gdk.h>
 #   if defined(GDK_WINDOWING_X11)
 #       include <gdk/gdkx.h>
 #   endif


### PR DESCRIPTION
use the spacenav socket only on wayland, as the "official 3dconnexion" linux sdk is no longer maintained it is unlikely to ever be useable under wayland anyway. 

use the recommended compile-time and run-time checks for x11 and wayland based on
https://github.com/GNOME/gtk/blob/b539c92312d449f41710e6930aaf086454d667d2/docs/reference/gdk/wayland.md

