### PR TITLE
GUI: Flexible vertical space above the toolbar

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -430,7 +430,7 @@ void GraphicsWindow::Init() {
             using namespace std::placeholders;
             // Do this first, so that if it causes an onRender event we don't try to paint without
             // a canvas.
-            window->SetMinContentSize(720, 670);
+            window->SetMinContentSize(720, /*ToolbarDrawOrHitTest 636*/ 32 * 18 + 3 * 16 + 8 + 4);
             window->onClose = std::bind(&SolveSpaceUI::MenuFile, Command::EXIT);
             window->onRender = std::bind(&GraphicsWindow::Paint, this);
             window->onKeyboardEvent = std::bind(&GraphicsWindow::KeyboardEvent, this, _1);

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -153,11 +153,18 @@ bool GraphicsWindow::ToolbarDrawOrHitTest(int mx, int my, UiCanvas *canvas,
     double width, height;
     window->GetContentSize(&width, &height);
 
-    int x = 17, y = (int)(height - 52);
+    int x = 17, y = (int)(height - 21); // 20 is the menu bar height
 
-    // When changing these values, also change the asReference drawing code in drawentity.cpp.
+    // When changing these values, also change the asReference drawing code in drawentity.cpp
+    // as well as the "window->SetMinContentSize(720, 636);" in graphicswin.cpp
     int fudge = 8;
-    int h = 32*18 + 3*16 + fudge;
+    int h = 32*18 + 3*16 + fudge;   // Toolbar height = 18 icons * 32 pixels + 3 dividers * 16 pixels + fudge
+
+    if(h < y) {
+        // If there is enough vertical space leave up to 32 pixels between the menu bar and the toolbar.
+        y -= ((y - h) < 32) ? y - h : 32;
+    }
+
     int aleft = 0, aright = 66, atop = y+16+fudge/2, abot = y+16-h;
 
     bool withinToolbar =


### PR DESCRIPTION
If the main window is not high enough allow the default 32 pixel padding
between the menu bar and the toolbar to shrink down to zero.

This allows the main window height to be a minimum of 688 pixels (on
Windows 10) so it is possible to capture 720P video tutorials.

Fixes #1130

![image](https://user-images.githubusercontent.com/15338069/140373798-479a51af-b458-4484-8283-2d57375805db.png)
