### PR TITLE
fix STL linking issue. Model was disappearing after the link group.

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -909,6 +909,8 @@ try_again:
                     return false;
                 }
             }
+            if(g.IsTriangleMeshAssembly())
+                g.forceToMesh = true;
         } else if(linkMap.count(g.linkFile) == 0) {
             dbp("Missing file for group: %s", g.name.c_str());
             // The file was moved; prompt the user for its new location.


### PR DESCRIPTION
This issue was mentioned on the forum. Linked STL groups don't have a NURBS shell, so they need to be forced to triangle mesh. The original STL code forced the previous group by mistake, and the fix for that didn't quite work. This seems to fix it.