### PR TITLE
No sparse expr

### DIFF
--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -246,7 +246,7 @@ public:
         int m, n;
         struct {
             // This only observes the Expr - does not own them!
-            Eigen::SparseMatrix<Expr *> sym;
+            std::vector<Eigen::Triplet<Expr *>> sym;
             Eigen::SparseMatrix<double> num;
         } A;
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -264,7 +264,7 @@ bool System::SolveLeastSquares() {
         }
     }
 
-    int size = mat.A.sym.outerSize();
+    const int size = mat.A.num.outerSize();
     for(int k = 0; k < size; k++) {
         for(SparseMatrix<double>::InnerIterator it(mat.A.num, k); it; ++it) {
             it.valueRef() *= mat.scale[it.col()];

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -84,11 +84,17 @@ void System::EvalJacobian() {
     mat.A.num.setZero();
     mat.A.num.resize(mat.m, mat.n);
 
-    std::vector<Eigen::Triplet<double>> values;
-    values.reserve(mat.A.sym.size());
-    for(const auto &exprTriplet : mat.A.sym) {
-        double value = exprTriplet.value()->Eval();
-        values.emplace_back(exprTriplet.row(), exprTriplet.col(), value);
+    std::vector<Eigen::Triplet<double>> values(mat.A.sym.size());
+    // Not using range-for to achieve (old) OpenMP compatibility:
+    // worth it because this profiles as taking a lot of time.
+    // Must be signed integer for MSVC.
+    const int n = (int)mat.A.sym.size();
+#pragma omp parallel for
+    for(int i = 0; i < n; ++i) {
+        const auto &exprTriplet = mat.A.sym[i];
+        double value            = exprTriplet.value()->Eval();
+        // assigning rather than emplace_back so we don't have to stick a critical pragma in here for openmp.
+        values[i] = {exprTriplet.row(), exprTriplet.col(), value};
     }
     mat.A.num.setFromTriplets(values.begin(), values.end());
 }


### PR DESCRIPTION
in #1159 we used a sparse matrix to hold expr pointers, when all we do with them is evaluate them into a sparse matrix of doubles. This stores them as a vector of triplets instead of the matrix, which makes it easy to evaluate to a vector of triplets with double data, from which we can set the sparse matrix efficiently. This actually shaved about 0.1s off of the test suite execution time (in relwithdebinfo) vs just #1159 on its own, so I think we probably want this one if we want that one.