### PR TITLE
Shrink textwindow stacksize

### DIFF
--- a/src/dsc.h
+++ b/src/dsc.h
@@ -723,6 +723,7 @@ public:
             (int)(255 - ((bgra >> 24) & 0xff)));
     }
 };
+static_assert(sizeof(RgbaColor) == 4, "RgbaColor must be exactly 4 bytes");
 
 struct RgbaColorCompare {
     bool operator()(RgbaColor a, RgbaColor b) const {

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -261,8 +261,8 @@ void GraphicsWindow::MakeTangentArc() {
     // in our group and workplane) that generate entities that have an
     // endpoint at our vertex to be rounded.
     int i, c = 0;
-    Entity *ent[2];
-    Request *req[2];
+    std::array<Entity *, 2> ent;
+    std::array<Request *, 2> req;
     hRequest hreq[2];
     hEntity hent[2];
     bool pointf[2];
@@ -314,8 +314,8 @@ void GraphicsWindow::MakeTangentArc() {
     // And thereafter we mustn't touch the entity or req ptrs,
     // because the new requests/entities we add might force a
     // realloc.
-    memset(ent, 0, sizeof(ent));
-    memset(req, 0, sizeof(req));
+    ent.fill(nullptr);
+    req.fill(nullptr);
 
     Vector pinter;
     double r = 0.0, vv = 0.0;

--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -297,7 +297,6 @@ void TextWindow::ClearSuper() {
     MakeColorTable(fgColors, fgColorTable);
     MakeColorTable(bgColors, bgColorTable);
 
-    ClearScreen();
     Show();
 }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -210,18 +210,42 @@ public:
     int scrollPos;      // The scrollbar position, in half-row units
     int halfRows;       // The height of our window, in half-row units
 
-    uint32_t text[MAX_ROWS][MAX_COLS];
-    typedef void LinkFunction(int link, uint32_t v);
+    static inline constexpr uint32_t computeIndex(uint32_t row, uint32_t col) {
+        return row * MAX_COLS + col;
+    }
+    template<typename T>
+    class GridData {
+    public:
+        GridData() : data_(new T[MAX_COLS * MAX_ROWS]) {
+        }
+        void reset() {
+            data_.reset(new T[MAX_COLS * MAX_ROWS]);
+        }
+        const T &operator()(uint32_t row, uint32_t col) const {
+            return data_[computeIndex(row, col)];
+        }
+        T &operator()(uint32_t row, uint32_t col) {
+            return data_[computeIndex(row, col)];
+        }
+
+    private:
+        std::unique_ptr<T[]> data_;
+    };
+
+    GridData<uint32_t> text;
     enum { NOT_A_LINK = 0 };
-    struct {
-        char            fg;
-        char            bg;
-        RgbaColor       bgRgb;
-        int             link;
-        uint32_t        data;
-        LinkFunction   *f;
-        LinkFunction   *h;
-    }       meta[MAX_ROWS][MAX_COLS];
+    typedef void LinkFunction(int link, uint32_t v);
+    struct MetaField {
+        char fg         = 'd';
+        char bg         = 'd';
+        RgbaColor bgRgb = RGBi(0, 0, 0);
+        int link        = NOT_A_LINK;
+        uint32_t data   = 0;
+        LinkFunction *f = nullptr;
+        LinkFunction *h = nullptr;
+    };
+
+    GridData<MetaField> meta;
     int hoveredRow, hoveredCol;
 
     int top[MAX_ROWS]; // in half-line units, or -1 for unused


### PR DESCRIPTION
Moves the two variables that are "grid-sized" to the heap. This fixes most of our asan leak warnings, and let me simplify a bit of code there too.