### PR TITLE
Param id map

### DIFF
--- a/.github/scripts/install-macos.sh
+++ b/.github/scripts/install-macos.sh
@@ -13,4 +13,4 @@ else
     brew install libomp
 fi
 
-git submodule update --init extlib/cairo extlib/freetype extlib/libdxfrw extlib/libpng extlib/mimalloc extlib/pixman extlib/zlib
+git submodule update --init extlib/cairo extlib/freetype extlib/libdxfrw extlib/libpng extlib/mimalloc extlib/pixman extlib/zlib extlib/eigen

--- a/.github/scripts/install-ubuntu.sh
+++ b/.github/scripts/install-ubuntu.sh
@@ -5,6 +5,6 @@ sudo apt-get update -qq
 sudo apt-get install -q -y \
   zlib1g-dev libpng-dev libcairo2-dev libfreetype6-dev libjson-c-dev \
   libfontconfig1-dev libgtkmm-3.0-dev libpangomm-1.4-dev libgl-dev \
-  libgl-dev libglu-dev libspnav-dev 
+  libgl-dev libglu-dev libspnav-dev
 
-git submodule update --init extlib/libdxfrw extlib/mimalloc
+git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "extlib/mimalloc"]
 	path = extlib/mimalloc
 	url = https://github.com/microsoft/mimalloc
+[submodule "extlib/eigen"]
+	path = extlib/eigen
+	url = https://gitlab.com/libeigen/eigen.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake/")
 
-cmake_policy(SET CMP0048 OLD)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
@@ -39,10 +38,10 @@ include(GetGitCommitHash)
 # and instead uncomment the following, adding the complete git hash of the checkout you are using:
 # set(GIT_COMMIT_HASH 0000000000000000000000000000000000000000)
 
-set(solvespace_VERSION_MAJOR 3)
-set(solvespace_VERSION_MINOR 0)
 string(SUBSTRING "${GIT_COMMIT_HASH}" 0 8 solvespace_GIT_HASH)
-project(solvespace LANGUAGES C CXX ASM)
+project(solvespace
+    VERSION 3.0
+    LANGUAGES C CXX ASM)
 
 set(ENABLE_GUI        ON CACHE BOOL
     "Whether the graphical interface is enabled")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
             "    mkdir build && cd build && cmake ..")
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_SOURCE_DIR}/cmake/")
 
 cmake_policy(SET CMP0048 OLD)
@@ -56,7 +56,7 @@ set(ENABLE_SANITIZERS OFF CACHE BOOL
     "Whether to enable Clang's AddressSanitizer and UndefinedBehaviorSanitizer")
 set(ENABLE_OPENMP     OFF CACHE BOOL
     "Whether geometric operations will be parallelized using OpenMP")
-set(ENABLE_LTO     OFF CACHE BOOL
+set(ENABLE_LTO        OFF CACHE BOOL
     "Whether interprocedural (global) optimizations are enabled")
 
 set(OPENGL 3 CACHE STRING "OpenGL version to use (one of: 1 3)")
@@ -114,7 +114,12 @@ endif()
 if(ENABLE_OPENMP)
     find_package( OpenMP REQUIRED )
     if(OPENMP_FOUND)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+        add_library(slvs_openmp INTERFACE)
+        target_compile_options(slvs_openmp INTERFACE ${OpenMP_CXX_FLAGS})
+        target_link_libraries(slvs_openmp INTERFACE
+            ${OpenMP_CXX_LIBRARIES})
+        target_include_directories(slvs_openmp INTERFACE SYSTEM
+            ${OpenMP_CXX_INCLUDE_DIRS})
         message(STATUS "found OpenMP, compiling with flags: " ${OpenMP_CXX_FLAGS} )
     endif()
 endif()
@@ -281,7 +286,6 @@ if(ENABLE_GUI)
     elseif(APPLE)
         find_package(OpenGL REQUIRED)
         find_library(APPKIT_LIBRARY AppKit REQUIRED)
-        set(util_LIBRARIES ${APPKIT_LIBRARY})
     else()
         find_package(OpenGL REQUIRED)
         find_package(SpaceWare)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,9 @@ endif()
 message(STATUS "Using in-tree libdxfrw")
 add_subdirectory(extlib/libdxfrw)
 
+message(STATUS "Using in-tree eigen")
+include_directories(extlib/eigen)
+
 message(STATUS "Using in-tree mimalloc")
 set(MI_OVERRIDE OFF CACHE BOOL "")
 set(MI_BUILD_SHARED OFF CACHE BOOL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ set(ENABLE_OPENMP     OFF CACHE BOOL
     "Whether geometric operations will be parallelized using OpenMP")
 set(ENABLE_LTO        OFF CACHE BOOL
     "Whether interprocedural (global) optimizations are enabled")
+option(FORCE_VENDORED_Eigen3
+    "Whether we should use our bundled Eigen even in the presence of a system copy"
+    OFF)
 
 set(OPENGL 3 CACHE STRING "OpenGL version to use (one of: 1 3)")
 
@@ -189,6 +192,18 @@ set(MI_BUILD_OBJECT OFF CACHE BOOL "")
 set(MI_BUILD_TESTS OFF CACHE BOOL "")
 add_subdirectory(extlib/mimalloc EXCLUDE_FROM_ALL)
 set(MIMALLOC_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/extlib/mimalloc/include)
+
+if(NOT FORCE_VENDORED_Eigen3)
+    find_package(Eigen3 CONFIG)
+endif()
+if(FORCE_VENDORED_Eigen3 OR NOT EIGEN3_FOUND)
+    message(STATUS "Using in-tree Eigen")
+    set(EIGEN3_FOUND             YES)
+    set(EIGEN3_INCLUDE_DIRS      ${CMAKE_SOURCE_DIR}/extlib/eigen)
+else()
+    message(STATUS "Using system Eigen: ${EIGEN3_INCLUDE_DIRS}")
+endif()
+
 
 if(WIN32 OR APPLE)
     # On Win32 and macOS we use vendored packages, since there is little to no benefit

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Before building, check out the project and the necessary submodules:
 ```sh
 git clone https://github.com/solvespace/solvespace
 cd solvespace
-git submodule update --init extlib/libdxfrw extlib/mimalloc
+git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen
 ```
 
 After that, build SolveSpace as following:
@@ -230,7 +230,7 @@ Before building, check out the project and the necessary submodules:
 ```sh
 git clone https://github.com/solvespace/solvespace
 cd solvespace
-git submodule update --init extlib/libdxfrw extlib/mimalloc
+git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen
 ```
 
 After that, build SolveSpace as following:

--- a/cmake/FindSpaceWare.cmake
+++ b/cmake/FindSpaceWare.cmake
@@ -16,7 +16,7 @@ if(UNIX)
 
     # Support the REQUIRED and QUIET arguments, and set SPACEWARE_FOUND if found.
     include(FindPackageHandleStandardArgs)
-    FIND_PACKAGE_HANDLE_STANDARD_ARGS(SPACEWARE DEFAULT_MSG
+    find_package_handle_standard_args(SpaceWare DEFAULT_MSG
         SPACEWARE_LIBRARY SPACEWARE_INCLUDE_DIR)
 
     if(SPACEWARE_FOUND)

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
       snapcraftctl set-version "$version"
       git describe --exact-match HEAD && grade="stable" || grade="devel"
       snapcraftctl set-grade "$grade"
-      git submodule update --init extlib/libdxfrw extlib/mimalloc
+      git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen
     configflags:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(solvespace-core STATIC
     sketch.h
     solvespace.h
     ui.h
+    utileigen.h
     platform/platform.h
     render/render.h
     render/gl3shader.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,32 +19,62 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
+# solvespace dependencies
+add_library(slvs_deps INTERFACE)
+target_include_directories(slvs_deps INTERFACE SYSTEM
+    ${OPENGL_INCLUDE_DIR}
+    ${ZLIB_INCLUDE_DIR}
+    ${PNG_PNG_INCLUDE_DIR}
+    ${FREETYPE_INCLUDE_DIRS}
+    ${CAIRO_INCLUDE_DIRS}
+    ${MIMALLOC_INCLUDE_DIR})
+target_link_libraries(slvs_deps INTERFACE
+    dxfrw
+    ${ZLIB_LIBRARY}
+    ${PNG_LIBRARY}
+    ${FREETYPE_LIBRARY}
+    ${CAIRO_LIBRARIES}
+    mimalloc-static)
+
+if(Backtrace_FOUND)
+    target_include_directories(slvs_deps INTERFACE SYSTEM
+        ${Backtrace_INCLUDE_DIRS})
+    target_link_libraries(slvs_deps INTERFACE
+        ${Backtrace_LIBRARY})
+endif()
+
+if(SPACEWARE_FOUND)
+    target_include_directories(slvs_deps INTERFACE SYSTEM
+        ${SPACEWARE_INCLUDE_DIR})
+    target_link_libraries(slvs_deps INTERFACE
+        ${SPACEWARE_LIBRARIES})
+endif()
+
+if(ENABLE_OPENMP)
+    target_link_libraries(slvs_deps INTERFACE slvs_openmp)
+endif()
+
+target_compile_options(slvs_deps
+    INTERFACE ${COVERAGE_FLAGS})
+
 # platform utilities
 
 if(APPLE)
-    set(util_LIBRARIES
+    target_link_libraries(slvs_deps INTERFACE
         ${APPKIT_LIBRARY})
 endif()
 
 # libslvs
-
-set(libslvs_SOURCES
+add_library(slvs SHARED
+    solvespace.h
+    platform/platform.h
     util.cpp
     entity.cpp
     expr.cpp
     constraint.cpp
     constrainteq.cpp
     system.cpp
-    platform/platform.cpp)
-
-set(libslvs_HEADERS
-    solvespace.h
-    platform/platform.h)
-
-add_library(slvs SHARED
-    ${libslvs_SOURCES}
-    ${libslvs_HEADERS}
-    ${util_SOURCES}
+    platform/platform.cpp
     lib.cpp)
 
 target_compile_definitions(slvs
@@ -53,12 +83,7 @@ target_compile_definitions(slvs
 target_include_directories(slvs
     PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
-target_link_libraries(slvs
-    ${util_LIBRARIES}
-    mimalloc-static)
-
-add_dependencies(slvs
-    mimalloc-static)
+target_link_libraries(slvs PRIVATE slvs_deps)
 
 set_target_properties(slvs PROPERTIES
     PUBLIC_HEADER ${CMAKE_SOURCE_DIR}/include/slvs.h
@@ -72,70 +97,6 @@ if(NOT WIN32)
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
-# solvespace dependencies
-
-include_directories(
-    ${OPENGL_INCLUDE_DIR}
-    ${ZLIB_INCLUDE_DIR}
-    ${PNG_PNG_INCLUDE_DIR}
-    ${FREETYPE_INCLUDE_DIRS}
-    ${CAIRO_INCLUDE_DIRS}
-    ${MIMALLOC_INCLUDE_DIR}
-    ${OpenMP_CXX_INCLUDE_DIRS})
-
-if(Backtrace_FOUND)
-    include_directories(
-        ${Backtrace_INCLUDE_DIRS})
-endif()
-
-if(SPACEWARE_FOUND)
-    include_directories(
-        ${SPACEWARE_INCLUDE_DIR})
-endif()
-
-if(OPENGL STREQUAL 3)
-    set(gl_SOURCES
-        render/gl3shader.cpp
-        render/rendergl3.cpp)
-elseif(OPENGL STREQUAL 1)
-    set(gl_SOURCES
-        render/rendergl1.cpp)
-else()
-    message(FATAL_ERROR "Unsupported OpenGL version ${OPENGL}")
-endif()
-
-set(platform_SOURCES
-    ${gl_SOURCES}
-    platform/entrygui.cpp)
-
-if(WIN32)
-    list(APPEND platform_SOURCES
-        platform/guiwin.cpp)
-
-    set(platform_LIBRARIES
-        comctl32
-        ${SPACEWARE_LIBRARIES})
-elseif(APPLE)
-    add_compile_options(
-        -DGL_SILENCE_DEPRECATION
-        -fobjc-arc)
-
-    list(APPEND platform_SOURCES
-        platform/guimac.mm)
-else()
-    list(APPEND platform_SOURCES
-        platform/guigtk.cpp)
-
-    set(platform_LIBRARIES
-        ${SPACEWARE_LIBRARIES})
-
-    foreach(pkg_config_lib GTKMM JSONC FONTCONFIG)
-        include_directories(${${pkg_config_lib}_INCLUDE_DIRS})
-        link_directories(${${pkg_config_lib}_LIBRARY_DIRS})
-        list(APPEND platform_LIBRARIES ${${pkg_config_lib}_LIBRARIES})
-    endforeach()
-endif()
-
 set(every_platform_SOURCES
     platform/guiwin.cpp
     platform/guigtk.cpp
@@ -143,7 +104,10 @@ set(every_platform_SOURCES
 
 # solvespace library
 
-set(solvespace_core_HEADERS
+set(solvespace_core_gl_SOURCES
+    solvespace.cpp)
+
+add_library(solvespace-core STATIC
     dsc.h
     expr.h
     polygon.h
@@ -153,9 +117,7 @@ set(solvespace_core_HEADERS
     platform/platform.h
     render/render.h
     render/gl3shader.h
-    srf/surface.h)
-
-set(solvespace_core_SOURCES
+    srf/surface.h
     bsp.cpp
     clipboard.cpp
     confscreen.cpp
@@ -207,40 +169,14 @@ set(solvespace_core_SOURCES
     srf/surfinter.cpp
     srf/triangulate.cpp)
 
-set(solvespace_core_gl_SOURCES
-    solvespace.cpp)
-
-add_library(solvespace-core STATIC
-    ${util_SOURCES}
-    ${solvespace_core_HEADERS}
-    ${solvespace_core_SOURCES})
-
-add_dependencies(solvespace-core
-    mimalloc-static)
-
-target_link_libraries(solvespace-core
-    ${OpenMP_CXX_LIBRARIES}
-    dxfrw
-    ${util_LIBRARIES}
-    ${ZLIB_LIBRARY}
-    ${PNG_LIBRARY}
-    ${FREETYPE_LIBRARY}
-    mimalloc-static)
-
-if(Backtrace_FOUND)
-    target_link_libraries(solvespace-core
-        ${Backtrace_LIBRARY})
-endif()
-
-target_compile_options(solvespace-core
-    PRIVATE ${COVERAGE_FLAGS})
+target_link_libraries(solvespace-core PUBLIC slvs_deps)
 
 # solvespace translations
 
 if(HAVE_GETTEXT)
+    get_target_property(solvespace_core_SOURCES solvespace-core SOURCES)
     set(inputs
         ${solvespace_core_SOURCES}
-        ${solvespace_core_HEADERS}
         ${every_platform_SOURCES}
         ${solvespace_core_gl_SOURCES})
 
@@ -323,52 +259,82 @@ endif()
 if(ENABLE_GUI)
     add_executable(solvespace WIN32 MACOSX_BUNDLE
         ${solvespace_core_gl_SOURCES}
-        ${platform_SOURCES}
+        platform/entrygui.cpp
         $<TARGET_PROPERTY:resources,EXTRA_SOURCES>)
 
     add_dependencies(solvespace
         resources)
 
     target_link_libraries(solvespace
+        PRIVATE
         solvespace-core
-        ${OPENGL_LIBRARIES}
-        ${platform_LIBRARIES}
-        ${COVERAGE_LIBRARY})
+        ${OPENGL_LIBRARIES})
 
-    if(MSVC)
-        set_target_properties(solvespace PROPERTIES
-            LINK_FLAGS "/MANIFEST:NO /SAFESEH:NO /INCREMENTAL:NO /OPT:REF")
+    # OpenGL version
+    if(OPENGL STREQUAL 3)
+        target_sources(solvespace PRIVATE
+            render/gl3shader.cpp
+            render/rendergl3.cpp)
+    elseif(OPENGL STREQUAL 1)
+        target_sources(solvespace PRIVATE
+            render/rendergl1.cpp)
+    else()
+        message(FATAL_ERROR "Unsupported OpenGL version ${OPENGL}")
+    endif()
+
+    # Platform-specific
+    if(WIN32)
+        target_sources(solvespace PRIVATE
+            platform/guiwin.cpp)
+
+        target_link_libraries(solvespace PRIVATE comctl32)
     elseif(APPLE)
+        target_compile_options(solvespace PRIVATE -fobjc-arc)
+        target_compile_definitions(solvespace PRIVATE GL_SILENCE_DEPRECATION)
+
+        target_sources(solvespace PRIVATE
+            platform/guimac.mm)
         set_target_properties(solvespace PROPERTIES
             OUTPUT_NAME SolveSpace
             XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME "YES"
             XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.solvespace"
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+    else()
+        target_sources(solvespace PRIVATE
+            platform/guigtk.cpp)
+
+        target_include_directories(solvespace PRIVATE SYSTEM
+            ${GTKMM_INCLUDE_DIRS}
+            ${JSONC_INCLUDE_DIRS}
+            ${FONTCONFIG_INCLUDE_DIRS})
+        target_link_libraries(solvespace PRIVATE
+            ${GTKMM_LIBRARIES}
+            ${JSONC_LIBRARIES}
+            ${FONTCONFIG_LIBRARIES})
+    endif()
+
+    if(MSVC)
+        set_target_properties(solvespace PROPERTIES
+            LINK_FLAGS "/MANIFEST:NO /SAFESEH:NO /INCREMENTAL:NO /OPT:REF")
     endif()
 endif()
 
 # solvespace headless library
 
-set(headless_SOURCES
+add_library(solvespace-headless STATIC EXCLUDE_FROM_ALL
+    ${solvespace_core_gl_SOURCES}
     platform/guinone.cpp
     render/rendercairo.cpp)
 
-add_library(solvespace-headless STATIC EXCLUDE_FROM_ALL
-    ${solvespace_core_gl_SOURCES}
-    ${headless_SOURCES})
-
 target_compile_definitions(solvespace-headless
-    PRIVATE -DHEADLESS)
+    PRIVATE HEADLESS)
 
 target_include_directories(solvespace-headless
     INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(solvespace-headless
-    solvespace-core
-    ${CAIRO_LIBRARIES})
-
-target_compile_options(solvespace-headless
-    PRIVATE ${COVERAGE_FLAGS})
+    PRIVATE
+    solvespace-core)
 
 # solvespace command-line executable
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,8 @@ target_include_directories(slvs_deps INTERFACE SYSTEM
     ${PNG_PNG_INCLUDE_DIR}
     ${FREETYPE_INCLUDE_DIRS}
     ${CAIRO_INCLUDE_DIRS}
-    ${MIMALLOC_INCLUDE_DIR})
+    ${MIMALLOC_INCLUDE_DIR}
+    ${EIGEN3_INCLUDE_DIRS})
 target_link_libraries(slvs_deps INTERFACE
     dxfrw
     ${ZLIB_LIBRARY}

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -400,13 +400,16 @@ Expr *Expr::PartialWrt(hParam p) const {
     ssassert(false, "Unexpected operation");
 }
 
-void Expr::ParamsUsedList(List<hParam> *list) const {
+void Expr::ParamsUsedList(std::vector<hParam> *list) const {
     if(op == Op::PARAM || op == Op::PARAM_PTR) {
+        // leaf: just add ourselves if we aren't already there
         hParam param = (op == Op::PARAM) ? parh : parp->h;
-        for(hParam &p : *list) {
-            if(p.v == param.v) return;
+        if(list->end() != std::find_if(list->begin(), list->end(),
+                                       [=](const hParam &p) { return p.v == param.v; })) {
+            // We found ourselves in the list already, early out.
+            return;
         }
-        list->Add(&param);
+        list->push_back(param);
         return;
     }
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -400,15 +400,21 @@ Expr *Expr::PartialWrt(hParam p) const {
     ssassert(false, "Unexpected operation");
 }
 
-uint64_t Expr::ParamsUsed() const {
-    uint64_t r = 0;
-    if(op == Op::PARAM)     r |= ((uint64_t)1 << (parh.v % 61));
-    if(op == Op::PARAM_PTR) r |= ((uint64_t)1 << (parp->h.v % 61));
+void Expr::ParamsUsedList(List<hParam> *list) const {
+    if(op == Op::PARAM || op == Op::PARAM_PTR) {
+        hParam param = (op == Op::PARAM) ? parh : parp->h;
+        for(hParam &p : *list) {
+            if(p.v == param.v) return;
+        }
+        list->Add(&param);
+        return;
+    }
 
     int c = Children();
-    if(c >= 1)          r |= a->ParamsUsed();
-    if(c >= 2)          r |= b->ParamsUsed();
-    return r;
+    if(c >= 1) {
+        a->ParamsUsedList(list);
+        if(c >= 2) b->ParamsUsedList(list);
+    }
 }
 
 bool Expr::DependsOn(hParam p) const {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -430,6 +430,11 @@ bool Expr::DependsOn(hParam p) const {
 bool Expr::Tol(double a, double b) {
     return fabs(a - b) < 0.001;
 }
+
+bool Expr::IsZeroConst() const {
+    return op == Op::CONSTANT && EXACT(v == 0.0);
+}
+
 Expr *Expr::FoldConstants() {
     Expr *n = AllocExpr();
     *n = *this;

--- a/src/expr.h
+++ b/src/expr.h
@@ -70,7 +70,7 @@ public:
 
     Expr *PartialWrt(hParam p) const;
     double Eval() const;
-    void ParamsUsedList(List<hParam> *list) const;
+    void ParamsUsedList(std::vector<hParam> *list) const;
     bool DependsOn(hParam p) const;
     static bool Tol(double a, double b);
     bool IsZeroConst() const;

--- a/src/expr.h
+++ b/src/expr.h
@@ -73,6 +73,7 @@ public:
     void ParamsUsedList(List<hParam> *list) const;
     bool DependsOn(hParam p) const;
     static bool Tol(double a, double b);
+    bool IsZeroConst() const;
     Expr *FoldConstants();
     void Substitute(hParam oldh, hParam newh);
 

--- a/src/expr.h
+++ b/src/expr.h
@@ -70,7 +70,7 @@ public:
 
     Expr *PartialWrt(hParam p) const;
     double Eval() const;
-    uint64_t ParamsUsed() const;
+    void ParamsUsedList(List<hParam> *list) const;
     bool DependsOn(hParam p) const;
     static bool Tol(double a, double b);
     Expr *FoldConstants();

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -551,9 +551,9 @@ void SolveSpaceUI::SolveGroup(hGroup hg, bool andFindFree) {
 
 SolveResult SolveSpaceUI::TestRankForGroup(hGroup hg, int *rank) {
     Group *g = SK.GetGroup(hg);
-    // If redundant is allowed, there is
+    // If we don't calculate dof or redundant is allowed, there is
     // no point to solve rank because this result is not meaningful
-    if(g->allowRedundant) return SolveResult::OKAY;
+    if(g->suppressDofCalculation || g->allowRedundant) return SolveResult::OKAY;
     WriteEqSystemForGroup(hg);
     SolveResult result = sys.SolveRank(g, rank);
     FreeAllTemporary();

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -550,8 +550,11 @@ void SolveSpaceUI::SolveGroup(hGroup hg, bool andFindFree) {
 }
 
 SolveResult SolveSpaceUI::TestRankForGroup(hGroup hg, int *rank) {
-    WriteEqSystemForGroup(hg);
     Group *g = SK.GetGroup(hg);
+    // If redundant is allowed, there is
+    // no point to solve rank because this result is not meaningful
+    if(g->allowRedundant) return SolveResult::OKAY;
+    WriteEqSystemForGroup(hg);
     SolveResult result = sys.SolveRank(g, rank);
     FreeAllTemporary();
     return result;

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -4,6 +4,7 @@
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
+#include "utileigen.h"
 
 Vector STriangle::Normal() const {
     Vector ab = b.Minus(a), bc = c.Minus(b);
@@ -11,9 +12,9 @@ Vector STriangle::Normal() const {
 }
 
 double STriangle::MinAltitude() const {
-    double altA = a.DistanceToLine(b, c.Minus(b)),
-           altB = b.DistanceToLine(c, a.Minus(c)),
-           altC = c.DistanceToLine(a, b.Minus(a));
+    double altA = DistanceToLineFromEndpoints(a, b, c),
+           altB = DistanceToLineFromEndpoints(b, c, a),
+           altC = DistanceToLineFromEndpoints(c, a, b);
 
     return min(altA, min(altB, altC));
 }

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -622,7 +622,7 @@ public:
     bool        free;
 
     // Used only in the solver
-    hParam      substd;
+    Param       *substd;
 
     static const hParam NO_PARAM;
 

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -175,6 +175,7 @@ public:
     bool        suppress;
     bool        relaxConstraints;
     bool        allowRedundant;
+    bool        suppressDofCalculation;
     bool        allDimsReference;
     double      scale;
 

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -291,6 +291,9 @@ public:
                           bool andFindBad = false, bool andFindFree = false);
 
     void Clear();
+    Param *GetLastParamSubstitution(Param *p);
+    void SubstituteParamsByLast(Expr *e);
+    void SortSubstitutionByDragged(Param *p);
 };
 
 #include "ttf.h"

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -261,7 +261,7 @@ public:
 
     static const double RANK_MAG_TOLERANCE, CONVERGE_TOLERANCE;
     int CalculateRank();
-    bool TestRank(int *rank = NULL);
+    bool TestRank(int *dof = NULL);
     static bool SolveLinearSystem(double X[], double A[][MAX_UNKNOWNS],
                                   double B[], int N);
     bool SolveLeastSquares();
@@ -279,7 +279,6 @@ public:
     bool NewtonSolve(int tag);
 
     void MarkParamsFree(bool findFree);
-    int CalculateDof();
 
     SolveResult Solve(Group *g, int *rank = NULL, int *dof = NULL,
                       List<hConstraint> *bad = NULL,

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -36,7 +36,7 @@
 
 #define EIGEN_NO_DEBUG
 #undef Success
-#include "Eigen/SparseCore"
+#include <Eigen/SparseCore>
 
 // We declare these in advance instead of simply using FT_Library
 // (defined as typedef FT_LibraryRec_* FT_Library) because including
@@ -245,14 +245,16 @@ public:
         // We're solving AX = B
         int m, n;
         struct {
-            Eigen::SparseMatrix<Expr*>  *sym;
-            Eigen::SparseMatrix<double> *num;
+            // This only observes the Expr - does not own them!
+            std::unique_ptr<Eigen::SparseMatrix<Expr *>> sym;
+            std::unique_ptr<Eigen::SparseMatrix<double>> num;
         } A;
 
         Eigen::VectorXd scale;
         Eigen::VectorXd X;
 
         struct {
+            // This only observes the Expr - does not own them!
             std::vector<Expr *> sym;
             Eigen::VectorXd     num;
         } B;

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -246,8 +246,8 @@ public:
         int m, n;
         struct {
             // This only observes the Expr - does not own them!
-            std::unique_ptr<Eigen::SparseMatrix<Expr *>> sym;
-            std::unique_ptr<Eigen::SparseMatrix<double>> num;
+            Eigen::SparseMatrix<Expr *> sym;
+            Eigen::SparseMatrix<double> num;
         } A;
 
         Eigen::VectorXd scale;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -48,8 +48,8 @@ bool System::WriteJacobian(int tag) {
             continue;
 
         mat.eq[i] = e.h;
-        Expr *f   = e.e->DeepCopyWithParamsAsPointers(&param, &(SK.param));
-        f = f->FoldConstants();
+        Expr *f = e.e->FoldConstants();
+        f = f->DeepCopyWithParamsAsPointers(&param, &(SK.param));
 
         for(j = 0; j < mat.n; j++) {
             mat.A.sym[i][j] = zero;
@@ -63,7 +63,6 @@ bool System::WriteJacobian(int tag) {
             if(j == paramToIndex.end()) continue;
             Expr *pd = f->PartialWrt(p);
             pd = pd->FoldConstants();
-            pd = pd->DeepCopyWithParamsAsPointers(&param, &(SK.param));
             mat.A.sym[i][j->second] = pd;
         }
         paramsUsed.Clear();

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -257,14 +257,14 @@ bool System::SolveLeastSquares() {
         } else {
             mat.scale[c] = 1;
         }
-        }
+    }
 
     int size = mat.A.sym.outerSize();
     for(int k = 0; k < size; k++) {
         for(SparseMatrix<double>::InnerIterator it(mat.A.num, k); it; ++it) {
             it.valueRef() *= mat.scale[it.col()];
-            }
         }
+    }
 
     SparseMatrix<double> AAt = mat.A.num * mat.A.num.transpose();
     AAt.makeCompressed();

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -33,8 +33,14 @@ bool System::WriteJacobian(int tag) {
     }
     mat.n = j;
 
-    int i = 0;
+    // Fill the param id to index map
+    std::map<uint32_t, int> paramToIndex;
+    for(int j = 0; j < mat.n; j++) {
+        paramToIndex[mat.param[j].v] = j;
+    }
 
+    int i = 0;
+    Expr *zero = Expr::From(0.0);
     for(auto &e : eq) {
         if(i >= MAX_UNKNOWNS) return false;
 
@@ -45,21 +51,22 @@ bool System::WriteJacobian(int tag) {
         Expr *f   = e.e->DeepCopyWithParamsAsPointers(&param, &(SK.param));
         f = f->FoldConstants();
 
-        // Hash table (61 bits) to accelerate generation of zero partials.
-        uint64_t scoreboard = f->ParamsUsed();
         for(j = 0; j < mat.n; j++) {
-            Expr *pd;
-            if(scoreboard & ((uint64_t)1 << (mat.param[j].v % 61)) &&
-                f->DependsOn(mat.param[j]))
-            {
-                pd = f->PartialWrt(mat.param[j]);
-                pd = pd->FoldConstants();
-                pd = pd->DeepCopyWithParamsAsPointers(&param, &(SK.param));
-            } else {
-                pd = Expr::From(0.0);
-            }
-            mat.A.sym[i][j] = pd;
+            mat.A.sym[i][j] = zero;
         }
+
+        List<hParam> paramsUsed = {};
+        f->ParamsUsedList(&paramsUsed);
+
+        for(hParam &p : paramsUsed) {
+            auto j = paramToIndex.find(p.v);
+            if(j == paramToIndex.end()) continue;
+            Expr *pd = f->PartialWrt(p);
+            pd = pd->FoldConstants();
+            pd = pd->DeepCopyWithParamsAsPointers(&param, &(SK.param));
+            mat.A.sym[i][j->second] = pd;
+        }
+        paramsUsed.Clear();
         mat.B.sym[i] = f;
         i++;
     }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -45,13 +45,16 @@ bool System::WriteJacobian(int tag) {
     if(mat.eq.size() >= MAX_UNKNOWNS) {
         return false;
     }
+    std::vector<hParam> paramsUsed;
+    // A single possibly-too-large allocation is probably preferred here?
+    mat.B.sym.reserve(mat.eq.size());
     for(size_t i = 0; i < mat.eq.size(); i++) {
         Equation *e = mat.eq[i];
         if(e->tag != tag) continue;
         Expr *f = e->e->FoldConstants();
         f = f->DeepCopyWithParamsAsPointers(&param, &(SK.param));
 
-        List<hParam> paramsUsed = {};
+        paramsUsed.clear();
         f->ParamsUsedList(&paramsUsed);
 
         for(hParam &p : paramsUsed) {
@@ -63,7 +66,7 @@ bool System::WriteJacobian(int tag) {
                 continue;
             mat.A.sym->insert(i, j->second) = pd;
         }
-        paramsUsed.Clear();
+        paramsUsed.clear();
         mat.B.sym.push_back(f);
     }
     return true;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -500,9 +500,9 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
     param.ClearTags();
     eq.ClearTags();
 
-    // Since we are allowing redundant, we
-    // don't want to catch result of dof checking without substitution
-    if(g->allowRedundant || !forceDofCheck) {
+    // Since we are suppressing dof calculation or allowing redundant, we
+    // can't / don't want to catch result of dof checking without substitution
+    if(g->suppressDofCalculation || g->allowRedundant || !forceDofCheck) {
         SolveBySubstitution();
     }
 
@@ -542,15 +542,16 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
     }
     // Clear dof value in order to have indication when dof is actually not calculated
     if(dof != NULL) *dof = -1;
-    // We are allowing redundant, so we no need to catch unsolveable + redundant
-    rankOk = (!g->allowRedundant) ? TestRank(dof) : true;
+    // We are suppressing or allowing redundant, so we no need to catch unsolveable + redundant
+    rankOk = (!g->suppressDofCalculation && !g->allowRedundant) ? TestRank(dof) : true;
 
     // And do the leftovers as one big system
     if(!NewtonSolve(0)) {
         goto didnt_converge;
     }
 
-    rankOk = TestRank(dof);
+    // Here we are want to calculate dof even when redundant is allowed, so just handle suppressing
+    rankOk = (!g->suppressDofCalculation) ? TestRank(dof) : true;
     if(!rankOk) {
         if(andFindBad) FindWhichToRemoveToFixJacobian(g, bad, forceDofCheck);
     } else {
@@ -614,7 +615,7 @@ SolveResult System::SolveRank(Group *g, int *rank, int *dof, List<hConstraint> *
     if(!rankOk) {
         // When we are testing with redundant allowed, we don't want to have additional info
         // about redundants since this test is working only for single redundant constraint
-        if(!g->allowRedundant) {
+        if(!g->suppressDofCalculation && !g->allowRedundant) {
             if(andFindBad) FindWhichToRemoveToFixJacobian(g, bad, true);
         }
     } else {

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -242,10 +242,12 @@ int System::CalculateRank() {
     return rank;
 }
 
-bool System::TestRank(int *rank) {
+bool System::TestRank(int *dof) {
     EvalJacobian();
     int jacobianRank = CalculateRank();
-    if(rank) *rank = jacobianRank;
+    // We are calculating dof based on real rank, not mat.m.
+    // Using this approach we can calculate real dof even when redundant is allowed.
+    if(dof != NULL) *dof = mat.n - jacobianRank;
     return jacobianRank == mat.m;
 }
 
@@ -498,9 +500,9 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
     param.ClearTags();
     eq.ClearTags();
 
-    // Solving by substitution eliminates duplicate e.g. H/V constraints, which can cause rank test
-    // to succeed even on overdefined systems, which will fail later.
-    if(!forceDofCheck) {
+    // Since we are allowing redundant, we
+    // don't want to catch result of dof checking without substitution
+    if(g->allowRedundant || !forceDofCheck) {
         SolveBySubstitution();
     }
 
@@ -538,22 +540,20 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
     if(!WriteJacobian(0)) {
         return SolveResult::TOO_MANY_UNKNOWNS;
     }
-
-    rankOk = TestRank(rank);
+    // Clear dof value in order to have indication when dof is actually not calculated
+    if(dof != NULL) *dof = -1;
+    // We are allowing redundant, so we no need to catch unsolveable + redundant
+    rankOk = (!g->allowRedundant) ? TestRank(dof) : true;
 
     // And do the leftovers as one big system
     if(!NewtonSolve(0)) {
         goto didnt_converge;
     }
 
-    rankOk = TestRank(rank);
+    rankOk = TestRank(dof);
     if(!rankOk) {
         if(andFindBad) FindWhichToRemoveToFixJacobian(g, bad, forceDofCheck);
     } else {
-        // This is not the full Jacobian, but any substitutions or single-eq
-        // solves removed one equation and one unknown, therefore no effect
-        // on the number of DOF.
-        if(dof) *dof = CalculateDof();
         MarkParamsFree(andFindFree);
     }
     // System solved correctly, so write the new values back in to the
@@ -610,11 +610,14 @@ SolveResult System::SolveRank(Group *g, int *rank, int *dof, List<hConstraint> *
         return SolveResult::TOO_MANY_UNKNOWNS;
     }
 
-    bool rankOk = TestRank(rank);
+    bool rankOk = TestRank(dof);
     if(!rankOk) {
-        if(andFindBad) FindWhichToRemoveToFixJacobian(g, bad, /*forceDofCheck=*/true);
+        // When we are testing with redundant allowed, we don't want to have additional info
+        // about redundants since this test is working only for single redundant constraint
+        if(!g->allowRedundant) {
+            if(andFindBad) FindWhichToRemoveToFixJacobian(g, bad, true);
+        }
     } else {
-        if(dof) *dof = CalculateDof();
         MarkParamsFree(andFindFree);
     }
     return rankOk ? SolveResult::OKAY : SolveResult::REDUNDANT_OKAY;
@@ -647,9 +650,5 @@ void System::MarkParamsFree(bool find) {
             }
         }
     }
-}
-
-int System::CalculateDof() {
-    return mat.n - mat.m;
 }
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -63,6 +63,8 @@ bool System::WriteJacobian(int tag) {
             if(j == paramToIndex.end()) continue;
             Expr *pd = f->PartialWrt(p);
             pd = pd->FoldConstants();
+            if(pd->IsZeroConst())
+                continue;
             mat.A.sym[i][j->second] = pd;
         }
         paramsUsed.Clear();

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -8,30 +8,32 @@
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
 
-// This tolerance is used to determine whether two (linearized) constraints
-// are linearly dependent. If this is too small, then we will attempt to
-// solve truly inconsistent systems and fail. But if it's too large, then
-// we will give up on legitimate systems like a skinny right angle triangle by
-// its hypotenuse and long side.
-const double System::RANK_MAG_TOLERANCE = 1e-4;
+#include <Eigen/SparseQR>
 
 // The solver will converge all unknowns to within this tolerance. This must
 // always be much less than LENGTH_EPS, and in practice should be much less.
 const double System::CONVERGE_TOLERANCE = (LENGTH_EPS/(1e2));
 
 bool System::WriteJacobian(int tag) {
+    // Clear all
+    mat.param.clear();
+    mat.eq.clear();
+    mat.B.sym.clear();
 
-    int j = 0;
-    for(auto &p : param) {
-        if(j >= MAX_UNKNOWNS)
-            return false;
-
-        if(p.tag != tag)
-            continue;
-        mat.param[j] = p.h;
-        j++;
+    for(Param &p : param) {
+        if(p.tag != tag) continue;
+        mat.param.push_back(p.h);
     }
-    mat.n = j;
+    mat.n = mat.param.size();
+
+    for(Equation &e : eq) {
+        if(e.tag != tag) continue;
+        mat.eq.push_back(&e);
+    }
+    mat.m = mat.eq.size();
+    delete mat.A.sym;
+    mat.A.sym = new Eigen::SparseMatrix<Expr *>(mat.m, mat.n);
+    mat.A.sym->reserve(Eigen::VectorXi::Constant(mat.n, 10));
 
     // Fill the param id to index map
     std::map<uint32_t, int> paramToIndex;
@@ -39,21 +41,14 @@ bool System::WriteJacobian(int tag) {
         paramToIndex[mat.param[j].v] = j;
     }
 
-    int i = 0;
-    Expr *zero = Expr::From(0.0);
-    for(auto &e : eq) {
-        if(i >= MAX_UNKNOWNS) return false;
-
-        if(e.tag != tag)
-            continue;
-
-        mat.eq[i] = e.h;
-        Expr *f = e.e->FoldConstants();
+    if(mat.eq.size() >= MAX_UNKNOWNS) {
+        return false;
+    }
+    for(size_t i = 0; i < mat.eq.size(); i++) {
+        Equation *e = mat.eq[i];
+        if(e->tag != tag) continue;
+        Expr *f = e->e->FoldConstants();
         f = f->DeepCopyWithParamsAsPointers(&param, &(SK.param));
-
-        for(j = 0; j < mat.n; j++) {
-            mat.A.sym[i][j] = zero;
-        }
 
         List<hParam> paramsUsed = {};
         f->ParamsUsedList(&paramsUsed);
@@ -65,24 +60,28 @@ bool System::WriteJacobian(int tag) {
             pd = pd->FoldConstants();
             if(pd->IsZeroConst())
                 continue;
-            mat.A.sym[i][j->second] = pd;
+            mat.A.sym->insert(i, j->second) = pd;
         }
         paramsUsed.Clear();
-        mat.B.sym[i] = f;
-        i++;
+        mat.B.sym.push_back(f);
     }
-    mat.m = i;
-
     return true;
 }
 
 void System::EvalJacobian() {
-    int i, j;
-    for(i = 0; i < mat.m; i++) {
-        for(j = 0; j < mat.n; j++) {
-            mat.A.num[i][j] = (mat.A.sym[i][j])->Eval();
+    using namespace Eigen;
+    delete mat.A.num;
+    mat.A.num = new Eigen::SparseMatrix<double>(mat.m, mat.n);
+    int size = mat.A.sym->outerSize();
+
+    for(int k = 0; k < size; k++) {
+        for(SparseMatrix <Expr *>::InnerIterator it(*mat.A.sym, k); it; ++it) {
+            double value = it.value()->Eval();
+            if(EXACT(value == 0.0)) continue;
+            mat.A.num->insert(it.row(), it.col()) = value;
         }
     }
+    mat.A.num->makeCompressed();
 }
 
 bool System::IsDragged(hParam p) {
@@ -209,45 +208,15 @@ void System::SolveBySubstitution() {
 }
 
 //-----------------------------------------------------------------------------
-// Calculate the rank of the Jacobian matrix, by Gram-Schimdt orthogonalization
-// in place. A row (~equation) is considered to be all zeros if its magnitude
-// is less than the tolerance RANK_MAG_TOLERANCE.
+// Calculate the rank of the Jacobian matrix
 //-----------------------------------------------------------------------------
 int System::CalculateRank() {
-    // Actually work with magnitudes squared, not the magnitudes
-    double rowMag[MAX_UNKNOWNS] = {};
-    double tol = RANK_MAG_TOLERANCE*RANK_MAG_TOLERANCE;
-
-    int i, iprev, j;
-    int rank = 0;
-
-    for(i = 0; i < mat.m; i++) {
-        // Subtract off this row's component in the direction of any
-        // previous rows
-        for(iprev = 0; iprev < i; iprev++) {
-            if(rowMag[iprev] <= tol) continue; // ignore zero rows
-
-            double dot = 0;
-            for(j = 0; j < mat.n; j++) {
-                dot += (mat.A.num[iprev][j]) * (mat.A.num[i][j]);
-            }
-            for(j = 0; j < mat.n; j++) {
-                mat.A.num[i][j] -= (dot/rowMag[iprev])*mat.A.num[iprev][j];
-            }
-        }
-        // Our row is now normal to all previous rows; calculate the
-        // magnitude of what's left
-        double mag = 0;
-        for(j = 0; j < mat.n; j++) {
-            mag += (mat.A.num[i][j]) * (mat.A.num[i][j]);
-        }
-        if(mag > tol) {
-            rank++;
-        }
-        rowMag[i] = mag;
-    }
-
-    return rank;
+    using namespace Eigen;
+    if(mat.n == 0 || mat.m == 0) return 0;
+    SparseQR <SparseMatrix<double>, COLAMDOrdering<int>> solver;
+    solver.compute(*mat.A.num);
+    int result = solver.rank();
+    return result;
 }
 
 bool System::TestRank(int *dof) {
@@ -259,69 +228,25 @@ bool System::TestRank(int *dof) {
     return jacobianRank == mat.m;
 }
 
-bool System::SolveLinearSystem(double X[], double A[][MAX_UNKNOWNS],
-                               double B[], int n)
+bool System::SolveLinearSystem(const Eigen::SparseMatrix <double> &A,
+                               const Eigen::VectorXd &B, Eigen::VectorXd *X)
 {
-    // Gaussian elimination, with partial pivoting. It's an error if the
-    // matrix is singular, because that means two constraints are
-    // equivalent.
-    int i, j, ip, jp, imax = 0;
-    double max, temp;
-
-    for(i = 0; i < n; i++) {
-        // We are trying eliminate the term in column i, for rows i+1 and
-        // greater. First, find a pivot (between rows i and N-1).
-        max = 0;
-        for(ip = i; ip < n; ip++) {
-            if(fabs(A[ip][i]) > max) {
-                imax = ip;
-                max = fabs(A[ip][i]);
-            }
-        }
-        // Don't give up on a singular matrix unless it's really bad; the
-        // assumption code is responsible for identifying that condition,
-        // so we're not responsible for reporting that error.
-        if(fabs(max) < 1e-20) continue;
-
-        // Swap row imax with row i
-        for(jp = 0; jp < n; jp++) {
-            swap(A[i][jp], A[imax][jp]);
-        }
-        swap(B[i], B[imax]);
-
-        // For rows i+1 and greater, eliminate the term in column i.
-        for(ip = i+1; ip < n; ip++) {
-            temp = A[ip][i]/A[i][i];
-
-            for(jp = i; jp < n; jp++) {
-                A[ip][jp] -= temp*(A[i][jp]);
-            }
-            B[ip] -= temp*B[i];
-        }
-    }
-
-    // We've put the matrix in upper triangular form, so at this point we
-    // can solve by back-substitution.
-    for(i = n - 1; i >= 0; i--) {
-        if(fabs(A[i][i]) < 1e-20) continue;
-
-        temp = B[i];
-        for(j = n - 1; j > i; j--) {
-            temp -= X[j]*A[i][j];
-        }
-        X[i] = temp / A[i][i];
-    }
-
-    return true;
+    if(A.outerSize() == 0) return true;
+    using namespace Eigen;
+    SparseQR<SparseMatrix<double>, COLAMDOrdering<int>> solver;
+    //SimplicialLDLT<SparseMatrix<double>> solver;
+    solver.compute(A);
+    *X = solver.solve(B);
+    return (solver.info() == Success);
 }
 
 bool System::SolveLeastSquares() {
-    int r, c, i;
-
+    using namespace Eigen;
     // Scale the columns; this scale weights the parameters for the least
     // squares solve, so that we can encourage the solver to make bigger
     // changes in some parameters, and smaller in others.
-    for(c = 0; c < mat.n; c++) {
+    mat.scale = VectorXd(mat.n);
+    for(int c = 0; c < mat.n; c++) {
         if(IsDragged(mat.param[c])) {
             // It's least squares, so this parameter doesn't need to be all
             // that big to get a large effect.
@@ -329,31 +254,25 @@ bool System::SolveLeastSquares() {
         } else {
             mat.scale[c] = 1;
         }
-        for(r = 0; r < mat.m; r++) {
-            mat.A.num[r][c] *= mat.scale[c];
         }
-    }
 
-    // Write A*A'
-    for(r = 0; r < mat.m; r++) {
-        for(c = 0; c < mat.m; c++) {  // yes, AAt is square
-            double sum = 0;
-            for(i = 0; i < mat.n; i++) {
-                sum += mat.A.num[r][i]*mat.A.num[c][i];
+    int size = mat.A.sym->outerSize();
+    for(int k = 0; k < size; k++) {
+        for(SparseMatrix<double>::InnerIterator it(*mat.A.num, k); it; ++it) {
+            it.valueRef() *= mat.scale[it.col()];
             }
-            mat.AAt[r][c] = sum;
         }
-    }
 
-    if(!SolveLinearSystem(mat.Z, mat.AAt, mat.B.num, mat.m)) return false;
+    SparseMatrix <double> AAt = *mat.A.num * mat.A.num->transpose();
+    AAt.makeCompressed();
+    VectorXd z(mat.n);
 
-    // And multiply that by A' to get our solution.
-    for(c = 0; c < mat.n; c++) {
-        double sum = 0;
-        for(i = 0; i < mat.m; i++) {
-            sum += mat.A.num[i][c]*mat.Z[i];
-        }
-        mat.X[c] = sum * mat.scale[c];
+    if(!SolveLinearSystem(AAt, mat.B.num, &z)) return false;
+
+    mat.X = mat.A.num->transpose() * z;
+
+    for(int c = 0; c < mat.n; c++) {
+        mat.X[c] *= mat.scale[c];
     }
     return true;
 }
@@ -365,6 +284,7 @@ bool System::NewtonSolve(int tag) {
     int i;
 
     // Evaluate the functions at our operating point.
+    mat.B.num = Eigen::VectorXd(mat.m);
     for(i = 0; i < mat.m; i++) {
         mat.B.num[i] = (mat.B.sym[i])->Eval();
     }
@@ -583,13 +503,12 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
 
 didnt_converge:
     SK.constraint.ClearTags();
-    // Not using range-for here because index is used in additional ways
-    for(i = 0; i < eq.n; i++) {
+    for(i = 0; i < mat.eq.size(); i++) {
         if(fabs(mat.B.num[i]) > CONVERGE_TOLERANCE || IsReasonable(mat.B.num[i])) {
             // This constraint is unsatisfied.
-            if(!mat.eq[i].isFromConstraint()) continue;
+            if(!mat.eq[i]->h.isFromConstraint()) continue;
 
-            hConstraint hc = mat.eq[i].constraint();
+            hConstraint hc = mat.eq[i]->h.constraint();
             ConstraintBase *c = SK.constraint.FindByIdNoOops(hc);
             if(!c) continue;
             // Don't double-show constraints that generated multiple
@@ -637,6 +556,10 @@ void System::Clear() {
     param.Clear();
     eq.Clear();
     dragged.Clear();
+    delete mat.A.num;
+    mat.A.num = NULL;
+    delete mat.A.sym;
+    mat.A.sym = NULL;
 }
 
 void System::MarkParamsFree(bool find) {

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -85,6 +85,60 @@ bool System::IsDragged(hParam p) {
     return false;
 }
 
+Param *System::GetLastParamSubstitution(Param *p) {
+    Param *current = p;
+    while(current->substd != NULL) {
+        current = current->substd;
+        if(current == p) {
+            // Break the loop
+            current->substd = NULL;
+            break;
+        }
+    }
+    return current;
+}
+
+void System::SortSubstitutionByDragged(Param *p) {
+    std::vector<Param *> subsParams;
+    Param *by = NULL;
+    Param *current = p;
+    while(current != NULL) {
+        subsParams.push_back(current);
+        if(IsDragged(current->h)) {
+            by = current;
+        }
+        current = current->substd;
+    }
+    if(by == NULL) by = p;
+    for(Param *p : subsParams) {
+       if(p == by) continue;
+       p->substd = by;
+       p->tag = VAR_SUBSTITUTED;
+    }
+    by->substd = NULL;
+    by->tag = 0;
+}
+
+void System::SubstituteParamsByLast(Expr *e) {
+    ssassert(e->op != Expr::Op::PARAM_PTR, "Expected an expression that refer to params via handles");
+
+    if(e->op == Expr::Op::PARAM) {
+        Param *p = param.FindByIdNoOops(e->parh);
+        if(p != NULL) {
+            Param *s = GetLastParamSubstitution(p);
+            if(s != NULL) {
+                e->parh = s->h;
+            }
+        }
+    } else {
+        int c = e->Children();
+        if(c >= 1) {
+            SubstituteParamsByLast(e->a);
+            if(c >= 2) SubstituteParamsByLast(e->b);
+        }
+    }
+}
+
 void System::SolveBySubstitution() {
     for(auto &teq : eq) {
         Expr *tex = teq.e;
@@ -102,25 +156,47 @@ void System::SolveBySubstitution() {
                 continue;
             }
 
-            if(IsDragged(a)) {
-                // A is being dragged, so A should stay, and B should go
-                std::swap(a, b);
+            if(a.v == b.v) {
+                teq.tag = EQ_SUBSTITUTED;
+                continue;
             }
 
-            for(auto &req : eq) {
-                req.e->Substitute(a, b); // A becomes B, B unchanged
-            }
-            for(auto &rp : param) {
-                if(rp.substd == a) {
-                    rp.substd = b;
+            Param *pa = param.FindById(a);
+            Param *pb = param.FindById(b);
+
+            // Take the last substitution of parameter a
+            // This resulted in creation of substitution chains
+            Param *last = GetLastParamSubstitution(pa);
+            last->substd = pb;
+            last->tag = VAR_SUBSTITUTED;
+
+            if(pb->substd != NULL) {
+                // Break the loops
+                GetLastParamSubstitution(pb);
+                // if b loop was broken
+                if(pb->substd == NULL) {
+                    // Clear substitution
+                    pb->tag = 0;
                 }
             }
-            Param *ptr = param.FindById(a);
-            ptr->tag = VAR_SUBSTITUTED;
-            ptr->substd = b;
-
             teq.tag = EQ_SUBSTITUTED;
         }
+    }
+
+    //
+    for(Param &p : param) {
+        SortSubstitutionByDragged(&p);
+    }
+
+    // Substitute all the equations
+    for(auto &req : eq) {
+        SubstituteParamsByLast(req.e);
+    }
+
+    // Substitute all the parameters with last substitutions
+    for(auto &p : param) {
+        if(p.substd == NULL) continue;
+        p.substd = GetLastParamSubstitution(p.substd);
     }
 }
 
@@ -485,7 +561,7 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
     for(auto &p : param) {
         double val;
         if(p.tag == VAR_SUBSTITUTED) {
-            val = param.FindById(p.substd)->val;
+            val = p.substd->val;
         } else {
             val = p.val;
         }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -411,17 +411,17 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
 {
     WriteEquationsExceptFor(Constraint::NO_CONSTRAINT, g);
 
-    int i;
     bool rankOk;
 
 /*
+    int x;
     dbp("%d equations", eq.n);
-    for(i = 0; i < eq.n; i++) {
-        dbp("  %.3f = %s = 0", eq[i].e->Eval(), eq[i].e->Print());
+    for(x = 0; x < eq.n; x++) {
+        dbp("  %.3f = %s = 0", eq[x].e->Eval(), eq[x].e->Print());
     }
     dbp("%d parameters", param.n);
-    for(i = 0; i < param.n; i++) {
-        dbp("   param %08x at %.3f", param[i].h.v, param[i].val);
+    for(x = 0; x < param.n; x++) {
+        dbp("   param %08x at %.3f", param[x].h.v, param[x].val);
     } */
 
     // All params and equations are assigned to group zero.
@@ -504,7 +504,7 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
 didnt_converge:
     SK.constraint.ClearTags();
     // Not using range-for here because index is used in additional ways
-    for(i = 0; i < mat.eq.size(); i++) {
+    for(size_t i = 0; i < mat.eq.size(); i++) {
         if(fabs(mat.B.num[i]) > CONVERGE_TOLERANCE || IsReasonable(mat.B.num[i])) {
             // This constraint is unsatisfied.
             if(!mat.eq[i]->h.isFromConstraint()) continue;

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -261,6 +261,8 @@ void TextWindow::ScreenChangeGroupOption(int link, uint32_t v) {
 
         case 'e': g->allowRedundant = !(g->allowRedundant); break;
 
+        case 'D': g->suppressDofCalculation = !(g->suppressDofCalculation); break;
+
         case 'v': g->visible = !(g->visible); break;
 
         case 'd': g->allDimsReference = !(g->allDimsReference); break;
@@ -510,6 +512,10 @@ void TextWindow::ShowGroupInfo() {
     Printf(false, " %f%Le%Fd%s  allow redundant constraints",
         &TextWindow::ScreenChangeGroupOption,
         g->allowRedundant ? CHECK_TRUE : CHECK_FALSE);
+
+    Printf(false, " %f%LD%Fd%s  suppress dof calculation (improves solver performance)",
+        &TextWindow::ScreenChangeGroupOption,
+        g->suppressDofCalculation ? CHECK_TRUE : CHECK_FALSE);
 
     Printf(false, " %f%Ld%Fd%s  treat all dimensions as reference",
         &TextWindow::ScreenChangeGroupOption,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,7 @@
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
+#include "utileigen.h"
 
 void SolveSpace::AssertFailure(const char *file, unsigned line, const char *function,
                                const char *condition, const char *message) {
@@ -541,8 +542,8 @@ Vector Vector::InPerspective(Vector u, Vector v, Vector n,
 }
 
 double Vector::DistanceToLine(Vector p0, Vector dp) const {
-    double m = dp.Magnitude();
-    return ((this->Minus(p0)).Cross(dp)).Magnitude() / m;
+    // call free function implementing this using Eigen
+    return SolveSpace::DistanceToLine(*this, p0, dp);
 }
 
 double Vector::DistanceToPlane(Vector normal, Vector origin) const {

--- a/src/utileigen.h
+++ b/src/utileigen.h
@@ -1,0 +1,79 @@
+//-----------------------------------------------------------------------------
+// Inlined implementations of some math operations using Eigen.
+//
+// Copyright 2008-2013 Jonathan Westhues.
+// Copyright 2018 Ryan Pavlik.
+//-----------------------------------------------------------------------------
+#ifndef __UTILEIGEN_H
+#define __UTILEIGEN_H
+
+#include "solvespace.h"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <unsupported/Eigen/AlignedVector3>
+
+namespace SolveSpace {
+
+/// A 3D vector of doubles using Eigen
+using EiVector3 = Eigen::Vector3d;
+
+/// A 3D vector of doubles using Eigen, with an extra double making it alignable for Eigen's SIMD
+///
+/// Higher performance, but harder to store in a structure
+/// because it needs to be over-aligned.
+using EiAlignedVector3 = Eigen::AlignedVector3<double>;
+
+/// A 4D vector of doubles using Eigen
+using EiVector4 = Eigen::Vector4d;
+
+/// A (normalized) quaternion using Eigen, each component in doubles.
+using EiQuaternion = Eigen::Quaterniond;
+
+/// Wrap a SolveSpace::Vector in an Eigen map object so Eigen can use it like an EiVector3 without
+/// copies.
+///
+/// You can use this to initialize a new EiAlignedVector3 (or EiVector3) if you want a fast local
+/// copy.
+inline Eigen::Map<EiVector3> map(Vector& v) {
+    return EiVector3::Map(&v.x);
+}
+
+/// Wrap a (constant) SolveSpace::Vector in an Eigen map object so Eigen can use it like an
+/// EiVector3 without copies.
+///
+/// You can use this to initialize a new EiAlignedVector3 (or EiVector3) if you want a fast local
+/// copy.
+inline Eigen::Map<const EiVector3> map(Vector const& v) {
+    return EiVector3::Map(&v.x);
+}
+
+/// Copy a SolveSpace::Vector4 to an Eigen EiVector4.
+///
+/// Can't map here, unfortunately, since element order differs.
+inline EiVector4 to_eigen(Vector4 const& v) {
+    return EiVector4(v.x, v.y, v.z, v.w);
+}
+
+inline double DistanceToLine(EiAlignedVector3 const& point, EiAlignedVector3 const& p0,
+                             EiAlignedVector3 const& dp) {
+    return (point - p0).cross(dp).norm() / dp.norm();
+}
+
+inline double DistanceToLine(Vector const& point, Vector const& p0, Vector const& dp) {
+    EiAlignedVector3 epoint = map(point);
+    EiAlignedVector3 ep0    = map(p0);
+    EiAlignedVector3 edp    = map(dp);
+    return DistanceToLine(epoint, ep0, edp);
+}
+
+
+inline double DistanceToLineFromEndpoints(Vector const& point, Vector const& p0, Vector const& p1) {
+    EiAlignedVector3 epoint = map(point);
+    EiAlignedVector3 ep0    = map(p0);
+    EiAlignedVector3 dp     = map(p1) - ep0;
+    return DistanceToLine(epoint, ep0, dp);
+}
+
+} // namespace SolveSpace
+#endif


### PR DESCRIPTION
Not sure why this fails as follows in the the test suite with asan:

```
cd /home/ryan/src/third-party/solvespace/build/test && /home/ryan/src/third-party/solvespace/build/bin/solvespace-testsuite
Missing (absent) translation for group-name'#references'
Missing (absent) translation for group-name'sketch-in-plane'
Reserved room for 0 symbols in B, used 0 with 0 params used.
AddressSanitizer:DEADLYSIGNAL
=================================================================
==69704==ERROR: AddressSanitizer: SEGV on unknown address 0x60400010c410 (pc 0x5609599c70d0 bp 0x6160000001b8 sp 0x7ffe014a1950 T0)
==69704==The signal is caused by a READ memory access.
    #0 0x5609599c70d0 in Eigen::SparseMatrix<SolveSpace::Expr*, 0, int>::insert(long, long) extlib/eigen/Eigen/src/SparseCore/SparseMatrix.h:1286
    #1 0x56095999e592 in operator() src/system.cpp:124
    #2 0x56095999e592 in iterateUsedParameters<SolveSpace::System::WriteJacobian(int)::<lambda(const SolveSpace::hParam&, int)> > src/system.cpp:63
    #3 0x56095999e592 in SolveSpace::System::WriteJacobian(int) src/system.cpp:118
    #4 0x5609599add9a in SolveSpace::System::Solve(SolveSpace::Group*, int*, int*, SolveSpace::List<SolveSpace::hConstraint>*, bool, bool, bool) src/system.cpp:527
    #5 0x56095974c4f8 in SolveSpace::SolveSpaceUI::SolveGroup(SolveSpace::hGroup, bool) src/generate.cpp:539
    #6 0x56095974c706 in SolveSpace::SolveSpaceUI::SolveGroupAndReport(SolveSpace::hGroup, bool) src/generate.cpp:493
    #7 0x56095975e66d in SolveSpace::SolveSpaceUI::GenerateAll(SolveSpace::SolveSpaceUI::Generate, bool, bool) src/generate.cpp:273
    #8 0x560959760b4b in SolveSpace::SolveSpaceUI::GenerateAll(SolveSpace::SolveSpaceUI::Generate, bool, bool) src/generate.cpp:196
    #9 0x5609595035b1 in SolveSpace::SolveSpaceUI::AfterNewFile() src/solvespace.cpp:516
    #10 0x560959457bdf in SolveSpace::Test::Helper::CheckLoad(char const*, int, char const*) test/harness.cpp:216
    #11 0x5609594fb106 in Test_normal_migrate_from_v22 test/constraint/length_difference/test.cpp:10
    #12 0x560959415a50 in std::function<void (SolveSpace::Test::Helper*)>::operator()(SolveSpace::Test::Helper*) const /usr/include/c++/10/bits/std_function.h:622
    #13 0x560959415a50 in main test/harness.cpp:373
    #14 0x7fd8fb4c5d09 in __libc_start_main ../csu/libc-start.c:308
    #15 0x56095944ead9 in _start (/home/ryan/src/third-party/solvespace/build/bin/solvespace-testsuite+0xb36ad9)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV extlib/eigen/Eigen/src/SparseCore/SparseMatrix.h:1286 in Eigen::SparseMatrix<SolveSpace::Expr*, 0, int>::insert(long, long)
==69704==ABORTING

```