### PR TITLE
CMake Fixes + Snap port to core20

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -15,9 +15,9 @@
         <key>CFBundlePackageType</key>
         <string>APPL</string>
         <key>CFBundleVersion</key>
-        <string>${solvespace_VERSION_MAJOR}.${solvespace_VERSION_MINOR}~${solvespace_GIT_HASH}</string>
+        <string>${PROJECT_VERSION}~${solvespace_GIT_HASH}</string>
         <key>CFBundleShortVersionString</key>
-        <string>${solvespace_VERSION_MAJOR}.${solvespace_VERSION_MINOR}</string>
+        <string>${PROJECT_VERSION}</string>
         <key>NSHumanReadableCopyright</key>
         <string>© 2008-2016 Jonathan Westhues and other authors</string>
         <key>NSPrincipalClass</key>

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: solvespace
-base: core18
+base: core20
 summary: Parametric 2d/3d CAD
 adopt-info: solvespace
 description: |
@@ -14,6 +14,7 @@ description: |
 
 confinement: strict
 license: GPL-3.0
+compression: lzo
 
 layout:
   /usr/share/solvespace:
@@ -23,13 +24,11 @@ apps:
   solvespace:
     command: usr/bin/solvespace
     desktop: solvespace.desktop
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     plugs: [opengl, unity7, home, removable-media, gsettings, network]
-    environment:
-      __EGL_VENDOR_LIBRARY_DIRS: $SNAP/gnome-platform/usr/share/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
   cli:
     command: usr/bin/solvespace-cli
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
     plugs: [home, removable-media, network]
 
 parts:
@@ -39,20 +38,24 @@ parts:
     source-type: local
     override-pull: |
       snapcraftctl pull
-      version_major=$(grep "solvespace_VERSION_MAJOR" CMakeLists.txt | tr -d "()" | cut -d" " -f2)
-      version_minor=$(grep "solvespace_VERSION_MINOR" CMakeLists.txt | tr -d "()" | cut -d" " -f2)
-      version="$version_major.$version_minor~$(git rev-parse --short=8 HEAD)"
+      git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen
+    override-build: |
+      snapcraftctl build
+      project_version=$(grep CMAKE_PROJECT_VERSION:STATIC CMakeCache.txt | cut -d "=" -f2)
+      cd $SNAPCRAFT_PART_SRC
+      version="$project_version~$(git rev-parse --short=8 HEAD)"
       snapcraftctl set-version "$version"
       git describe --exact-match HEAD && grade="stable" || grade="devel"
       snapcraftctl set-grade "$grade"
-      git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen
-    configflags:
+    cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_TESTS=OFF
       - -DSNAP=ON
       - -DENABLE_OPENMP=ON
       - -DENABLE_LTO=ON
+    build-snaps:
+      - gnome-3-38-2004-sdk
     build-packages:
       - zlib1g-dev
       - libpng-dev
@@ -63,7 +66,6 @@ parts:
       - libsigc++-2.0-dev
       - libspnav-dev
       - git
-      - g++
     stage-packages:
       - libspnav0
       - libsigc++-2.0-0v5
@@ -71,11 +73,14 @@ parts:
   cleanup:
     after: [solvespace]
     plugin: nil
-    build-snaps: [core18, gnome-3-34-1804]
+    build-snaps: [gnome-3-38-2004]
     override-prime: |
-      # Remove all files from snap that are already included in the base snap or in
-      # any connected content snaps
       set -eux
-      for snap in "core18" "gnome-3-34-1804"; do  # List all content-snaps and base snaps you're using here
-        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
+      for snap in "gnome-3-38-2004"; do  # List all content-snaps you're using here
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" "$SNAPCRAFT_PRIME/usr/{}" \;
       done
+      for cruft in bug lintian man; do
+        rm -rf $SNAPCRAFT_PRIME/usr/share/$cruft
+      done
+      find $SNAPCRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
+      find $SNAPCRAFT_PRIME/usr/share -type d -empty -delete

--- a/res/win32/versioninfo.rc.in
+++ b/res/win32/versioninfo.rc.in
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-FILEVERSION     ${solvespace_VERSION_MAJOR},${solvespace_VERSION_MINOR},0,0
-PRODUCTVERSION  ${solvespace_VERSION_MAJOR},${solvespace_VERSION_MINOR},0,0
+FILEVERSION     ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},0,0
+PRODUCTVERSION  ${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},0,0
 FILEFLAGSMASK   0
 FILEFLAGS       0
 FILEOS          VOS_NT_WINDOWS32
@@ -13,9 +13,9 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "The SolveSpace authors"
             VALUE "ProductName",      "SolveSpace"
-            VALUE "ProductVersion",   "${solvespace_VERSION_MAJOR}.${solvespace_VERSION_MINOR}~${solvespace_GIT_HASH}"
+            VALUE "ProductVersion",   "${PROJECT_VERSION}~${solvespace_GIT_HASH}"
             VALUE "FileDescription",  "SolveSpace, a parametric 2d/3d CAD"
-            VALUE "FileVersion",      "${solvespace_VERSION_MAJOR}.${solvespace_VERSION_MINOR}~${solvespace_GIT_HASH}"
+            VALUE "FileVersion",      "${PROJECT_VERSION}~${solvespace_GIT_HASH}"
             VALUE "OriginalFilename", "solvespace.exe"
             VALUE "InternalName",     "solvespace"
             VALUE "LegalCopyright",   "(c) 2008-2021 Jonathan Westhues and other authors"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(slvs PRIVATE slvs_deps)
 
 set_target_properties(slvs PROPERTIES
     PUBLIC_HEADER ${CMAKE_SOURCE_DIR}/include/slvs.h
-    VERSION ${solvespace_VERSION_MAJOR}.${solvespace_VERSION_MINOR}
+    VERSION ${PROJECT_VERSION}
     SOVERSION 1)
 
 if(NOT WIN32)
@@ -204,7 +204,7 @@ if(HAVE_GETTEXT)
                 --keyword --keyword=_ --keyword=N_ --keyword=C_:2,1c --keyword=CN_:2,1c
                 --force-po --width=100 --sort-by-file
                 --package-name=SolveSpace
-                --package-version=${solvespace_VERSION_MAJOR}.${solvespace_VERSION_MINOR}
+                --package-version=${PROJECT_VERSION}
                 "--copyright-holder=the PACKAGE authors"
                 --msgid-bugs-address=whitequark@whitequark.org
                 --from-code=utf-8 --output=${gen_output_pot} ${inputs}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,6 +308,10 @@ if(ENABLE_GUI)
             ${GTKMM_INCLUDE_DIRS}
             ${JSONC_INCLUDE_DIRS}
             ${FONTCONFIG_INCLUDE_DIRS})
+        target_link_directories(solvespace PRIVATE
+            ${GTKMM_LIBRARY_DIRS}
+            ${JSONC_LIBRARY_DIRS}
+            ${FONTCONFIG_LIBRARY_DIRS})
         target_link_libraries(solvespace PRIVATE
             ${GTKMM_LIBRARIES}
             ${JSONC_LIBRARIES}

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,7 +1,7 @@
 #ifndef SOLVESPACE_CONFIG_H
 #define SOLVESPACE_CONFIG_H
 
-#define PACKAGE_VERSION "@solvespace_VERSION_MAJOR@.@solvespace_VERSION_MINOR@~@solvespace_GIT_HASH@"
+#define PACKAGE_VERSION "@PROJECT_VERSION@~@solvespace_GIT_HASH@"
 
 /* Non-OS X *nix only */
 #define UNIX_DATADIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DATAROOTDIR@/solvespace"


### PR DESCRIPTION
In 006539b, solvespace_MAJOR_VERSION etc. were removed.
However, these variables were still referenced in some places.
Solution: Use PROJECT_VERSION instead.

006539b removed the call to link_directories for gtkmm, jsonc & fontconfig.
This leads to linking errors if those libraries are in "non-standard"
paths.
Fix this by introducing a target specific target_link_directories call.

Fixes #1173

Moving to core20 was long overdue anyway, and
the recent CMake changes necessitated some fixes.
Also switch to LZO compression for (way) better cold start
performance.

I left the CMake commits separate for easier review. I/we can squash them before merging.