### PR TITLE
snap: add g++ as build package

### DIFF
--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -66,6 +66,7 @@ parts:
       - libsigc++-2.0-dev
       - libspnav-dev
       - git
+      - g++
     stage-packages:
       - libspnav0
       - libsigc++-2.0-0v5


### PR DESCRIPTION
It got dropped in 34efb6de77 by mistake.