### PR TITLE
Fix various typos

### DIFF
--- a/src/importmesh.cpp
+++ b/src/importmesh.cpp
@@ -10,7 +10,7 @@
 
 #define MIN_POINT_DISTANCE 0.001
 
-// we will check for duplicate verticies and keep all their normals
+// we will check for duplicate vertices and keep all their normals
 class vertex {
 public:
     Vector p;
@@ -171,7 +171,7 @@ bool LinkStl(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *s
         addUnique(verts, tr.b, normal);
         addUnique(verts, tr.c, normal);
     }
-    dbp("%d verticies", verts.size());
+    dbp("%d vertices", verts.size());
 
     BBox box = {};
     box.minp = verts[0].p;

--- a/src/ttf.cpp
+++ b/src/ttf.cpp
@@ -11,7 +11,7 @@
 #include FT_ADVANCES_H
 
 /* Yecch. Irritatingly, you need to do this nonsense to get the error string table,
-   since nobody thought to put this exact function into FreeType isself. */
+   since nobody thought to put this exact function into FreeType itself. */
 #undef __FTERRORS_H__
 #define FT_ERRORDEF(e, v, s) { (e), (s) },
 #define FT_ERROR_START_LIST

--- a/src/ttf.cpp
+++ b/src/ttf.cpp
@@ -11,7 +11,7 @@
 #include FT_ADVANCES_H
 
 /* Yecch. Irritatingly, you need to do this nonsense to get the error string table,
-   since nobody thought to put this exact function into FreeType itsself. */
+   since nobody thought to put this exact function into FreeType isself. */
 #undef __FTERRORS_H__
 #define FT_ERRORDEF(e, v, s) { (e), (s) },
 #define FT_ERROR_START_LIST


### PR DESCRIPTION
Found via `codespell -q 3 -S ./res/locales,./extlib -L asign,ba,hsi,mata,pinter,tothe,wser`