### PR TITLE
Hide edit boxes before closing the property browser.

### DIFF
--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -235,6 +235,7 @@ void TextWindow::Init() {
 
             using namespace std::placeholders;
             window->onClose = []() {
+                SS.TW.HideEditControl();
                 SS.GW.showTextWindow = false;
                 SS.GW.EnsureValidActives();
             };


### PR DESCRIPTION
When the text window/property browser is closed while and edit box
is active its window remained open. This is incorrect and probably
causes a hang on Linux described in #1168. So hide the edit control
when closing.

Probably Fixes #1168 