### PR TITLE
Load 16bit PNG images correctly by re-scaling to 8bit

### DIFF
--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -179,7 +179,8 @@ void Pixmap::ConvertTo(Format newFormat) {
 
 static std::shared_ptr<Pixmap> ReadPngIntoPixmap(png_struct *png_ptr, png_info *info_ptr,
                                                  bool flip) {
-    png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_EXPAND | PNG_TRANSFORM_GRAY_TO_RGB, NULL);
+    png_read_png(png_ptr, info_ptr,
+                 PNG_TRANSFORM_EXPAND | PNG_TRANSFORM_GRAY_TO_RGB | PNG_TRANSFORM_SCALE_16, NULL);
 
     std::shared_ptr<Pixmap> pixmap = std::make_shared<Pixmap>();
     pixmap->width    = png_get_image_width(png_ptr, info_ptr);


### PR DESCRIPTION
Fixes #1110