### PR TITLE
Fix resolve of relative path of assembly group.

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -415,7 +415,8 @@ void SolveSpaceUI::LoadUsingTable(const Platform::Path &filename, char *key, cha
                 case 'P': {
                     Platform::Path path = Platform::Path::FromPortable(val);
                     if(!path.IsEmpty()) {
-                        p->P() = filename.Parent().Join(path).Expand();
+                        const Platform::Path &parent = filename.Parent();
+                        p->P() = parent.IsEmpty() ? path : parent.Join(path).Expand();
                     }
                     break;
                 }


### PR DESCRIPTION
If the path of the slvs file that refers to assemblies, the
Parent() of the file is empty, thus the Join() operation returns
an empty string, and loading a file with assemblies fails.
Fix: Don't Join() in that case.

Signed-off-by: Henner Zeller <h.zeller@acm.org>