### PR TITLE
Check for text STL when linking

### DIFF
--- a/src/importmesh.cpp
+++ b/src/importmesh.cpp
@@ -130,7 +130,7 @@ bool LinkStl(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *s
     char str[80] = {};
     f.read(str, 80);
     
-    if(str[0]=='s' && str[1]=='o' && str[2]=='l' && str[3]=='i' && str[4]=='d') {
+    if(0==memcmp("solid", str, 5)) {
     // we could display a message that text stl files are not supported
     // just returning false will trigger the warning that linked file is not present
     // best solution is to add an importer for text STL.

--- a/src/importmesh.cpp
+++ b/src/importmesh.cpp
@@ -131,9 +131,9 @@ bool LinkStl(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *s
     f.read(str, 80);
     
     if(0==memcmp("solid", str, 5)) {
-    // we could display a message that text stl files are not supported
     // just returning false will trigger the warning that linked file is not present
     // best solution is to add an importer for text STL.
+        Message(_("Text-formated STL files are not currently supported"));
         return false;
     }
     

--- a/src/importmesh.cpp
+++ b/src/importmesh.cpp
@@ -130,6 +130,13 @@ bool LinkStl(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *s
     char str[80] = {};
     f.read(str, 80);
     
+    if(str[0]=='s' && str[1]=='o' && str[2]=='l' && str[3]=='i' && str[4]=='d') {
+    // we could display a message that text stl files are not supported
+    // just returning false will trigger the warning that linked file is not present
+    // best solution is to add an importer for text STL.
+        return false;
+    }
+    
     uint32_t n;
     uint32_t color;
     


### PR DESCRIPTION
This is more of a WIP.  It no longer locks up if you link a text formated STL file, but the dialog we get is not helpful.