### PR TITLE
Fix normal issue, when a workplane is created from a point and normal…

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -136,6 +136,9 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
                         g.predef.negateV = wrkplg->predef.negateV;
                     } else if(wrkplg->subtype == Subtype::WORKPLANE_BY_POINT_ORTHO) {
                         g.predef.q = wrkplg->predef.q;
+                    } else if(wrkplg->subtype == Subtype::WORKPLANE_BY_POINT_NORMAL) {
+                        g.predef.q = wrkplg->predef.q;
+                        g.predef.entityB = wrkplg->predef.entityB;
                     } else ssassert(false, "Unexpected workplane subtype");
                 }
             } else if(gs.anyNormals == 1 && gs.points == 1 && gs.n == 2) {

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -140,6 +140,7 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
                 }
             } else if(gs.anyNormals == 1 && gs.points == 1 && gs.n == 2) {
                 g.subtype       = Subtype::WORKPLANE_BY_POINT_NORMAL;
+                g.predef.entityB = gs.anyNormal[0];
                 g.predef.q      = SK.GetEntity(gs.anyNormal[0])->NormalGetNum();
                 g.predef.origin = gs.point[0];
             //} else if(gs.faces == 1 && gs.points == 1 && gs.n == 2) {
@@ -455,9 +456,11 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                 if(predef.negateU) u = u.ScaledBy(-1);
                 if(predef.negateV) v = v.ScaledBy(-1);
                 q = Quaternion::From(u, v);
-            } else if(subtype == Subtype::WORKPLANE_BY_POINT_ORTHO || subtype == Subtype::WORKPLANE_BY_POINT_NORMAL /*|| subtype == Subtype::WORKPLANE_BY_POINT_FACE*/) {
+            } else if(subtype == Subtype::WORKPLANE_BY_POINT_ORTHO) {
                 // Already given, numerically.
                 q = predef.q;
+            } else if(subtype == Subtype::WORKPLANE_BY_POINT_NORMAL) {
+                q = SK.GetEntity(predef.entityB)->NormalGetNum();
             } else ssassert(false, "Unexpected workplane subtype");
 
             Entity normal = {};


### PR DESCRIPTION
… we were only storing the numeric normal so the plane (and subsequent extrusion) wouldn't follow if the sketch was on the face of a revolve. Now we store the handle to the defining normal it predef.entityB so it can update properly on regeneration.

Fixes #1120 