### PR TITLE
Add display of a circle length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 out/
 .vs/
 CMakeSettings.json
+
+# Qt
+CMakeLists.txt.user

--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -171,6 +171,7 @@ void TextWindow::DescribeSelection() {
                 double r = e->CircleGetRadiusNum();
                 Printf(true,  "   diameter =  %Fi%s", SS.MmToString(r*2).c_str());
                 Printf(false, "     radius =  %Fi%s", SS.MmToString(r).c_str());
+                Printf(false, " circle len =  %Fi%s", SS.MmToString(r*2*M_PI).c_str());
                 break;
             }
             case Entity::Type::FACE_NORMAL_PT:


### PR DESCRIPTION
Added display of a circle length referring to issue #1211 . Also added "CMakeLists.txt.user" to .gitignore as this unnecessary user-specific file is being generated by Qt/