### PR TITLE
CI: Use upstream action to build snap & drop arm64 snap

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,44 +123,10 @@ jobs:
     - name: Set Up Source
       run: rsync --filter=":- .gitignore" -r ./ pkg/snap/solvespace-snap-src
     - name: Build Snap
+      uses: snapcore/action-build@v1
       id: build
-      uses: diddlesnaps/snapcraft-multiarch-action@v1
       with:
         path: pkg/snap
-    - name: Upload & Release to Edge
-      if: github.event_name == 'push'
-      uses: snapcore/action-publish@v1
-      with:
-        store_login: ${{ secrets.SNAPSTORE_LOGIN }}
-        snap: ${{ steps.build.outputs.snap }}
-        release: edge
-    - name: Upload & Release to Beta + Edge
-      if: github.event_name == 'release'
-      uses: snapcore/action-publish@v1
-      with:
-        store_login: ${{ secrets.SNAPSTORE_LOGIN }}
-        snap: ${{ steps.build.outputs.snap }}
-        release: edge,beta
-
-  deploy_snap_arm64:
-    needs: [test_ubuntu, test_windows, test_macos]
-    name: Deploy ARM64 Snap
-    runs-on: ubuntu-latest
-    steps:
-    - uses: docker/setup-qemu-action@v1
-      with:
-        image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
-    - uses: actions/checkout@v2
-    - name: Fetch Tags
-      run: git fetch --force --tags
-    - name: Set Up Source
-      run: rsync --filter=":- .gitignore" -r ./ pkg/snap/solvespace-snap-src
-    - name: Build Snap
-      id: build
-      uses: diddlesnaps/snapcraft-multiarch-action@v1
-      with:
-        path: pkg/snap
-        architecture: arm64
     - name: Upload & Release to Edge
       if: github.event_name == 'push'
       uses: snapcore/action-publish@v1


### PR DESCRIPTION
Snapd stopped working in Docker containers in commit
https://github.com/snapcore/snapd/commit/c6011693a816f7f8a5b0c7858ddce91c6ef1a352

Therefore, we cannot use the current build action,
which relies on Docker to implement cross-compilation.
Switching to the upstream build action avoids the problem at the cost
of losing the arm64 builds on amd64 hardware.
Those need to be reintroduced by some other mechanism,
e.g. via Launchpad, in the future.

Fixes #1229