### PR TITLE
Use nullptr instead of NULL 

### DIFF
--- a/src/bsp.cpp
+++ b/src/bsp.cpp
@@ -23,8 +23,8 @@ SBsp3 *SBsp3::FromMesh(const SMesh *m) {
         swap(mc.l[k], mc.l[n]);
     }
 
-    SBsp3 *bsp3 = NULL;
-    for(auto &elt : mc.l) { bsp3 = InsertOrCreate(bsp3, &elt, NULL); }
+    SBsp3 *bsp3 = nullptr;
+    for(auto &elt : mc.l) { bsp3 = InsertOrCreate(bsp3, &elt, nullptr); }
     mc.Clear();
     return bsp3;
 }
@@ -437,7 +437,7 @@ SBsp3 *SBsp3::InsertConvex(STriMeta meta, Vector *vertex, size_t cnt, SMesh *ins
 }
 
 SBsp3 *SBsp3::InsertOrCreate(SBsp3 *where, STriangle *tr, SMesh *instead) {
-    if(where == NULL) {
+    if(where == nullptr) {
         if(instead) {
             // ruevs: I do not think this code is reachable, but in
             // principle should we use instead->keepInsideOtherShell
@@ -447,7 +447,7 @@ SBsp3 *SBsp3::InsertOrCreate(SBsp3 *where, STriangle *tr, SMesh *instead) {
             } else {
                 instead->AddTriangle(tr->meta, tr->a, tr->b, tr->c);
             }
-            return NULL;
+            return nullptr;
         }
 
         // Brand new node; so allocate for it, and fill us in.
@@ -541,7 +541,7 @@ Vector SBsp2::IntersectionWith(Vector a, Vector b) const {
 }
 
 SBsp2 *SBsp2::InsertOrCreateEdge(SBsp2 *where, SEdge *nedge, Vector nnp, Vector out) {
-    if(where == NULL) {
+    if(where == nullptr) {
         // Brand new node; so allocate for it, and fill us in.
         SBsp2 *r = Alloc();
         r->np = nnp;

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -88,13 +88,13 @@ void GraphicsWindow::CopySelection() {
         Request::Type req;
         int pts;
         if(!EntReqTable::GetEntityInfo(e->type, e->extraPoints,
-                &req, &pts, NULL, &hasDistance))
+                &req, &pts, nullptr, &hasDistance))
         {
             if(!e->h.isFromRequest()) continue;
             Request *r = SK.GetRequest(e->h.request());
             if(r->type != Request::Type::DATUM_POINT) continue;
             EntReqTable::GetEntityInfo((Entity::Type)0, e->extraPoints,
-                &req, &pts, NULL, &hasDistance);
+                &req, &pts, nullptr, &hasDistance);
         }
         if(req == Request::Type::WORKPLANE) continue;
 
@@ -196,7 +196,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
         bool hasDistance;
         int i, pts;
         EntReqTable::GetRequestInfo(r->type, r->extraPoints,
-            NULL, &pts, NULL, &hasDistance);
+            nullptr, &pts, nullptr, &hasDistance);
         for(i = 0; i < pts; i++) {
             Vector pt = cr->point[i];
             // We need the reflection to occur within the workplane; it may

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -704,7 +704,7 @@ void GraphicsWindow::Draw(Canvas *canvas) {
     if(showSnapGrid) DrawSnapGrid(canvas);
 
     // Draw all the things that don't change when we rotate.
-    if(persistentCanvas != NULL) {
+    if(persistentCanvas != nullptr) {
         if(persistentDirty) {
             persistentDirty = false;
 
@@ -858,7 +858,7 @@ void GraphicsWindow::Draw(Canvas *canvas) {
 }
 
 void GraphicsWindow::Paint() {
-    ssassert(window != NULL && canvas != NULL,
+    ssassert(window != nullptr && canvas != nullptr,
              "Cannot paint without window and canvas");
 
     havePainted = true;

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -1304,7 +1304,7 @@ s:
 }
 
 void Constraint::Draw(DrawAs how, Canvas *canvas) {
-    DoLayout(how, canvas, NULL, NULL);
+    DoLayout(how, canvas, nullptr, nullptr);
 }
 
 Vector Constraint::GetLabelPos(const Camera &camera) {
@@ -1312,7 +1312,7 @@ Vector Constraint::GetLabelPos(const Camera &camera) {
 
     ObjectPicker canvas = {};
     canvas.camera = camera;
-    DoLayout(DrawAs::DEFAULT, &canvas, &p, NULL);
+    DoLayout(DrawAs::DEFAULT, &canvas, &p, nullptr);
     canvas.Clear();
 
     return p;
@@ -1321,7 +1321,7 @@ Vector Constraint::GetLabelPos(const Camera &camera) {
 void Constraint::GetReferencePoints(const Camera &camera, std::vector<Vector> *refs) {
     ObjectPicker canvas = {};
     canvas.camera = camera;
-    DoLayout(DrawAs::DEFAULT, &canvas, NULL, refs);
+    DoLayout(DrawAs::DEFAULT, &canvas, nullptr, refs);
     canvas.Clear();
 }
 

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -435,7 +435,7 @@ void Entity::GenerateBezierCurves(SBezierList *sbl) const {
                 // The control point must lie on both tangents.
                 Vector p1 = Vector::AtIntersectionOfLines(p0, p0.Plus(t0),
                                                           p2, p2.Plus(t2),
-                                                          NULL);
+                                                          nullptr);
 
                 SBezier sb = SBezier::From(p0, p1, p2);
                 sb.weight[1] = cos(dtheta/2);
@@ -809,7 +809,7 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
             Vector iu = v[3].Minus(v[0]);
             Vector iv = v[1].Minus(v[0]);
 
-            if(how == DrawAs::DEFAULT && pixmap == NULL) {
+            if(how == DrawAs::DEFAULT && pixmap == nullptr) {
                 Canvas::Stroke stroke = Style::Stroke(Style::DRAW_ERROR);
                 stroke.color = stroke.color.WithAlpha(50);
                 Canvas::hStroke hs = canvas->GetStroke(stroke);

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -79,7 +79,7 @@ void SolveSpaceUI::ExportSectionTo(const Platform::Path &filename) {
 
     // If there's a shell, then grab the edges and possibly Beziers.
     bool export_as_pwl = SS.exportPwlCurves || fabs(SS.exportOffset) > LENGTH_EPS;
-    g->runningShell.MakeSectionEdgesInto(n, d, &el, export_as_pwl ? NULL : &bl);
+    g->runningShell.MakeSectionEdgesInto(n, d, &el, export_as_pwl ? nullptr : &bl);
 
     // All of these are solid model edges, so use the appropriate style.
     SEdge *se;
@@ -117,7 +117,7 @@ void SolveSpaceUI::ExportSectionTo(const Platform::Path &filename) {
     VectorFileWriter *out = VectorFileWriter::ForFile(filename);
     if(out) {
         // parallel projection (no perspective), and no mesh
-        ExportLinesAndMesh(&el, &bl, NULL,
+        ExportLinesAndMesh(&el, &bl, nullptr,
                            u, v, n, origin, 0,
                            out);
     }
@@ -194,14 +194,14 @@ void SolveSpaceUI::ExportViewOrWireframeTo(const Platform::Path &filename, bool 
     SS.exportMode = true;
     GenerateAll(Generate::ALL);
 
-    SMesh *sm = NULL;
+    SMesh *sm = nullptr;
     if(SS.GW.showShaded || SS.GW.drawOccludedAs != GraphicsWindow::DrawOccludedAs::VISIBLE) {
         Group *g = SK.GetGroup(SS.GW.activeGroup);
         g->GenerateDisplayItems();
         sm = &(g->displayMesh);
     }
     if(sm && sm->IsEmpty()) {
-        sm = NULL;
+        sm = nullptr;
     }
 
     for(auto &entity : SK.entity) {
@@ -305,7 +305,7 @@ void SolveSpaceUI::ExportWireframeCurves(SEdgeList *sel, SBezierList *sbl,
         sblss.AddOpenPath(sb);
     }
 
-    out->OutputLinesAndMesh(&sblss, NULL);
+    out->OutputLinesAndMesh(&sblss, nullptr);
     sblss.Clear();
 }
 
@@ -338,7 +338,7 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
     if(fabs(SS.exportOffset) > LENGTH_EPS) {
         // assemble those edges into a polygon, and clear the edge list
         SPolygon sp = {};
-        sel->AssemblePolygon(&sp, NULL);
+        sel->AssemblePolygon(&sp, nullptr);
         sel->Clear();
 
         SPolygon compd = {};
@@ -406,7 +406,7 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
         // to back-facing.
         if(SS.GW.showEdges || SS.GW.showOutlines) {
             root->MakeCertainEdgesInto(sel, EdgeKind::TURNING,
-                                       /*coplanarIsInter=*/false, NULL, NULL,
+                                       /*coplanarIsInter=*/false, nullptr, nullptr,
                                        GW.showOutlines ? Style::OUTLINE : Style::SOLID_EDGE);
         }
 
@@ -599,7 +599,7 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
     sblss.FindOuterFacesFrom(sbl, &spxyz, &srf,
                              SS.ExportChordTolMm(),
                              &allClosed, &notClosedAt,
-                             NULL, NULL,
+                             nullptr, nullptr,
                              &leftovers);
     sblss.l.Add(&leftovers);
 
@@ -649,7 +649,7 @@ VectorFileWriter *VectorFileWriter::ForFile(const Platform::Path &filename) {
         ".step, .stp, .dxf, .svg, .plt, .hpgl, .pdf, .txt, .ngc, "
         ".eps, or .ps.",
             filename.raw.c_str());
-        return NULL;
+        return nullptr;
     }
     ret->filename = filename;
     if(!needOpen) return ret;
@@ -657,7 +657,7 @@ VectorFileWriter *VectorFileWriter::ForFile(const Platform::Path &filename) {
     FILE *f = OpenFile(filename, "wb");
     if(!f) {
         Error("Couldn't write to '%s'", filename.raw.c_str());
-        return NULL;
+        return nullptr;
     }
     ret->f = f;
     return ret;

--- a/src/exportstep.cpp
+++ b/src/exportstep.cpp
@@ -136,7 +136,7 @@ int StepFileWriter::ExportCurveLoop(SBezierLoop *loop, bool inner) {
         int curveId = ExportCurve(sb);
 
         int thisFinish;
-        if(loop->l.NextAfter(sb) != NULL) {
+        if(loop->l.NextAfter(sb) != nullptr) {
             fprintf(f, "#%d=CARTESIAN_POINT('',(%.10f,%.10f,%.10f));\n",
                 id, CO(sb->Finish()));
             fprintf(f, "#%d=VERTEX_POINT('',#%d);\n", id+1, id);
@@ -162,7 +162,7 @@ int StepFileWriter::ExportCurveLoop(SBezierLoop *loop, bool inner) {
     int *oe;
     for(oe = listOfTrims.First(); oe; oe = listOfTrims.NextAfter(oe)) {
         fprintf(f, "#%d", *oe);
-        if(listOfTrims.NextAfter(oe) != NULL) fprintf(f, ",");
+        if(listOfTrims.NextAfter(oe) != nullptr) fprintf(f, ",");
     }
     fprintf(f, "));\n");
 
@@ -239,8 +239,8 @@ void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
     sblss.FindOuterFacesFrom(sbl, &spxyz, ss,
                              SS.ExportChordTolMm(),
                              &allClosed, &notClosedAt,
-                             NULL, NULL,
-                             NULL);
+                             nullptr, nullptr,
+                             nullptr);
 
     // So in our list of SBezierLoopSet, each set contains at least one loop
     // (the outer boundary), plus any inner loops associated with that outer
@@ -269,7 +269,7 @@ void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
         int *fb;
         for(fb = listOfLoops.First(); fb; fb = listOfLoops.NextAfter(fb)) {
             fprintf(f, "#%d", *fb);
-            if(listOfLoops.NextAfter(fb) != NULL) fprintf(f, ",");
+            if(listOfLoops.NextAfter(fb) != nullptr) fprintf(f, ",");
         }
 
         fprintf(f, "),#%d,.T.);\n", srfid);
@@ -361,7 +361,7 @@ void StepFileWriter::ExportSurfacesTo(const Platform::Path &filename) {
         // Bezier split so that we use the section as t goes from 0 to 1), and
         // the piecewise linearization of those loops in xyz space.
         SBezierList sbl = {};
-        ss.MakeSectionEdgesInto(shell, NULL, &sbl);
+        ss.MakeSectionEdgesInto(shell, nullptr, &sbl);
 
         // Apply the export scale factor.
         ss.ScaleSelfBy(1.0/SS.exportScale);
@@ -376,7 +376,7 @@ void StepFileWriter::ExportSurfacesTo(const Platform::Path &filename) {
     int *af;
     for(af = advancedFaces.First(); af; af = advancedFaces.NextAfter(af)) {
         fprintf(f, "#%d", *af);
-        if(advancedFaces.NextAfter(af) != NULL) fprintf(f, ",");
+        if(advancedFaces.NextAfter(af) != nullptr) fprintf(f, ",");
     }
     fprintf(f, "));\n");
     fprintf(f, "#%d=MANIFOLD_SOLID_BREP('brep',#%d);\n", id+1, id);
@@ -396,7 +396,7 @@ void StepFileWriter::WriteWireframe() {
     int *c;
     for(c = curves.First(); c; c = curves.NextAfter(c)) {
         fprintf(f, "#%d", *c);
-        if(curves.NextAfter(c) != NULL) fprintf(f, ",");
+        if(curves.NextAfter(c) != nullptr) fprintf(f, ",");
     }
     fprintf(f, "));\n");
     fprintf(f, "#%d=GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION"

--- a/src/exportvector.cpp
+++ b/src/exportvector.cpp
@@ -581,7 +581,7 @@ void DxfFileWriter::FinishAndCloseFile() {
     std::stringstream stream;
     dxf.write(stream, &interface, DRW::AC1021, /*bin=*/false);
     paths.clear();
-    constraint = NULL;
+    constraint = nullptr;
 
     if(!WriteFile(filename, stream.str())) {
         Error("Couldn't write to '%s'", filename.raw.c_str());
@@ -1286,7 +1286,7 @@ void GCodeFileWriter::Bezier(SBezier *sb) {
 
 void GCodeFileWriter::FinishAndCloseFile() {
     SPolygon sp = {};
-    sel.AssemblePolygon(&sp, NULL);
+    sel.AssemblePolygon(&sp, nullptr);
 
     int i;
     for(i = 0; i < SS.gCode.passes; i++) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -614,7 +614,7 @@ public:
         TokenType  type;
         Expr      *expr;
 
-        static Token From(TokenType type = TokenType::ERROR, Expr *expr = NULL);
+        static Token From(TokenType type = TokenType::ERROR, Expr *expr = nullptr);
         static Token From(TokenType type, Expr::Op op);
         bool IsError() const { return type == TokenType::ERROR; }
     };
@@ -910,10 +910,10 @@ Expr *ExprParser::Parse(const std::string &input, std::string *error) {
     ExprParser parser;
     parser.it  = input.cbegin();
     parser.end = input.cend();
-    if(!parser.Parse(error)) return NULL;
+    if(!parser.Parse(error)) return nullptr;
 
     Token r = parser.PopOperand(error);
-    if(r.IsError()) return NULL;
+    if(r.IsError()) return nullptr;
     return r.expr;
 }
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -117,7 +117,7 @@ const SolveSpaceUI::SaveTable SolveSpaceUI::SAVED[] = {
     { 'g',  "Group.allDimsReference",   'b',    &(SS.sv.g.allDimsReference)   },
     { 'g',  "Group.scale",              'f',    &(SS.sv.g.scale)              },
     { 'g',  "Group.remap",              'M',    &(SS.sv.g.remap)              },
-    { 'g',  "Group.impFile",            'i',    NULL                          },
+    { 'g',  "Group.impFile",            'i',    nullptr                          },
     { 'g',  "Group.impFileRel",         'P',    &(SS.sv.g.linkFile)           },
 
     { 'p',  "Param.h.v.",               'x',    &(SS.sv.p.h.v)                },
@@ -206,7 +206,7 @@ const SolveSpaceUI::SaveTable SolveSpaceUI::SAVED[] = {
     { 's',  "Style.stippleType",        'd',    &(SS.sv.s.stippleType)        },
     { 's',  "Style.stippleScale",       'f',    &(SS.sv.s.stippleScale)       },
 
-    { 0, NULL, 0, NULL }
+    { 0, nullptr, 0, nullptr }
 };
 
 struct SAVEDptr {
@@ -431,7 +431,7 @@ void SolveSpaceUI::LoadUsingTable(const Platform::Path &filename, char *key, cha
                         EntityKey ek;
                         EntityId ei;
                         char line2[1024];
-                        if (fgets(line2, (int)sizeof(line2), fh) == NULL)
+                        if (fgets(line2, (int)sizeof(line2), fh) == nullptr)
                             break;
                         if(sscanf(line2, "%d %x %d", &(ei.v), &(ek.input.v),
                                                      &(ek.copyNumber)) == 3) {
@@ -584,12 +584,12 @@ void SolveSpaceUI::UpgradeLegacyData() {
                 // request would generate, then add them now, so that we can
                 // force them to their appropriate positions.
                 for(Param &p : param) {
-                    if(SK.param.FindByIdNoOops(p.h) != NULL) continue;
+                    if(SK.param.FindByIdNoOops(p.h) != nullptr) continue;
                     SK.param.Add(&p);
                 }
                 bool allPointsExist = true;
                 for(Entity &e : entity) {
-                    if(SK.entity.FindByIdNoOops(e.h) != NULL) continue;
+                    if(SK.entity.FindByIdNoOops(e.h) != nullptr) continue;
                     SK.entity.Add(&e);
                     allPointsExist = false;
                 }
@@ -625,7 +625,7 @@ void SolveSpaceUI::UpgradeLegacyData() {
         c.Generate(&param);
         bool allParamsExist = true;
         for(Param &p : param) {
-            if(oldParam.FindByIdNoOops(p.h) != NULL) continue;
+            if(oldParam.FindByIdNoOops(p.h) != nullptr) continue;
             allParamsExist = false;
             break;
         }
@@ -973,7 +973,7 @@ bool SolveSpaceUI::ReloadLinkedImage(const Platform::Path &saveFile,
         if(image != SS.images.end()) return true;
 
         pixmap = Pixmap::ReadPng(*filename);
-        if(pixmap == NULL) {
+        if(pixmap == nullptr) {
             // The file was moved; prompt the user for its new location.
             switch(LocateImportedFile(filename->RelativeTo(saveFile), canCancel)) {
                 case Platform::MessageDialog::Response::YES:
@@ -1002,7 +1002,7 @@ bool SolveSpaceUI::ReloadLinkedImage(const Platform::Path &saveFile,
             dialog->FreezeChoices(settings, "LinkImage");
             *filename = dialog->GetFilename();
             pixmap = Pixmap::ReadPng(*filename);
-            if(pixmap == NULL) {
+            if(pixmap == nullptr) {
                 Error("The image '%s' is corrupted.", filename->raw.c_str());
             }
             // We know where the file is now, good.

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -536,7 +536,7 @@ void SolveSpaceUI::SolveGroup(hGroup hg, bool andFindFree) {
     Group *g = SK.GetGroup(hg);
     g->solved.remove.Clear();
     g->solved.findToFixTimeout = SS.timeoutRedundantConstr;
-    SolveResult how = sys.Solve(g, NULL,
+    SolveResult how = sys.Solve(g, nullptr,
                                    &(g->solved.dof),
                                    &(g->solved.remove),
                                    /*andFindBad=*/!g->allowRedundant,

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -38,13 +38,13 @@ struct MenuEntry {
 #define KR    MenuKind::RADIO_MARK
 const MenuEntry Menu[] = {
 //lv label                              cmd                        accel    kind
-{ 0, N_("&File"),                       Command::NONE,             0,       KN, NULL   },
+{ 0, N_("&File"),                       Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&New"),                        Command::NEW,              C|'n',   KN, mFile  },
 { 1, N_("&Open..."),                    Command::OPEN,             C|'o',   KN, mFile  },
 { 1, N_("Open &Recent"),                Command::OPEN_RECENT,      0,       KN, mFile  },
 { 1, N_("&Save"),                       Command::SAVE,             C|'s',   KN, mFile  },
 { 1, N_("Save &As..."),                 Command::SAVE_AS,          0,       KN, mFile  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Export &Image..."),            Command::EXPORT_IMAGE,     0,       KN, mFile  },
 { 1, N_("Export 2d &View..."),          Command::EXPORT_VIEW,      0,       KN, mFile  },
 { 1, N_("Export 2d &Section..."),       Command::EXPORT_SECTION,   0,       KN, mFile  },
@@ -53,28 +53,28 @@ const MenuEntry Menu[] = {
 { 1, N_("Export &Surfaces..."),         Command::EXPORT_SURFACES,  0,       KN, mFile  },
 { 1, N_("Im&port..."),                  Command::IMPORT,           0,       KN, mFile  },
 #ifndef __APPLE__
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("E&xit"),                       Command::EXIT,             C|'q',   KN, mFile  },
 #endif
 
-{ 0, N_("&Edit"),                       Command::NONE,             0,       KN, NULL   },
+{ 0, N_("&Edit"),                       Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&Undo"),                       Command::UNDO,             C|'z',   KN, mEdit  },
 { 1, N_("&Redo"),                       Command::REDO,             C|'y',   KN, mEdit  },
 { 1, N_("Re&generate All"),             Command::REGEN_ALL,        ' ',     KN, mEdit  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Snap Selection to &Grid"),     Command::SNAP_TO_GRID,     '.',     KN, mEdit  },
 { 1, N_("Rotate Imported &90°"),        Command::ROTATE_90,        '9',     KN, mEdit  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Cu&t"),                        Command::CUT,              C|'x',   KN, mClip  },
 { 1, N_("&Copy"),                       Command::COPY,             C|'c',   KN, mClip  },
 { 1, N_("&Paste"),                      Command::PASTE,            C|'v',   KN, mClip  },
 { 1, N_("Paste &Transformed..."),       Command::PASTE_TRANSFORM,  C|'t',   KN, mClip  },
 { 1, N_("&Delete"),                     Command::DELETE,           '\x7f',  KN, mClip  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Select &Edge Chain"),          Command::SELECT_CHAIN,     C|'e',   KN, mEdit  },
 { 1, N_("Select &All"),                 Command::SELECT_ALL,       C|'a',   KN, mEdit  },
 { 1, N_("&Unselect All"),               Command::UNSELECT_ALL,     '\x1b',  KN, mEdit  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&Line Styles..."),             Command::EDIT_LINE_STYLES, 0,       KN, mEdit  },
 { 1, N_("&View Projection..."),         Command::VIEW_PROJECTION,  0,       KN, mEdit  },
 #ifndef __APPLE__
@@ -85,59 +85,59 @@ const MenuEntry Menu[] = {
 { 1, N_("Zoom &In"),                    Command::ZOOM_IN,          '+',     KN, mView  },
 { 1, N_("Zoom &Out"),                   Command::ZOOM_OUT,         '-',     KN, mView  },
 { 1, N_("Zoom To &Fit"),                Command::ZOOM_TO_FIT,      'f',     KN, mView  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Align View to &Workplane"),    Command::ONTO_WORKPLANE,   'w',     KN, mView  },
 { 1, N_("Nearest &Ortho View"),         Command::NEAREST_ORTHO,    F|2,     KN, mView  },
 { 1, N_("Nearest &Isometric View"),     Command::NEAREST_ISO,      F|3,     KN, mView  },
 { 1, N_("&Center View At Point"),       Command::CENTER_VIEW,      F|4,     KN, mView  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Show Snap &Grid"),             Command::SHOW_GRID,        '>',     KC, mView  },
 { 1, N_("Darken Inactive Solids"),      Command::DIM_SOLID_MODEL,  0,       KC, mView  },
 { 1, N_("Use &Perspective Projection"), Command::PERSPECTIVE_PROJ, '`',     KC, mView  },
 { 1, N_("Show E&xploded View"),         Command::EXPLODE_SKETCH,   '\\',    KC, mView  },
-{ 1, N_("Dimension &Units"),            Command::NONE,             0,       KN, NULL  },
+{ 1, N_("Dimension &Units"),            Command::NONE,             0,       KN, nullptr  },
 { 2, N_("Dimensions in &Millimeters"),  Command::UNITS_MM,         0,       KR, mView },
 { 2, N_("Dimensions in M&eters"),       Command::UNITS_METERS,     0,       KR, mView },
 { 2, N_("Dimensions in &Inches"),       Command::UNITS_INCHES,     0,       KR, mView },
 { 2, N_("Dimensions in &Feet and Inches"), Command::UNITS_FEET_INCHES, 0,   KR, mView },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Show &Toolbar"),               Command::SHOW_TOOLBAR,     0,       KC, mView  },
 { 1, N_("Show Property Bro&wser"),      Command::SHOW_TEXT_WND,    '\t',    KC, mView  },
-{ 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
+{ 1,  nullptr,                             Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&Full Screen"),                Command::FULL_SCREEN,      C|F|11,  KC, mView  },
 
 { 0, N_("&New Group"),                  Command::NONE,             0,       KN, mGrp   },
 { 1, N_("Sketch In &3d"),               Command::GROUP_3D,         S|'3',   KN, mGrp   },
 { 1, N_("Sketch In New &Workplane"),    Command::GROUP_WRKPL,      S|'w',   KN, mGrp   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Step &Translating"),           Command::GROUP_TRANS,      S|'t',   KN, mGrp   },
 { 1, N_("Step &Rotating"),              Command::GROUP_ROT,        S|'r',   KN, mGrp   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("E&xtrude"),                    Command::GROUP_EXTRUDE,    S|'x',   KN, mGrp   },
 { 1, N_("&Helix"),                      Command::GROUP_HELIX,      S|'h',   KN, mGrp   },
 { 1, N_("&Lathe"),                      Command::GROUP_LATHE,      S|'l',   KN, mGrp   },
 { 1, N_("Re&volve"),                    Command::GROUP_REVOLVE,    S|'v',   KN, mGrp   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Link / Assemble..."),          Command::GROUP_LINK,       S|'i',   KN, mGrp   },
 { 1, N_("Link Recent"),                 Command::GROUP_RECENT,     0,       KN, mGrp   },
 
 { 0, N_("&Sketch"),                     Command::NONE,             0,       KN, mReq   },
 { 1, N_("In &Workplane"),               Command::SEL_WORKPLANE,    '2',     KR, mReq   },
 { 1, N_("Anywhere In &3d"),             Command::FREE_IN_3D,       '3',     KR, mReq   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Datum &Point"),                Command::DATUM_POINT,      'p',     KN, mReq   },
 { 1, N_("&Workplane"),                  Command::WORKPLANE,        0,       KN, mReq   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Line &Segment"),               Command::LINE_SEGMENT,     's',     KN, mReq   },
 { 1, N_("C&onstruction Line Segment"),  Command::CONSTR_SEGMENT,   S|'s',   KN, mReq   },
 { 1, N_("&Rectangle"),                  Command::RECTANGLE,        'r',     KN, mReq   },
 { 1, N_("&Circle"),                     Command::CIRCLE,           'c',     KN, mReq   },
 { 1, N_("&Arc of a Circle"),            Command::ARC,              'a',     KN, mReq   },
 { 1, N_("&Bezier Cubic Spline"),        Command::CUBIC,            'b',     KN, mReq   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&Text in TrueType Font"),      Command::TTF_TEXT,         't',     KN, mReq   },
 { 1, N_("&Image"),                      Command::IMAGE,            0,       KN, mReq   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("To&ggle Construction"),        Command::CONSTRUCTION,     'g',     KN, mReq   },
 { 1, N_("Tangent &Arc at Point"),       Command::TANGENT_ARC,      S|'a',   KN, mReq   },
 { 1, N_("Split Curves at &Intersection"), Command::SPLIT_CURVES,   'i',     KN, mReq   },
@@ -149,10 +149,10 @@ const MenuEntry Menu[] = {
 { 1, N_("Reference An&gle"),            Command::REF_ANGLE,        S|'n',   KN, mCon   },
 { 1, N_("Other S&upplementary Angle"),  Command::OTHER_ANGLE,      'u',     KN, mCon   },
 { 1, N_("Toggle R&eference Dim"),       Command::REFERENCE,        'e',     KN, mCon   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&Horizontal"),                 Command::HORIZONTAL,       'h',     KN, mCon   },
 { 1, N_("&Vertical"),                   Command::VERTICAL,         'v',     KN, mCon   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&On Point / Curve / Plane"),   Command::ON_ENTITY,        'o',     KN, mCon   },
 { 1, N_("E&qual Length / Radius / Angle"), Command::EQUAL,         'q',     KN, mCon   },
 { 1, N_("Length / Arc Ra&tio"),         Command::RATIO,            'z',     KN, mCon   },
@@ -163,7 +163,7 @@ const MenuEntry Menu[] = {
 { 1, N_("&Perpendicular"),              Command::PERPENDICULAR,    '[',     KN, mCon   },
 { 1, N_("Same Orient&ation"),           Command::ORIENTED_SAME,    'x',     KN, mCon   },
 { 1, N_("Lock Point Where &Dragged"),   Command::WHERE_DRAGGED,    ']',     KN, mCon   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Comment"),                     Command::COMMENT,          ';',     KN, mCon   },
 
 { 0, N_("&Analyze"),                    Command::NONE,             0,       KN, mAna   },
@@ -173,9 +173,9 @@ const MenuEntry Menu[] = {
 { 1, N_("Show &Interfering Parts"),     Command::INTERFERENCE,     C|S|'i', KN, mAna   },
 { 1, N_("Show &Naked Edges"),           Command::NAKED_EDGES,      C|S|'n', KN, mAna   },
 { 1, N_("Show &Center of Mass"),        Command::CENTER_OF_MASS,   C|S|'c', KN, mAna   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("Show &Underconstrained Points"), Command::SHOW_DOF,       C|S|'f', KN, mAna   },
-{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, nullptr,                              Command::NONE,             0,       KN, nullptr   },
 { 1, N_("&Trace Point"),                Command::TRACE_PT,         C|S|'t', KN, mAna   },
 { 1, N_("&Stop Tracing..."),            Command::STOP_TRACING,     C|S|'s', KN, mAna   },
 { 1, N_("Step &Dimension..."),          Command::STEP_DIM,         C|S|'d', KN, mAna   },
@@ -187,7 +187,7 @@ const MenuEntry Menu[] = {
 #ifndef __APPLE__
 { 1, N_("&About"),                      Command::ABOUT,            0,       KN, mHelp  },
 #endif
-{ -1, 0,                                Command::NONE,             0,       KN, NULL   }
+{ -1, nullptr,                                Command::NONE,             0,       KN, nullptr   }
 };
 #undef S
 #undef C
@@ -279,7 +279,7 @@ void GraphicsWindow::PopulateMainMenu() {
             subMenuStack.pop_back();
         }
 
-        if(Menu[i].label == NULL) {
+        if(Menu[i].label == nullptr) {
             currentSubMenu->AddSeparator();
             continue;
         }
@@ -303,7 +303,7 @@ void GraphicsWindow::PopulateMainMenu() {
                     EnsureValidActives();
                 });
             }
-        } else if(Menu[i].fn == NULL) {
+        } else if(Menu[i].fn == nullptr) {
             subMenuStack.push_back(currentSubMenu);
             currentSubMenu = currentSubMenu->AddSubMenu(label);
         } else {
@@ -1172,7 +1172,7 @@ void GraphicsWindow::MenuEdit(Command id) {
 
         case Command::ROTATE_90: {
             SS.GW.GroupSelection();
-            Entity *e = NULL;
+            Entity *e = nullptr;
             if(SS.GW.gs.n == 1 && SS.GW.gs.points == 1) {
                 e = SK.GetEntity(SS.GW.gs.point[0]);
             } else if(SS.GW.gs.n == 1 && SS.GW.gs.entities == 1) {

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -328,7 +328,7 @@ void Group::MenuGroup(Command id, Platform::Path linkFile) {
     // Copy color from the previous mesh-contributing group.
     if(g.IsMeshGroup() && !SK.groupOrder.IsEmpty()) {
         Group *running = SK.GetRunningMeshGroupFor(SS.GW.activeGroup);
-        if(running != NULL) {
+        if(running != nullptr) {
             g.color = running->color;
         }
     }
@@ -403,7 +403,7 @@ bool Group::IsForcedToMeshBySource() const {
         if(srcg->forceToMesh) return true;
     }
     Group *g = srcg->RunningMeshGroup();
-    if(g == NULL) return false;
+    if(g == nullptr) return false;
     return g->forceToMesh || g->IsForcedToMeshBySource();
 }
 
@@ -515,7 +515,7 @@ void Group::Generate(IdList<Entity,hEntity> *entity,
                 if(e->IsPoint()) pt = e->h;
 
                 e->CalculateNumerical(/*forExport=*/false);
-                hEntity he = e->h; e = NULL;
+                hEntity he = e->h; e = nullptr;
                 // As soon as I call CopyEntity, e may become invalid! That
                 // adds entities, which may cause a realloc.
                 CopyEntity(entity, SK.GetEntity(he), ai, REMAP_BOTTOM,
@@ -1181,7 +1181,7 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
             int i, points;
             bool hasNormal, hasDistance;
             EntReqTable::GetEntityInfo(ep->type, ep->extraPoints,
-                NULL, &points, &hasNormal, &hasDistance);
+                nullptr, &points, &hasNormal, &hasDistance);
             for(i = 0; i < points; i++) {
                 en.point[i] = Remap(ep->point[i], remap);
             }

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -44,7 +44,7 @@ void Group::AssembleLoops(bool *allClosed,
     // Try to assemble all these Beziers into loops. The closed loops go into
     // bezierLoops, with the outer loops grouped with their holes. The
     // leftovers, if any, go in bezierOpens.
-    bezierLoops.FindOuterFacesFrom(&sbl, &polyLoops, NULL,
+    bezierLoops.FindOuterFacesFrom(&sbl, &polyLoops, nullptr,
                                    SS.ChordTolMm(),
                                    allClosed, &(polyError.notClosedAt),
                                    allCoplanar, &(polyError.errorPointAt),

--- a/src/importdxf.cpp
+++ b/src/importdxf.cpp
@@ -157,12 +157,12 @@ public:
     std::map<std::string, hStyle> styles;
     std::map<std::string, Block> blocks;
     std::map<std::string, DRW_Layer> layers;
-    Block *readBlock = NULL;
-    const DRW_Insert *insertInsert = NULL;
+    Block *readBlock = nullptr;
+    const DRW_Insert *insertInsert = nullptr;
 
     template<class T>
     bool addPendingBlockEntity(const T &e) {
-        if(readBlock == NULL) return false;
+        if(readBlock == nullptr) return false;
         readBlock->entities.emplace_back(new T(e));
         return true;
     }
@@ -263,8 +263,8 @@ public:
     }
 
     DRW_Layer *getSourceLayer(const DRW_Entity *e) {
-        DRW_Layer *layer = NULL;
-        if(insertInsert != NULL) {
+        DRW_Layer *layer = nullptr;
+        if(insertInsert != nullptr) {
             std::string l = insertInsert->layer;
             auto bi = layers.find(l);
             if(bi != layers.end()) layer = &bi->second;
@@ -279,7 +279,7 @@ public:
     int getColor(const DRW_Entity *e) {
         int col = e->color;
         if(col == DRW::ColorByBlock) {
-            if(insertInsert != NULL) {
+            if(insertInsert != nullptr) {
                 col = insertInsert->color;
             } else {
                 col = 7;
@@ -287,7 +287,7 @@ public:
         }
         if(col == DRW::ColorByLayer) {
             DRW_Layer *layer = getSourceLayer(e);
-            if(layer != NULL) {
+            if(layer != nullptr) {
                 col = layer->color;
             } else {
                 col = 7;
@@ -299,7 +299,7 @@ public:
     DRW_LW_Conv::lineWidth getLineWidth(const DRW_Entity *e) {
         DRW_LW_Conv::lineWidth result = e->lWeight;
         if(result == DRW_LW_Conv::widthByBlock) {
-            if(insertInsert != NULL) {
+            if(insertInsert != nullptr) {
                 result = insertInsert->lWeight;
             } else {
                 result = DRW_LW_Conv::widthDefault;
@@ -307,7 +307,7 @@ public:
         }
         if(result == DRW_LW_Conv::widthByLayer) {
             DRW_Layer *layer = getSourceLayer(e);
-            if(layer != NULL) {
+            if(layer != nullptr) {
                 result = layer->lWeight;
             } else {
                 result = DRW_LW_Conv::widthDefault;
@@ -319,7 +319,7 @@ public:
     std::string getLineType(const DRW_Entity *e) {
         std::string  result = e->lineType;
         if(result == "BYBLOCK") {
-            if(insertInsert != NULL) {
+            if(insertInsert != nullptr) {
                 result = ToUpper(insertInsert->lineType);
             } else {
                 result = "CONTINUOUS";
@@ -327,7 +327,7 @@ public:
         }
         if(result == "BYLAYER") {
             DRW_Layer *layer = getSourceLayer(e);
-            if(layer != NULL) {
+            if(layer != nullptr) {
                 result = ToUpper(layer->lineType);
             } else {
                 result = "CONTINUOUS";
@@ -580,7 +580,7 @@ public:
     }
 
     void endBlock() override {
-        readBlock = NULL;
+        readBlock = nullptr;
     }
 
     void addPoint(const DRW_Point &data) override {

--- a/src/importidf.cpp
+++ b/src/importidf.cpp
@@ -280,7 +280,7 @@ static void MakeBeziersForArcs(SBezierList *sbl, Vector center, Vector pa, Vecto
         // The control point must lie on both tangents.
         Vector p1 = Vector::AtIntersectionOfLines(p0, p0.Plus(t0),
                                                   p2, p2.Plus(t2),
-                                                  NULL);
+                                                  nullptr);
 
         SBezier sb = SBezier::From(p0, p1, p2);
         sb.weight[1] = cos(dtheta/2);
@@ -501,9 +501,9 @@ bool LinkIDF(const Platform::Path &filename, EntityList *el, SMesh *m, SShell *s
     SEdge errorAt = {};
     
     SBezierLoopSetSet sblss = {};
-    sblss.FindOuterFacesFrom(&sbl, &polyLoops, NULL,
+    sblss.FindOuterFacesFrom(&sbl, &polyLoops, nullptr,
                              100.0, &allClosed, &errorAt,
-                             &allCoplanar, &errorPointAt, NULL);
+                             &allCoplanar, &errorPointAt, nullptr);
 
     //hack for when there is no sketch yet and the first group is a linked IDF
     double ctc = SS.chordTolCalculated;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -206,7 +206,7 @@ default: dbp("bad constraint type %d", sc->type); return;
 
     // Now we're finally ready to solve!
     bool andFindBad = ssys->calculateFaileds ? true : false;
-    SolveResult how = SYS.Solve(&g, NULL, &(ssys->dof), &bad, andFindBad, /*andFindFree=*/false);
+    SolveResult how = SYS.Solve(&g, nullptr, &(ssys->dof), &bad, andFindBad, /*andFindFree=*/false);
 
     switch(how) {
         case SolveResult::OKAY:

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -85,7 +85,7 @@ void SMesh::MakeEdgesInPlaneInto(SEdgeList *sel, Vector n, double d) {
     SKdNode *root = SKdNode::From(&m);
     root->SnapToMesh(&m);
     root->MakeCertainEdgesInto(sel, EdgeKind::NAKED_OR_SELF_INTER,
-                               /*coplanarIsInter=*/false, NULL, NULL);
+                               /*coplanarIsInter=*/false, nullptr, nullptr);
 
     m.Clear();
 }
@@ -348,7 +348,7 @@ uint32_t SMesh::FirstIntersectionWith(Point2d mp) const {
         if(tr.meta.face == 0) continue;
 
         double t;
-        if(!tr.Raytrace(rayPoint, rayDir, &t, NULL)) continue;
+        if(!tr.Raytrace(rayPoint, rayDir, &t, nullptr)) continue;
         if(t > faceT) {
             face  = tr.meta.face;
             faceT = t;
@@ -391,7 +391,7 @@ SKdNode *SKdNode::From(SMesh *m) {
         swap(tra[k], tra[n]);
     }
 
-    STriangleLl *tll = NULL;
+    STriangleLl *tll = nullptr;
     for(i = 0; i < m->l.n; i++) {
         STriangleLl *tn = STriangleLl::Alloc();
         tn->tri = &(tra[i]);
@@ -462,7 +462,7 @@ SKdNode *SKdNode::From(STriangleLl *tll) {
     }
 
     STriangleLl *ll;
-    STriangleLl *lgt, *llt; lgt = llt = NULL;
+    STriangleLl *lgt, *llt; lgt = llt = nullptr;
     for(ll = tll; ll; ll = ll->next) {
         STriangle *tr = ll->tri;
 
@@ -698,7 +698,7 @@ void SKdNode::SplitLinesAgainstTriangle(SEdgeList *sel, STriangle *tr) const {
             {
                 Vector m = Vector::AtIntersectionOfPlaneAndLine(
                                         tn, td,
-                                        se->a, se->b, NULL);
+                                        se->a, se->b, nullptr);
                 seln.AddEdge(m, se->b, se->auxA, 0, se->tag);
                 se->b = m;
             }
@@ -900,7 +900,7 @@ void SKdNode::FindEdgeOn(Vector a, Vector b, int cnt, bool coplanarIsInter,
                         info->intersectsMesh = true;
                     } else {
                         Vector p = Vector::AtIntersectionOfPlaneAndLine(
-                                                n, d, a, b, NULL);
+                                                n, d, a, b, nullptr);
                         Vector ta = tr->a,
                                tb = tr->b,
                                tc = tr->c;

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -333,7 +333,7 @@ void GraphicsWindow::MakeTangentArc() {
 
         pinter = Vector::AtIntersectionOfLines(p0, p0.Plus(t0),
                                                p1, p1.Plus(t1),
-                                               NULL, NULL, NULL);
+                                               nullptr, nullptr, nullptr);
 
         // The sign of vv determines whether shortest distance is
         // clockwise or anti-clockwise.
@@ -432,7 +432,7 @@ void GraphicsWindow::MakeTangentArc() {
     SK.GetEntity(earc->point[a])->PointForceTo(pc[0].PointAt(t[0]));
     SK.GetEntity(earc->point[b])->PointForceTo(pc[1].PointAt(t[1]));
 
-    earc = NULL;
+    earc = nullptr;
 
     // Modify or duplicate the original entities and connect them to the tangent arc.
     pc[0].CreateRequestTrimmedTo(t[0], SS.tangentArcModify,
@@ -473,7 +473,7 @@ hEntity GraphicsWindow::SplitCircle(hEntity he, Vector pinter) {
         // Start with an unbroken circle, split it into a 360 degree arc.
         Vector center = SK.GetEntity(circle->point[0])->PointGetNum();
 
-        circle = NULL; // shortly invalid!
+        circle = nullptr; // shortly invalid!
         hRequest hr = AddRequest(Request::Type::ARC_OF_CIRCLE, /*rememberForUndo=*/false);
 
         Entity *arc = SK.GetEntity(hr.entity(0));
@@ -493,7 +493,7 @@ hEntity GraphicsWindow::SplitCircle(hEntity he, Vector pinter) {
                start  = SK.GetEntity(hs)->PointGetNum(),
                finish = SK.GetEntity(hf)->PointGetNum();
 
-        circle = NULL; // shortly invalid!
+        circle = nullptr; // shortly invalid!
         hRequest hr0 = AddRequest(Request::Type::ARC_OF_CIRCLE, /*rememberForUndo=*/false),
                  hr1 = AddRequest(Request::Type::ARC_OF_CIRCLE, /*rememberForUndo=*/false);
 

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -58,7 +58,7 @@ void GraphicsWindow::StartDraggingByEntity(hEntity he) {
     {
         int pts;
         EntReqTable::GetEntityInfo(e->type, e->extraPoints,
-            NULL, &pts, NULL, NULL);
+            nullptr, &pts, nullptr, nullptr);
         for(int i = 0; i < pts; i++) {
             AddPointToDraggedList(e->point[i]);
         }
@@ -189,7 +189,7 @@ void GraphicsWindow::MouseMoved(double x, double y, bool leftDown,
         // If we're currently not doing anything, then see if we should
         // start dragging something.
         if(leftDown && dm > 3) {
-            Entity *e = NULL;
+            Entity *e = nullptr;
             hEntity dragEntity = ChooseFromHoverToDrag().entity;
             if(dragEntity.v) e = SK.GetEntity(dragEntity);
             if(e && e->type != Entity::Type::WORKPLANE) {
@@ -697,7 +697,7 @@ void GraphicsWindow::MouseRightUp(double x, double y) {
                     Entity *e = SK.GetEntity(r->h.entity(0));
                     for(int i = MAX_POINTS_IN_ENTITY; i > addAfterPoint + 1; i--) {
                         Entity *p0 = SK.entity.FindByIdNoOops(e->point[i]);
-                        if(p0 == NULL) continue;
+                        if(p0 == nullptr) continue;
                         Entity *p1 = SK.GetEntity(e->point[i - 1]);
                         ReplacePointInConstraints(p1->h, p0->h);
                         p0->PointForceTo(p1->PointGetNum());
@@ -825,7 +825,7 @@ Vector GraphicsWindow::SnapToEntityByScreenPoint(Point2d pp, hEntity he) {
 
     double minD = -1.0f;
     double k;
-    const SEdge *edge = NULL;
+    const SEdge *edge = nullptr;
     for(const auto &e : edges->l) {
         Point2d p0 = ProjectPoint(e.a);
         Point2d p1 = ProjectPoint(e.b);
@@ -836,7 +836,7 @@ Vector GraphicsWindow::SnapToEntityByScreenPoint(Point2d pp, hEntity he) {
         k = pp.Minus(p0).Dot(dir) / dir.Dot(dir);
         edge = &e;
     }
-    if(edge == NULL) return UnProjectPoint(pp);
+    if(edge == nullptr) return UnProjectPoint(pp);
     return edge->a.Plus(edge->b.Minus(edge->a).ScaledBy(k));
 }
 
@@ -851,7 +851,7 @@ bool GraphicsWindow::ConstrainPointByHovered(hEntity pt, const Point2d *projecte
         return true;
     }
     if(e->IsCircle()) {
-        if(projected != NULL) {
+        if(projected != nullptr) {
             Vector snapPos = SnapToEntityByScreenPoint(*projected, e->h);
             point->PointForceTo(snapPos);
         }
@@ -860,7 +860,7 @@ bool GraphicsWindow::ConstrainPointByHovered(hEntity pt, const Point2d *projecte
         return true;
     }
     if(e->type == Entity::Type::LINE_SEGMENT) {
-        if(projected != NULL) {
+        if(projected != nullptr) {
             Vector snapPos = SnapToEntityByScreenPoint(*projected, e->h);
             point->PointForceTo(snapPos);
         }
@@ -1291,14 +1291,14 @@ void GraphicsWindow::MouseLeftDown(double mx, double my, bool shiftDown, bool ct
     }
 
     // Activate group with newly created request/constraint
-    Group *g = NULL;
+    Group *g = nullptr;
     if(hr.v != 0) {
         g = SK.GetGroup(SK.GetRequest(hr)->group);
     }
     if(hc.v != 0) {
         g = SK.GetGroup(SK.GetConstraint(hc)->group);
     }
-    if(g != NULL) {
+    if(g != nullptr) {
         g->visible = true;
     }
 
@@ -1522,8 +1522,8 @@ void GraphicsWindow::SixDofEvent(Platform::SixDofEvent event) {
 
     // This can either transform our view, or transform a linked part.
     GroupSelection();
-    Entity *e = NULL;
-    Group *g = NULL;
+    Entity *e = nullptr;
+    Group *g = nullptr;
     if(gs.points == 1   && gs.n == 1) e = SK.GetEntity(gs.point [0]);
     if(gs.entities == 1 && gs.n == 1) e = SK.GetEntity(gs.entity[0]);
     if(e) g = SK.GetGroup(e->group);

--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -83,7 +83,7 @@ public:
     // Why aren't we using GSettings? Two reasons. It doesn't allow to easily see whether
     // the setting had the default value, and it requires to install a schema globally.
     Path         _path;
-    json_object *_json = NULL;
+    json_object *_json = nullptr;
 
     static Path GetConfigPath() {
         Path configHome;
@@ -130,7 +130,7 @@ public:
             }
         }
 
-        if(_json == NULL) {
+        if(_json == nullptr) {
             _json = json_object_new_object();
         }
     }
@@ -364,7 +364,7 @@ public:
     std::vector<std::shared_ptr<MenuImplGtk>>       subMenus;
 
     MenuItemRef AddItem(const std::string &label,
-                        std::function<void()> onTrigger = NULL,
+                        std::function<void()> onTrigger = nullptr,
                         bool mnemonics = true) override {
         auto menuItem = std::make_shared<MenuItemImplGtk>();
         menuItems.push_back(menuItem);
@@ -743,7 +743,7 @@ protected:
 class GtkWindow : public Gtk::Window {
     Platform::Window   *_receiver;
     Gtk::VBox           _vbox;
-    Gtk::MenuBar       *_menu_bar = NULL;
+    Gtk::MenuBar       *_menu_bar = nullptr;
     Gtk::HBox           _hbox;
     GtkEditorOverlay    _editor_overlay;
     Gtk::VScrollbar     _scrollbar;
@@ -930,7 +930,7 @@ public:
             Gtk::MenuBar *gtkMenuBar = &((MenuBarImplGtk*)&*newMenuBar)->gtkMenuBar;
             gtkWindow.set_menu_bar(gtkMenuBar);
         } else {
-            gtkWindow.set_menu_bar(NULL);
+            gtkWindow.set_menu_bar(nullptr);
         }
         menuBar = newMenuBar;
     }
@@ -1476,8 +1476,8 @@ std::vector<Platform::Path> GetFontFiles() {
 
     // fontconfig is already initialized by GTK
     FcPattern   *pat = FcPatternCreate();
-    FcObjectSet *os  = FcObjectSetBuild(FC_FILE, (char *)0);
-    FcFontSet   *fs  = FcFontList(0, pat, os);
+    FcObjectSet *os  = FcObjectSetBuild(FC_FILE, (char *)nullptr);
+    FcFontSet   *fs  = FcFontList(nullptr, pat, os);
 
     for(int i = 0; i < fs->nfont; i++) {
         FcChar8 *filenameFC = FcPatternFormat(fs->fonts[i], (const FcChar8*) "%{file}");
@@ -1493,7 +1493,7 @@ std::vector<Platform::Path> GetFontFiles() {
 }
 
 void OpenInBrowser(const std::string &url) {
-    gtk_show_uri(Gdk::Screen::get_default()->gobj(), url.c_str(), GDK_CURRENT_TIME, NULL);
+    gtk_show_uri(Gdk::Screen::get_default()->gobj(), url.c_str(), GDK_CURRENT_TIME, nullptr);
 }
 
 Gtk::Main *gtkMain;

--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -138,8 +138,8 @@ Path Path::CurrentDirectory() {
     rawW.resize(length);
     return From(Narrow(rawW));
 #else
-    char *raw = getcwd(NULL, 0);
-    ssassert(raw != NULL, "Cannot get current directory");
+    char *raw = getcwd(nullptr, 0);
+    ssassert(raw != nullptr, "Cannot get current directory");
     Path path = From(raw);
     free(raw);
     return path;
@@ -411,7 +411,7 @@ FILE *OpenFile(const Platform::Path &filename, const char *mode) {
 
 bool FileExists(const Platform::Path &filename) {
     FILE *f = OpenFile(filename, "rb");
-    if(f == NULL) return false;
+    if(f == nullptr) return false;
     fclose(f);
     return true;
 }
@@ -428,7 +428,7 @@ void RemoveFile(const Platform::Path &filename) {
 
 bool ReadFile(const Platform::Path &filename, std::string *data) {
     FILE *f = OpenFile(filename, "rb");
-    if(f == NULL) return false;
+    if(f == nullptr) return false;
 
     if(fseek(f, 0, SEEK_END) != 0)
         return false;
@@ -445,7 +445,7 @@ bool ReadFile(const Platform::Path &filename, std::string *data) {
 
 bool WriteFile(const Platform::Path &filename, const std::string &data) {
     FILE *f = OpenFile(filename, "wb");
-    if(f == NULL) return false;
+    if(f == nullptr) return false;
 
     if(fwrite(&data[0], 1, data.size(), f) != data.size())
         return false;
@@ -531,8 +531,8 @@ static const char *selfSymlink = "";
 static Platform::Path FindLocalResourceDir() {
     // Find out the path to the running binary.
     Platform::Path selfPath;
-    char *expandedSelfPath = realpath(selfSymlink, NULL);
-    if(expandedSelfPath != NULL) {
+    char *expandedSelfPath = realpath(selfSymlink, nullptr);
+    if(expandedSelfPath != nullptr) {
         selfPath = Path::From(expandedSelfPath);
     }
     free(expandedSelfPath);
@@ -686,10 +686,10 @@ void DebugPrint(const char *fmt, ...) {
 //-----------------------------------------------------------------------------
 
 struct MimallocHeap {
-    mi_heap_t *heap = NULL;
+    mi_heap_t *heap = nullptr;
 
     ~MimallocHeap() {
-        if(heap != NULL)
+        if(heap != nullptr)
             mi_heap_destroy(heap);
     }
 };
@@ -697,12 +697,12 @@ struct MimallocHeap {
 static thread_local MimallocHeap TempArena;
 
 void *AllocTemporary(size_t size) {
-    if(TempArena.heap == NULL) {
+    if(TempArena.heap == nullptr) {
         TempArena.heap = mi_heap_new();
-        ssassert(TempArena.heap != NULL, "out of memory");
+        ssassert(TempArena.heap != nullptr, "out of memory");
     }
     void *ptr = mi_heap_zalloc(TempArena.heap, size);
-    ssassert(ptr != NULL, "out of memory");
+    ssassert(ptr != nullptr, "out of memory");
     return ptr;
 }
 

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -78,7 +78,7 @@ bool STriangle::Raytrace(const Vector &rayPoint, const Vector &rayDir,
     *t = edge2.Dot(qvec) * inv_det;
 
     // Calculate intersection point.
-    if(inters != NULL) *inters = rayPoint.Plus(rayDir.ScaledBy(*t));
+    if(inters != nullptr) *inters = rayPoint.Plus(rayDir.ScaledBy(*t));
 
     return true;
 }
@@ -363,7 +363,7 @@ SEdgeLl *SEdgeLl::Alloc() {
     return sell;
 }
 SKdNodeEdges *SKdNodeEdges::From(SEdgeList *sel) {
-    SEdgeLl *sell = NULL;
+    SEdgeLl *sell = nullptr;
     SEdge *se;
     for(se = sel->l.First(); se; se = sel->l.NextAfter(se)) {
         SEdgeLl *n = SEdgeLl::Alloc();
@@ -426,7 +426,7 @@ SKdNodeEdges *SKdNodeEdges::From(SEdgeLl *sell) {
     }
 
     // Sort the edges according to which side(s) of the split plane they're on.
-    SEdgeLl *gtl = NULL, *ltl = NULL;
+    SEdgeLl *gtl = nullptr, *ltl = nullptr;
     for(flip = sell; flip; flip = flip->next) {
         if(flip->se->a.Element(n->which) < n->c + KDTREE_EPS ||
            flip->se->b.Element(n->which) < n->c + KDTREE_EPS)

--- a/src/polyline.cpp
+++ b/src/polyline.cpp
@@ -23,7 +23,7 @@ bool PolylineBuilder::Vertex::GetNext(uint32_t kind, Vertex **next, Edge **nextE
 
 bool PolylineBuilder::Vertex::GetNext(uint32_t kind, Vector plane, double dist,
                                       Vertex **next, Edge **nextEdge) {
-    Edge *best = NULL;
+    Edge *best = nullptr;
     double minD = VERY_POSITIVE;
     for(Edge *e : edges) {
         if(e->tag != 0) continue;
@@ -32,12 +32,12 @@ bool PolylineBuilder::Vertex::GetNext(uint32_t kind, Vector plane, double dist,
         // We choose the best next edge with minimal distance from the current plane
         Vector nextPos = e->GetOtherVertex(this)->pos;
         double curD = fabs(plane.Dot(nextPos) - dist);
-        if(best != NULL && curD > minD) continue;
+        if(best != nullptr && curD > minD) continue;
         best = e;
         minD = curD;
     }
 
-    if(best != NULL) {
+    if(best != nullptr) {
         best->tag = 1;
         *next = best->GetOtherVertex(this);
         *nextEdge = best;
@@ -57,7 +57,7 @@ size_t PolylineBuilder::Vertex::CountEdgesWithTagAndKind(int tag, uint32_t kind)
 PolylineBuilder::Vertex *PolylineBuilder::Edge::GetOtherVertex(PolylineBuilder::Vertex *v) const {
     if(a == v) return b;
     if(b == v) return a;
-    return NULL;
+    return nullptr;
 }
 
 size_t PolylineBuilder::VertexPairHash::operator()(const std::pair<Vertex *, Vertex *> &v) const {
@@ -118,7 +118,7 @@ PolylineBuilder::Edge *PolylineBuilder::AddEdge(const Vector &p0, const Vector &
                                                 uint32_t kind, uintptr_t data) {
     Vertex *v0 = AddVertex(p0);
     Vertex *v1 = AddVertex(p1);
-    if(v0 == v1) return NULL;
+    if(v0 == v1) return nullptr;
 
     auto it = edgeMap.find(std::make_pair(v0, v1));
     if(it != edgeMap.end()) {

--- a/src/render/gl3shader.cpp
+++ b/src/render/gl3shader.cpp
@@ -112,7 +112,7 @@ precision highp float;
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
     if(infoLen > 1) {
         std::string infoStr(infoLen, '\0');
-        glGetShaderInfoLog(shader, infoLen, NULL, &infoStr[0]);
+        glGetShaderInfoLog(shader, infoLen, nullptr, &infoStr[0]);
         dbp(infoStr.c_str());
     }
 
@@ -149,7 +149,7 @@ void Shader::Init(const std::string &vertexRes, const std::string &fragmentRes,
     glGetProgramiv(program, GL_INFO_LOG_LENGTH, &infoLen);
     if(infoLen > 1) {
         std::string infoStr(infoLen, '\0');
-        glGetProgramInfoLog(program, infoLen, NULL, &infoStr[0]);
+        glGetProgramInfoLog(program, infoLen, nullptr, &infoStr[0]);
         dbp(infoStr.c_str());
     }
 
@@ -604,7 +604,7 @@ void EdgeRenderer::Draw(const EdgeRenderer::Handle &handle) {
     glVertexAttribPointer(ATTRIB_POS, 3, GL_FLOAT, GL_FALSE, sizeof(EdgeVertex), (void *)offsetof(EdgeVertex, pos));
     glVertexAttribPointer(ATTRIB_LOC, 3, GL_FLOAT, GL_FALSE, sizeof(EdgeVertex), (void *)offsetof(EdgeVertex, loc));
     glVertexAttribPointer(ATTRIB_TAN, 3, GL_FLOAT, GL_FALSE, sizeof(EdgeVertex), (void *)offsetof(EdgeVertex, tan));
-    glDrawElements(GL_TRIANGLES, handle.size, GL_UNSIGNED_INT, NULL);
+    glDrawElements(GL_TRIANGLES, handle.size, GL_UNSIGNED_INT, nullptr);
 
     glDisableVertexAttribArray(ATTRIB_POS);
     glDisableVertexAttribArray(ATTRIB_LOC);
@@ -815,7 +815,7 @@ void OutlineRenderer::Draw(const OutlineRenderer::Handle &handle, Canvas::DrawOu
                           (void *)offsetof(OutlineVertex, nol));
     glVertexAttribPointer(ATTRIB_NOR, 3, GL_FLOAT, GL_FALSE, sizeof(OutlineVertex),
                           (void *)offsetof(OutlineVertex, nor));
-    glDrawElements(GL_TRIANGLES, handle.size, GL_UNSIGNED_INT, NULL);
+    glDrawElements(GL_TRIANGLES, handle.size, GL_UNSIGNED_INT, nullptr);
 
     glDisableVertexAttribArray(ATTRIB_POS);
     glDisableVertexAttribArray(ATTRIB_LOC);
@@ -1015,7 +1015,7 @@ void IndexedMeshRenderer::Draw(const IndexedMeshRenderer::Handle &handle) {
     }
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, handle.indexBuffer);
-    glDrawElements(GL_TRIANGLES, handle.size, GL_UNSIGNED_INT, NULL);
+    glDrawElements(GL_TRIANGLES, handle.size, GL_UNSIGNED_INT, nullptr);
 
     glDisableVertexAttribArray(ATTRIB_POS);
     if(NeedsTexture()) glDisableVertexAttribArray(ATTRIB_TEX);

--- a/src/render/rendercairo.cpp
+++ b/src/render/rendercairo.cpp
@@ -11,8 +11,8 @@ namespace SolveSpace {
 void CairoRenderer::Clear() {
     SurfaceRenderer::Clear();
 
-    if(context != NULL) cairo_destroy(context);
-    context = NULL;
+    if(context != nullptr) cairo_destroy(context);
+    context = nullptr;
 }
 
 void CairoRenderer::GetIdent(const char **vendor, const char **renderer, const char **version) {
@@ -160,8 +160,8 @@ void CairoPixmapRenderer::Init() {
 void CairoPixmapRenderer::Clear() {
     CairoRenderer::Clear();
 
-    if(surface != NULL) cairo_surface_destroy(surface);
-    surface = NULL;
+    if(surface != nullptr) cairo_surface_destroy(surface);
+    surface = nullptr;
 }
 
 std::shared_ptr<Pixmap> CairoPixmapRenderer::ReadFrame() {

--- a/src/render/rendergl3.cpp
+++ b/src/render/rendergl3.cpp
@@ -207,7 +207,7 @@ Canvas::Stroke *OpenGl3Renderer::SelectStroke(hStroke hcs) {
     current.hcs    = hcs;
     current.stroke = stroke;
     current.hcf    = {};
-    current.fill   = NULL;
+    current.fill   = nullptr;
     current.texture.reset();
     return stroke;
 }
@@ -251,7 +251,7 @@ Canvas::Fill *OpenGl3Renderer::SelectFill(hFill hcf) {
     ssglDepthRange(fill->layer, fill->zIndex);
 
     current.hcs    = {};
-    current.stroke = NULL;
+    current.stroke = nullptr;
     current.hcf    = hcf;
     current.fill   = fill;
     if(fill->pattern != FillPattern::SOLID) {
@@ -314,7 +314,7 @@ void OpenGl3Renderer::SelectTexture(std::shared_ptr<const Pixmap> pm) {
 
 void OpenGl3Renderer::DoLine(const Vector &a, const Vector &b, hStroke hcs) {
     SEdgeListItem *eli = lines.FindByIdNoOops(hcs);
-    if(eli == NULL) {
+    if(eli == nullptr) {
         SEdgeListItem item = {};
         item.h = hcs;
         lines.Add(&item);
@@ -326,7 +326,7 @@ void OpenGl3Renderer::DoLine(const Vector &a, const Vector &b, hStroke hcs) {
 
 void OpenGl3Renderer::DoPoint(Vector p, hStroke hs) {
     SPointListItem *pli = points.FindByIdNoOops(hs);
-    if(pli == NULL) {
+    if(pli == nullptr) {
         SPointListItem item = {};
         item.h = hs;
         points.Add(&item);
@@ -345,7 +345,7 @@ void OpenGl3Renderer::DoStippledLine(const Vector &a, const Vector &b, hStroke h
         return;
     }
 
-    const char *patternSeq = NULL;
+    const char *patternSeq = nullptr;
     Stroke s = *stroke;
     s.stipplePattern = StipplePattern::CONTINUOUS;
     hcs = GetStroke(s);
@@ -482,7 +482,7 @@ void OpenGl3Renderer::DrawVectorText(const std::string &text, double height,
                                      const Vector &o, const Vector &u, const Vector &v,
                                      hStroke hcs) {
     SEdgeListItem *eli = lines.FindByIdNoOops(hcs);
-    if(eli == NULL) {
+    if(eli == nullptr) {
         SEdgeListItem item = {};
         item.h = hcs;
         lines.Add(&item);
@@ -496,7 +496,7 @@ void OpenGl3Renderer::DrawVectorText(const std::string &text, double height,
 void OpenGl3Renderer::DrawQuad(const Vector &a, const Vector &b, const Vector &c, const Vector &d,
                                hFill hcf) {
     SMeshListItem *li = meshes.FindByIdNoOops(hcf);
-    if(li == NULL) {
+    if(li == nullptr) {
         SMeshListItem item = {};
         item.h = hcf;
         meshes.Add(&item);
@@ -549,7 +549,7 @@ void OpenGl3Renderer::DrawPixmap(std::shared_ptr<const Pixmap> pm,
     hcf = GetFill(fill);
 
     SMeshListItem *mli = meshes.FindByIdNoOops(hcf);
-    if(mli == NULL) {
+    if(mli == nullptr) {
         SMeshListItem item = {};
         item.h = hcf;
         meshes.Add(&item);
@@ -872,14 +872,14 @@ public:
     int GetZIndex() const override { return fillFront.zIndex; }
 
     static std::shared_ptr<DrawCall> Create(OpenGl3Renderer *renderer, const SMesh &m,
-                                            Canvas::Fill *fillFront, Canvas::Fill *fillBack = NULL,
+                                            Canvas::Fill *fillFront, Canvas::Fill *fillBack = nullptr,
                                             bool isShaded = false) {
         MeshDrawCall *dc = new MeshDrawCall();
         dc->fillFront       = *fillFront;
         dc->handle          = renderer->meshRenderer.Add(m);
         dc->fillBack        = *fillBack;
         dc->isShaded        = isShaded;
-        dc->hasFillBack     = (fillBack != NULL);
+        dc->hasFillBack     = (fillBack != nullptr);
         return std::shared_ptr<DrawCall>(dc);
     }
 

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -52,7 +52,7 @@ bool EntReqTable::GetRequestInfo(Request::Type req, int extraPoints,
 {
     for(const EntReqMapping &te : EntReqMap) {
         if(req == te.reqType) {
-            CopyEntityInfo(&te, extraPoints, ent, NULL, pts, hasNormal, hasDistance);
+            CopyEntityInfo(&te, extraPoints, ent, nullptr, pts, hasNormal, hasDistance);
             return true;
         }
     }
@@ -64,7 +64,7 @@ bool EntReqTable::GetEntityInfo(Entity::Type ent, int extraPoints,
 {
     for(const EntReqMapping &te : EntReqMap) {
         if(ent == te.entType) {
-            CopyEntityInfo(&te, extraPoints, NULL, req, pts, hasNormal, hasDistance);
+            CopyEntityInfo(&te, extraPoints, nullptr, req, pts, hasNormal, hasDistance);
             return true;
         }
     }
@@ -73,7 +73,7 @@ bool EntReqTable::GetEntityInfo(Entity::Type ent, int extraPoints,
 
 Request::Type EntReqTable::GetRequestForEntity(Entity::Type ent) {
     Request::Type req;
-    ssassert(GetEntityInfo(ent, 0, &req, NULL, NULL, NULL),
+    ssassert(GetEntityInfo(ent, 0, &req, nullptr, nullptr, nullptr),
              "No entity for request");
     return req;
 }
@@ -107,7 +107,7 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
             auto image = SS.images.find(file);
             if(image != SS.images.end()) {
                 std::shared_ptr<Pixmap> pixmap = (*image).second;
-                if(pixmap != NULL) {
+                if(pixmap != nullptr) {
                     aspectRatio = (double)pixmap->width / (double)pixmap->height;
                 }
             }
@@ -222,7 +222,7 @@ std::string Request::DescriptionString() const {
             case Type::IMAGE:           s = "image";          break;
         }
     }
-    ssassert(s != NULL, "Unexpected request type");
+    ssassert(s != nullptr, "Unexpected request type");
     return ssprintf("r%03x-%s", h.v, s);
 }
 

--- a/src/resource.cpp
+++ b/src/resource.cpp
@@ -180,7 +180,7 @@ void Pixmap::ConvertTo(Format newFormat) {
 static std::shared_ptr<Pixmap> ReadPngIntoPixmap(png_struct *png_ptr, png_info *info_ptr,
                                                  bool flip) {
     png_read_png(png_ptr, info_ptr,
-                 PNG_TRANSFORM_EXPAND | PNG_TRANSFORM_GRAY_TO_RGB | PNG_TRANSFORM_SCALE_16, NULL);
+                 PNG_TRANSFORM_EXPAND | PNG_TRANSFORM_GRAY_TO_RGB | PNG_TRANSFORM_SCALE_16, nullptr);
 
     std::shared_ptr<Pixmap> pixmap = std::make_shared<Pixmap>();
     pixmap->width    = png_get_image_width(png_ptr, info_ptr);
@@ -203,17 +203,17 @@ static std::shared_ptr<Pixmap> ReadPngIntoPixmap(png_struct *png_ptr, png_info *
                pixmap->width * pixmap->GetBytesPerPixel());
     }
 
-    png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     return pixmap;
 }
 
 std::shared_ptr<Pixmap> Pixmap::FromPng(const uint8_t *data, size_t size, bool flip) {
     struct Slice { const uint8_t *data; size_t size; };
     Slice dataSlice = { data, size };
-    png_struct *png_ptr = NULL;
-    png_info *info_ptr = NULL;
+    png_struct *png_ptr = nullptr;
+    png_info *info_ptr = nullptr;
 
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
     if(!png_ptr) goto exit;
     info_ptr = png_create_info_struct(png_ptr);
     if(!info_ptr) goto exit;
@@ -235,19 +235,19 @@ std::shared_ptr<Pixmap> Pixmap::FromPng(const uint8_t *data, size_t size, bool f
     return ReadPngIntoPixmap(png_ptr, info_ptr, flip);
 
 exit:
-    png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     return nullptr;
 }
 
 std::shared_ptr<Pixmap> Pixmap::ReadPng(FILE *f, bool flip) {
-    png_struct *png_ptr = NULL;
-    png_info *info_ptr = NULL;
+    png_struct *png_ptr = nullptr;
+    png_info *info_ptr = nullptr;
 
     uint8_t header[8];
     if(fread(header, 1, sizeof(header), f) != sizeof(header)) goto exit;
     if(png_sig_cmp(header, 0, sizeof(header))) goto exit;
 
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
     if(!png_ptr) goto exit;
     info_ptr = png_create_info_struct(png_ptr);
     if(!info_ptr) goto exit;
@@ -260,13 +260,13 @@ std::shared_ptr<Pixmap> Pixmap::ReadPng(FILE *f, bool flip) {
     return ReadPngIntoPixmap(png_ptr, info_ptr, flip);
 
 exit:
-    png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
     return nullptr;
 }
 
 std::shared_ptr<Pixmap> Pixmap::ReadPng(const Platform::Path &filename, bool flip) {
     FILE *f = OpenFile(filename, "rb");
-    if(!f) return NULL;
+    if(!f) return nullptr;
     std::shared_ptr<Pixmap> pixmap = ReadPng(f, flip);
     fclose(f);
     return pixmap;
@@ -292,10 +292,10 @@ bool Pixmap::WritePng(FILE *f, bool flip) {
         }
     }
 
-    png_struct *png_ptr = NULL;
-    png_info *info_ptr = NULL;
+    png_struct *png_ptr = nullptr;
+    png_info *info_ptr = nullptr;
 
-    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
     if(!png_ptr) goto exit;
     info_ptr = png_create_info_struct(png_ptr);
     if(!info_ptr) goto exit;
@@ -1516,7 +1516,7 @@ const std::set<Locale, LocaleLess> &Locales() {
         Locale locale = {};
         locale.language    = m.str(1);
         locale.region      = m.str(2);
-        locale.lcid        = std::stoi(m.str(3), NULL, 16);
+        locale.lcid        = std::stoi(m.str(3), nullptr, 16);
         locale.displayName = m.str(4);
         locales.emplace(locale);
     }

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -911,7 +911,7 @@ void SolveSpaceUI::MenuAnalyze(Command id) {
             SEdgeList sel = {};
             g->polyLoops.MakeEdgesInto(&sel);
             SPolygon sp = {};
-            sel.AssemblePolygon(&sp, NULL, /*keepDir=*/true);
+            sel.AssemblePolygon(&sp, nullptr, /*keepDir=*/true);
             sp.normal = sp.ComputeNormal();
             sp.FixContourDirections();
             double area = sp.SignedArea();
@@ -1070,25 +1070,25 @@ void SolveSpaceUI::Clear() {
         if(i < undo.cnt) undo.d[i].Clear();
         if(i < redo.cnt) redo.d[i].Clear();
     }
-    TW.window = NULL;
-    GW.openRecentMenu = NULL;
-    GW.linkRecentMenu = NULL;
-    GW.showGridMenuItem = NULL;
-    GW.dimSolidModelMenuItem = NULL;
-    GW.perspectiveProjMenuItem = NULL;
-    GW.explodeMenuItem = NULL;
-    GW.showToolbarMenuItem = NULL;
-    GW.showTextWndMenuItem = NULL;
-    GW.fullScreenMenuItem = NULL;
-    GW.unitsMmMenuItem = NULL;
-    GW.unitsMetersMenuItem = NULL;
-    GW.unitsInchesMenuItem = NULL;
-    GW.unitsFeetInchesMenuItem = NULL;
-    GW.inWorkplaneMenuItem = NULL;
-    GW.in3dMenuItem = NULL;
-    GW.undoMenuItem = NULL;
-    GW.redoMenuItem = NULL;
-    GW.window = NULL;
+    TW.window = nullptr;
+    GW.openRecentMenu = nullptr;
+    GW.linkRecentMenu = nullptr;
+    GW.showGridMenuItem = nullptr;
+    GW.dimSolidModelMenuItem = nullptr;
+    GW.perspectiveProjMenuItem = nullptr;
+    GW.explodeMenuItem = nullptr;
+    GW.showToolbarMenuItem = nullptr;
+    GW.showTextWndMenuItem = nullptr;
+    GW.fullScreenMenuItem = nullptr;
+    GW.unitsMmMenuItem = nullptr;
+    GW.unitsMetersMenuItem = nullptr;
+    GW.unitsInchesMenuItem = nullptr;
+    GW.unitsFeetInchesMenuItem = nullptr;
+    GW.inWorkplaneMenuItem = nullptr;
+    GW.in3dMenuItem = nullptr;
+    GW.undoMenuItem = nullptr;
+    GW.redoMenuItem = nullptr;
+    GW.window = nullptr;
 }
 
 void Sketch::Clear() {
@@ -1160,11 +1160,11 @@ BBox Sketch::CalculateEntityBBox(bool includingInvisible) {
 
 Group *Sketch::GetRunningMeshGroupFor(hGroup h) {
     Group *g = GetGroup(h);
-    while(g != NULL) {
+    while(g != nullptr) {
         if(g->IsMeshGroup()) {
             return g;
         }
         g = g->PreviousGroup();
     }
-    return NULL;
+    return nullptr;
 }

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -89,7 +89,7 @@ SCurve SCurve::MakeCopySplitAgainst(SShell *agnstA, SShell *agnstB,
     }
     
     const SCurvePt *p = pts.First();
-    ssassert(p != NULL, "Cannot split an empty curve");
+    ssassert(p != nullptr, "Cannot split an empty curve");
     SCurvePt prev = *p;
     ret.pts.Add(p);
     p = pts.NextAfter(p);
@@ -204,7 +204,7 @@ void SShell::CopyCurvesSplitAgainst(bool opA, SShell *agnst, SShell *into) {
 #pragma omp parallel for
     for(int i=0; i<curve.n; i++) {
         SCurve *sc = &curve[i];
-        SCurve scn = sc->MakeCopySplitAgainst(agnst, NULL,
+        SCurve scn = sc->MakeCopySplitAgainst(agnst, nullptr,
                                 surface.FindById(sc->surfA),
                                 surface.FindById(sc->surfB));
         scn.source = opA ? SCurve::Source::A : SCurve::Source::B;
@@ -673,7 +673,7 @@ SSurface SSurface::MakeCopyTrimAgainst(SShell *parent,
 
     SPolygon poly = {};
     final.l.ClearTags();
-    if(!final.AssemblePolygon(&poly, NULL, /*keepDir=*/true))
+    if(!final.AssemblePolygon(&poly, nullptr, /*keepDir=*/true))
 #pragma omp critical
     {
         into->booleanFailed = true;
@@ -792,8 +792,8 @@ void SShell::MakeFromAssemblyOf(SShell *a, SShell *b) {
 void SShell::MakeFromBoolean(SShell *a, SShell *b, SSurface::CombineAs type) {
     booleanFailed = false;
 
-    a->MakeClassifyingBsps(NULL);
-    b->MakeClassifyingBsps(NULL);
+    a->MakeClassifyingBsps(nullptr);
+    b->MakeClassifyingBsps(nullptr);
 
     // Copy over all the original curves, splitting them so that a
     // piecewise linear segment never crosses a surface from the other
@@ -877,7 +877,7 @@ SBspUv *SBspUv::From(SEdgeList *el, SSurface *srf) {
         // stability for the normals.
         return la > lb;
     });
-    SBspUv *bsp = NULL;
+    SBspUv *bsp = nullptr;
     for(se = work.l.First(); se; se = work.l.NextAfter(se)) {
         bsp = InsertOrCreateEdge(bsp, (se->a).ProjectXy(), (se->b).ProjectXy(), srf);
     }
@@ -926,7 +926,7 @@ double SBspUv::ScaledDistanceToLine(Point2d pt, Point2d a, Point2d b, bool asSeg
 }
 
 SBspUv *SBspUv::InsertOrCreateEdge(SBspUv *where, Point2d ea, Point2d eb, SSurface *srf) {
-    if(where == NULL) {
+    if(where == nullptr) {
         SBspUv *ret = Alloc();
         ret->a = ea;
         ret->b = eb;

--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -139,7 +139,7 @@ bool SBezier::IsCircle(Vector axis, Vector *center, double *r) const {
 
     *center = Vector::AtIntersectionOfLines(ctrl[0], (ctrl[0]).Plus(r0),
                                             ctrl[2], (ctrl[2]).Plus(r2),
-                                            NULL, NULL, NULL);
+                                            nullptr, nullptr, nullptr);
 
     double rd0 = center->Minus(ctrl[0]).Magnitude(),
            rd2 = center->Minus(ctrl[2]).Magnitude();
@@ -283,7 +283,7 @@ void SBezier::AllIntersectionsWith(const SBezier *sbb, SPointList *spl) const {
         // the case where two pairs of line segments intersect at their
         // vertices. So this isn't robust, although that case isn't very
         // likely.
-        seb.AnyEdgeCrossings(se->a, se->b, NULL, &splRaw);
+        seb.AnyEdgeCrossings(se->a, se->b, nullptr, &splRaw);
     }
     SPoint *sp;
     for(sp = splRaw.l.First(); sp; sp = splRaw.l.NextAfter(sp)) {
@@ -465,7 +465,7 @@ void SBezierLoop::MakePwlInto(SContour *sc, double chordTol) const {
         sb->MakePwlInto(sc, chordTol);
         // Avoid double points at join between Beziers; except that
         // first and last points should be identical.
-        if(l.NextAfter(sb) != NULL) {
+        if(l.NextAfter(sb) != nullptr) {
             sc->l.RemoveLast(1);
         }
     }

--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -268,7 +268,7 @@ void SSurface::AllPointsIntersecting(Vector a, Vector b,
            (n.Dot(a) > d + LENGTH_EPS && n.Dot(b) < d - LENGTH_EPS) ||
            (n.Dot(b) > d + LENGTH_EPS && n.Dot(a) < d - LENGTH_EPS))
         {
-            Vector p = Vector::AtIntersectionOfPlaneAndLine(n, d, a, b, NULL);
+            Vector p = Vector::AtIntersectionOfPlaneAndLine(n, d, a, b, nullptr);
             Inter inter;
             ClosestPointTo(p, &(inter.p.x), &(inter.p.y));
             inters.Add(&inter);

--- a/src/srf/shell.cpp
+++ b/src/srf/shell.cpp
@@ -237,7 +237,7 @@ void SShell::MakeFromHelicalRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector
                         hEntity he;
                         he.v          = sb->entity;
                         hEntity hface = group->Remap(he, Group::REMAP_LINE_TO_FACE);
-                        if(SK.entity.FindByIdNoOops(hface) != NULL) {
+                        if(SK.entity.FindByIdNoOops(hface) != nullptr) {
                             ss.face = hface.v;
                         }
                     }
@@ -389,7 +389,7 @@ void SShell::MakeFromRevolutionOf(SBezierLoopSet *sbls, Vector pt, Vector axis, 
                         hEntity he;
                         he.v = sb->entity;
                         hEntity hface = group->Remap(he, Group::REMAP_LINE_TO_FACE);
-                        if(SK.entity.FindByIdNoOops(hface) != NULL) {
+                        if(SK.entity.FindByIdNoOops(hface) != nullptr) {
                             ss.face = hface.v;
                         }
                     }

--- a/src/srf/surface.cpp
+++ b/src/srf/surface.cpp
@@ -415,7 +415,7 @@ void SSurface::TriangulateInto(SShell *shell, SMesh *sm) {
     MakeEdgesInto(shell, &el, MakeAs::UV);
 
     SPolygon poly = {};
-    if(el.AssemblePolygon(&poly, NULL, /*keepDir=*/true)) {
+    if(el.AssemblePolygon(&poly, nullptr, /*keepDir=*/true)) {
         int i, start = sm->l.n;
         if(degm == 1 && degn == 1) {
             // A surface with curvature along one direction only; so

--- a/src/srf/surfinter.cpp
+++ b/src/srf/surfinter.cpp
@@ -23,7 +23,7 @@ void SSurface::AddExactIntersectionCurve(SBezier *sb, SSurface *srfB,
     // Now we have to piecewise linearize the curve. If there's already an
     // identical curve in the shell, then follow that pwl exactly, otherwise
     // calculate from scratch.
-    SCurve split, *existing = NULL;
+    SCurve split, *existing = nullptr;
     SBezier sbrev = *sb;
     sbrev.Reverse();
     bool backwards = false;
@@ -243,7 +243,7 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
                        p1 = p0.Plus(along);
 
                 bezier.ctrl[i] =
-                    Vector::AtIntersectionOfPlaneAndLine(n, d, p0, p1, NULL);
+                    Vector::AtIntersectionOfPlaneAndLine(n, d, p0, p1, nullptr);
             }
 
             AddExactIntersectionCurve(&bezier, b, agnstA, agnstB, into);
@@ -362,7 +362,7 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
                      *srfB = (a == 0) ? b : this;
 
             SEdgeList el = {};
-            srfA->MakeEdgesInto(shA, &el, MakeAs::XYZ, NULL);
+            srfA->MakeEdgesInto(shA, &el, MakeAs::XYZ, nullptr);
 
             SEdge *se;
             for(se = el.l.First(); se; se = el.l.NextAfter(se)) {

--- a/src/srf/triangulate.cpp
+++ b/src/srf/triangulate.cpp
@@ -67,7 +67,7 @@ void SPolygon::UvTriangulateInto(SMesh *m, SSurface *srf) {
 //        dbp("finished finding holes: %d ms", (int)(GetMilliseconds() - in));
         for(;;) {
             double xmin = 1e10;
-            SContour *scmin = NULL;
+            SContour *scmin = nullptr;
 
             for(sc = l.First(); sc; sc = l.NextAfter(sc)) {
                 if(sc->tag != 2) continue;
@@ -634,10 +634,10 @@ void SPolygon::UvGridTriangulateInto(SMesh *mesh, SSurface *srf) {
                 //  +-------------> j/v axis
 
                 if( (i==(li.n-2)) || (j==(lj.n-2)) ||
-                   orig.AnyEdgeCrossings(a, b, NULL) ||
-                   orig.AnyEdgeCrossings(b, c, NULL) ||
-                   orig.AnyEdgeCrossings(c, d, NULL) ||
-                   orig.AnyEdgeCrossings(d, a, NULL))
+                   orig.AnyEdgeCrossings(a, b, nullptr) ||
+                   orig.AnyEdgeCrossings(b, c, nullptr) ||
+                   orig.AnyEdgeCrossings(c, d, nullptr) ||
+                   orig.AnyEdgeCrossings(d, a, nullptr))
                 {
                     this_flag = false;
                 }
@@ -693,7 +693,7 @@ void SPolygon::UvGridTriangulateInto(SMesh *mesh, SSurface *srf) {
 
         // Because no duplicate edges were created we do not need to cull them.
         SPolygon hp = {};
-        holes.AssemblePolygon(&hp, NULL, /*keepDir=*/true);
+        holes.AssemblePolygon(&hp, nullptr, /*keepDir=*/true);
 
         SContour *sc;
         for(sc = hp.l.First(); sc; sc = hp.l.NextAfter(sc)) {

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -23,7 +23,7 @@ const Style::Default Style::Defaults[] = {
     { { DIM_SOLID },    "DimSolid",     RGBf(0.1, 0.1, 0.1), 1.0, 0, true,  StipplePattern::CONTINUOUS },
     { { HIDDEN_EDGE },  "HiddenEdge",   RGBf(0.8, 0.8, 0.8), 1.0, 1, true,  StipplePattern::DASH },
     { { OUTLINE },      "Outline",      RGBf(0.8, 0.8, 0.8), 3.0, 5, true,  StipplePattern::CONTINUOUS },
-    { { 0 },            NULL,           RGBf(0.0, 0.0, 0.0), 0.0, 0, true,  StipplePattern::CONTINUOUS }
+    { { 0 },            nullptr,           RGBf(0.0, 0.0, 0.0), 0.0, 0, true,  StipplePattern::CONTINUOUS }
 };
 
 std::string Style::CnfColor(const std::string &prefix) {
@@ -92,7 +92,7 @@ void Style::CreateDefaultStyle(hStyle h) {
 void Style::FillDefaultStyle(Style *s, const Default *d, bool factory) {
     Platform::SettingsRef settings = Platform::GetSettings();
 
-    if(d == NULL) d = &Defaults[0];
+    if(d == nullptr) d = &Defaults[0];
     s->color         = (factory)
                         ? d->color
                         : settings->ThawColor(CnfColor(d->cnfPrefix), d->color);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -104,11 +104,11 @@ bool System::IsDragged(hParam p) {
 
 Param *System::GetLastParamSubstitution(Param *p) {
     Param *current = p;
-    while(current->substd != NULL) {
+    while(current->substd != nullptr) {
         current = current->substd;
         if(current == p) {
             // Break the loop
-            current->substd = NULL;
+            current->substd = nullptr;
             break;
         }
     }
@@ -117,22 +117,22 @@ Param *System::GetLastParamSubstitution(Param *p) {
 
 void System::SortSubstitutionByDragged(Param *p) {
     std::vector<Param *> subsParams;
-    Param *by = NULL;
+    Param *by = nullptr;
     Param *current = p;
-    while(current != NULL) {
+    while(current != nullptr) {
         subsParams.push_back(current);
         if(IsDragged(current->h)) {
             by = current;
         }
         current = current->substd;
     }
-    if(by == NULL) by = p;
+    if(by == nullptr) by = p;
     for(Param *p : subsParams) {
        if(p == by) continue;
        p->substd = by;
        p->tag = VAR_SUBSTITUTED;
     }
-    by->substd = NULL;
+    by->substd = nullptr;
     by->tag = 0;
 }
 
@@ -141,9 +141,9 @@ void System::SubstituteParamsByLast(Expr *e) {
 
     if(e->op == Expr::Op::PARAM) {
         Param *p = param.FindByIdNoOops(e->parh);
-        if(p != NULL) {
+        if(p != nullptr) {
             Param *s = GetLastParamSubstitution(p);
-            if(s != NULL) {
+            if(s != nullptr) {
                 e->parh = s->h;
             }
         }
@@ -187,11 +187,11 @@ void System::SolveBySubstitution() {
             last->substd = pb;
             last->tag = VAR_SUBSTITUTED;
 
-            if(pb->substd != NULL) {
+            if(pb->substd != nullptr) {
                 // Break the loops
                 GetLastParamSubstitution(pb);
                 // if b loop was broken
-                if(pb->substd == NULL) {
+                if(pb->substd == nullptr) {
                     // Clear substitution
                     pb->tag = 0;
                 }
@@ -212,7 +212,7 @@ void System::SolveBySubstitution() {
 
     // Substitute all the parameters with last substitutions
     for(auto &p : param) {
-        if(p.substd == NULL) continue;
+        if(p.substd == nullptr) continue;
         p.substd = GetLastParamSubstitution(p.substd);
     }
 }
@@ -234,7 +234,7 @@ bool System::TestRank(int *dof) {
     int jacobianRank = CalculateRank();
     // We are calculating dof based on real rank, not mat.m.
     // Using this approach we can calculate real dof even when redundant is allowed.
-    if(dof != NULL) *dof = mat.n - jacobianRank;
+    if(dof != nullptr) *dof = mat.n - jacobianRank;
     return jacobianRank == mat.m;
 }
 
@@ -477,7 +477,7 @@ SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
         return SolveResult::TOO_MANY_UNKNOWNS;
     }
     // Clear dof value in order to have indication when dof is actually not calculated
-    if(dof != NULL) *dof = -1;
+    if(dof != nullptr) *dof = -1;
     // We are suppressing or allowing redundant, so we no need to catch unsolveable + redundant
     rankOk = (!g->suppressDofCalculation && !g->allowRedundant) ? TestRank(dof) : true;
 

--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -46,7 +46,7 @@ public:
     }
 
     void Draw(UiCanvas *uiCanvas, int x, int y, bool asHovered) override {
-        if(icon == NULL) {
+        if(icon == nullptr) {
             icon = LoadPng("icons/text-window/" + iconName + ".png");
         }
 
@@ -105,13 +105,13 @@ public:
     }
 
     void Draw(UiCanvas *uiCanvas, int x, int y, bool asHovered) override {
-        if(visibleIcon == NULL) {
+        if(visibleIcon == nullptr) {
             visibleIcon = LoadPng("icons/text-window/occluded-visible.png");
         }
-        if(stippledIcon == NULL) {
+        if(stippledIcon == nullptr) {
             stippledIcon = LoadPng("icons/text-window/occluded-stippled.png");
         }
-        if(invisibleIcon == NULL) {
+        if(invisibleIcon == nullptr) {
             invisibleIcon = LoadPng("icons/text-window/occluded-invisible.png");
         }
 
@@ -383,7 +383,7 @@ void TextWindow::Printf(bool halfLine, const char *fmt, ...) {
     RgbaColor bgRgb = RGBi(0, 0, 0);
     int link = NOT_A_LINK;
     uint32_t data = 0;
-    LinkFunction *f = NULL, *h = NULL;
+    LinkFunction *f = nullptr, *h = nullptr;
 
     c = 0;
     while(*fmt) {
@@ -444,14 +444,14 @@ void TextWindow::Printf(bool halfLine, const char *fmt, ...) {
                     // leave the background, though
                     link = NOT_A_LINK;
                     data = 0;
-                    f = NULL;
-                    h = NULL;
+                    f = nullptr;
+                    h = nullptr;
                     break;
 
                 case 'F':
                 case 'B': {
                     char cc = fmt[1];  // color code
-                    RgbaColor *rgbPtr = NULL;
+                    RgbaColor *rgbPtr = nullptr;
                     switch(cc) {
                         case 0:   goto done;  // truncated directive
                         case 'p': cc = (char)va_arg(vl, int); break;
@@ -622,7 +622,7 @@ void TextWindow::DrawOrHitTestIcons(UiCanvas *uiCanvas, TextWindow::DrawOrHitHow
 
     Button *oldHovered = hoveredButton;
     if(how != PAINT) {
-        hoveredButton = NULL;
+        hoveredButton = nullptr;
     }
 
     double hoveredX, hoveredY;
@@ -643,7 +643,7 @@ void TextWindow::DrawOrHitTestIcons(UiCanvas *uiCanvas, TextWindow::DrawOrHitHow
     }
 
     if(how != PAINT && hoveredButton != oldHovered) {
-        if(hoveredButton == NULL) {
+        if(hoveredButton == nullptr) {
             window->SetTooltip("", 0, 0, 0, 0);
         } else {
             window->SetTooltip(hoveredButton->Tooltip(), hoveredX, hoveredY, 28, 28);
@@ -1076,7 +1076,7 @@ void TextWindow::MouseEvent(bool leftClick, bool leftDown, double x, double y) {
     using Platform::Window;
 
     if(SS.TW.window->IsEditorVisible() || SS.GW.window->IsEditorVisible()) {
-        if(DrawOrHitTestColorPicker(NULL, leftClick ? CLICK : HOVER, leftDown, x, y)) {
+        if(DrawOrHitTestColorPicker(nullptr, leftClick ? CLICK : HOVER, leftDown, x, y)) {
             return;
         }
 
@@ -1089,7 +1089,7 @@ void TextWindow::MouseEvent(bool leftClick, bool leftDown, double x, double y) {
         return;
     }
 
-    DrawOrHitTestIcons(NULL, leftClick ? CLICK : HOVER, x, y);
+    DrawOrHitTestIcons(nullptr, leftClick ? CLICK : HOVER, x, y);
 
     GraphicsWindow::Selection ps = SS.GW.hover;
     SS.GW.hover.Clear();
@@ -1144,7 +1144,7 @@ void TextWindow::MouseEvent(bool leftClick, bool leftDown, double x, double y) {
 }
 
 void TextWindow::MouseLeave() {
-    hoveredButton = NULL;
+    hoveredButton = nullptr;
     hoveredRow = 0;
     hoveredCol = 0;
     window->Invalidate();

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -91,7 +91,7 @@ static ToolIcon Toolbar[] = {
 };
 
 void GraphicsWindow::ToolbarDraw(UiCanvas *canvas) {
-    ToolbarDrawOrHitTest(0, 0, canvas, NULL, NULL, NULL);
+    ToolbarDrawOrHitTest(0, 0, canvas, nullptr, nullptr, nullptr);
 }
 
 bool GraphicsWindow::ToolbarMouseMoved(int x, int y) {
@@ -103,7 +103,7 @@ bool GraphicsWindow::ToolbarMouseMoved(int x, int y) {
 
     Command hitCommand;
     int hitX, hitY;
-    bool withinToolbar = ToolbarDrawOrHitTest(x, y, NULL, &hitCommand, &hitX, &hitY);
+    bool withinToolbar = ToolbarDrawOrHitTest(x, y, nullptr, &hitCommand, &hitX, &hitY);
 
     if(hitCommand != toolbarHovered) {
         toolbarHovered = hitCommand;
@@ -140,7 +140,7 @@ bool GraphicsWindow::ToolbarMouseDown(int x, int y) {
     y += ((int)height/2);
 
     Command hitCommand;
-    bool withinToolbar = ToolbarDrawOrHitTest(x, y, NULL, &hitCommand, NULL, NULL);
+    bool withinToolbar = ToolbarDrawOrHitTest(x, y, nullptr, &hitCommand, nullptr, nullptr);
     if(hitCommand != Command::NONE) {
         SS.GW.ActivateCommand(hitCommand);
     }

--- a/src/ttf.cpp
+++ b/src/ttf.cpp
@@ -95,7 +95,7 @@ TtfFont *TtfFontList::LoadFont(const std::string &font)
         [&font](const TtfFont &tf) { return tf.FontFileBaseName() == font; });
 
     if(tf != l.end()) {
-        if(tf->fontFace == NULL) {
+        if(tf->fontFace == nullptr) {
             if(tf->IsResource())
                 tf->LoadFromResource(fontLibrary, /*keepOpen=*/true);
             else
@@ -103,7 +103,7 @@ TtfFont *TtfFontList::LoadFont(const std::string &font)
         }
         return tf;
     } else {
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -111,7 +111,7 @@ void TtfFontList::PlotString(const std::string &font, const std::string &str,
                              SBezierList *sbl, Vector origin, Vector u, Vector v)
 {
     TtfFont *tf = LoadFont(font);
-    if(!str.empty() && tf != NULL) {
+    if(!str.empty() && tf != nullptr) {
         tf->PlotString(str, sbl, origin, u, v);
     } else {
         // No text or no font; so draw a big X for an error marker.
@@ -126,7 +126,7 @@ void TtfFontList::PlotString(const std::string &font, const std::string &str,
 double TtfFontList::AspectRatio(const std::string &font, const std::string &str)
 {
     TtfFont *tf = LoadFont(font);
-    if(tf != NULL) {
+    if(tf != nullptr) {
         return tf->AspectRatio(str);
     }
 
@@ -207,7 +207,7 @@ bool TtfFont::ExtractTTFData(bool keepOpen) {
         dbp("freetype: loading unicode CMap for file '%s' failed: %s",
             fontFile.raw.c_str(), ft_error_string(fterr));
         FT_Done_Face(fontFace);
-        fontFace = NULL;
+        fontFace = nullptr;
         return false;
     }
 
@@ -228,7 +228,7 @@ bool TtfFont::ExtractTTFData(bool keepOpen) {
         dbp("freetype: size request for file '%s' failed: %s",
             fontFile.raw.c_str(), ft_error_string(fterr));
         FT_Done_Face(fontFace);
-        fontFace = NULL;
+        fontFace = nullptr;
         return false;
     }
 
@@ -247,7 +247,7 @@ bool TtfFont::ExtractTTFData(bool keepOpen) {
             dbp("freetype: cannot load glyph for GID 0x%04x in file '%s': %s",
                 gid, fontFile.raw.c_str(), ft_error_string(fterr));
             FT_Done_Face(fontFace);
-            fontFace = NULL;
+            fontFace = nullptr;
             return false;
         }
 
@@ -261,7 +261,7 @@ bool TtfFont::ExtractTTFData(bool keepOpen) {
     // descriptor limit (especially on Windows), breaking all file operations.
     if(!keepOpen) {
         FT_Done_Face(fontFace);
-        fontFace = NULL;
+        fontFace = nullptr;
         return true;
     }
 
@@ -333,7 +333,7 @@ static int CubicTo(const FT_Vector *c1, const FT_Vector *c2, const FT_Vector *p,
 void TtfFont::PlotString(const std::string &str,
                          SBezierList *sbl, Vector origin, Vector u, Vector v)
 {
-    ssassert(fontFace != NULL, "Expected font face to be loaded");
+    ssassert(fontFace != nullptr, "Expected font face to be loaded");
 
     FT_Outline_Funcs outlineFuncs;
     outlineFuncs.move_to  = MoveTo;
@@ -406,7 +406,7 @@ void TtfFont::PlotString(const std::string &str,
 }
 
 double TtfFont::AspectRatio(const std::string &str) {
-    ssassert(fontFace != NULL, "Expected font face to be loaded");
+    ssassert(fontFace != nullptr, "Expected font face to be loaded");
 
     // We always request a unit size character, so the aspect ratio is the same as advance length.
     double dx = 0;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -20,7 +20,7 @@ std::string SolveSpace::ssprintf(const char *fmt, ...)
     va_list va;
 
     va_start(va, fmt);
-    int size = vsnprintf(NULL, 0, fmt, va);
+    int size = vsnprintf(nullptr, 0, fmt, va);
     ssassert(size >= 0, "vsnprintf could not encode string");
     va_end(va);
 
@@ -109,7 +109,7 @@ static void MessageBox(const char *fmt, va_list va, bool error,
 #ifndef LIBRARY
     va_list va_size;
     va_copy(va_size, va);
-    int size = vsnprintf(NULL, 0, fmt, va_size);
+    int size = vsnprintf(nullptr, 0, fmt, va_size);
     ssassert(size >= 0, "vsnprintf could not encode string");
     va_end(va_size);
 

--- a/test/debugtool.cpp
+++ b/test/debugtool.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
     if(args.size() == 3 && args[1] == "expr") {
         std::string expr = args[2], err;
         Expr *e = Expr::Parse(expr.c_str(), &err);
-        if(e == NULL) {
+        if(e == nullptr) {
             fprintf(stderr, "cannot parse: %s\n", err.c_str());
         } else {
             fprintf(stderr, "%g\n", e->Eval());

--- a/test/harness.cpp
+++ b/test/harness.cpp
@@ -108,7 +108,7 @@ static std::string PrepareSavefile(std::string data) {
             for(int i = 0; SolveSpaceUI::SAVED[i].type != 0; i++) {
                 if(SolveSpaceUI::SAVED[i].fmt  != 'f') continue;
                 if(SolveSpaceUI::SAVED[i].desc != key) continue;
-                double f = strtod(value.c_str(), NULL);
+                double f = strtod(value.c_str(), nullptr);
                 f = round(f * precision) / precision;
                 std::string newValue = ssprintf("%.20f", f);
                 ssassert(value.size() == newValue.size(), "Expected no change in value length");
@@ -204,7 +204,7 @@ bool Test::Helper::CheckLoad(const char *file, int line, const char *fixture) {
     Platform::Path fixturePath = GetAssetPath(file, fixture);
 
     FILE *f = OpenFile(fixturePath, "rb");
-    bool fixtureExists = (f != NULL);
+    bool fixtureExists = (f != nullptr);
     if(f) fclose(f);
 
     bool result = fixtureExists && SS.LoadFromFile(fixturePath);


### PR DESCRIPTION
I saw that you are developing with std=c++11, and using [nullptr](https://en.cppreference.com/w/cpp/language/nullptr) is recommended.
I excuted cmake
```sh
cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. 
```
with extra flag for  `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`  clang-tidy purpose.
From build directory executed:
```sh
run-clang-tidy -checks='modernize-use-nullptr'
```
![modernize-use-nullptr](https://user-images.githubusercontent.com/56769579/171316539-0fb3755d-a613-4815-96d8-27578926753c.png)
After that i ran same command with -f to auto apply fixes:
![diffs](https://user-images.githubusercontent.com/56769579/171316693-3474b146-35e4-4962-8d40-41b52e9766ca.png)
After that i built everything again, ran app with no problems:
![ApplyfixTestingProg](https://user-images.githubusercontent.com/56769579/171316880-12ab7a81-7893-41c6-b483-d5a5226c85b6.png)
I even have executed `solvespace-testsuite`:
![TestPassed](https://user-images.githubusercontent.com/56769579/171317006-1f5c5c94-4a43-4b00-a1f9-8c0bd7d21f58.png)


This was done for [issue clang-tidy](https://gitlab.com/pap1rana/azrs-tracking/-/issues/8) for my faculty project.