### PR TITLE
WIP First try at faces perpendicular constraint

### DIFF
--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -721,7 +721,11 @@ void Constraint::MenuConstrain(Command id) {
         }
 
         case Command::PARALLEL:
-            if(gs.vectors == 2 && gs.n == 2) {
+            if(gs.faces == 2 && gs.n == 2) {
+                c.type = Type::PARALLEL;
+                c.entityA = gs.face[0];
+                c.entityB = gs.face[1];            
+            } else if(gs.vectors == 2 && gs.n == 2) {
                 c.type = Type::PARALLEL;
                 c.entityA = gs.vector[0];
                 c.entityB = gs.vector[1];
@@ -765,6 +769,7 @@ void Constraint::MenuConstrain(Command id) {
             } else {
                 Error(_("Bad selection for parallel / tangent constraint. This "
                         "constraint can apply to:\n\n"
+                        "    * two faces\n"
                         "    * two line segments (parallel)\n"
                         "    * a line segment and a normal (parallel)\n"
                         "    * two normals (parallel)\n"
@@ -776,13 +781,18 @@ void Constraint::MenuConstrain(Command id) {
             break;
 
         case Command::PERPENDICULAR:
-            if(gs.vectors == 2 && gs.n == 2) {
+            if(gs.faces == 2 && gs.n == 2) {
+                c.type = Type::PERPENDICULAR;
+                c.entityA = gs.face[0];
+                c.entityB = gs.face[1];            
+            } else if(gs.vectors == 2 && gs.n == 2) {
                 c.type = Type::PERPENDICULAR;
                 c.entityA = gs.vector[0];
                 c.entityB = gs.vector[1];
             } else {
                 Error(_("Bad selection for perpendicular constraint. This "
                         "constraint can apply to:\n\n"
+                        "    * two faces\n"
                         "    * two line segments\n"
                         "    * a line segment and a normal\n"
                         "    * two normals\n"));

--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -177,8 +177,10 @@ void TextWindow::DescribeSelection() {
             case Entity::Type::FACE_NORMAL_PT:
             case Entity::Type::FACE_XPROD:
             case Entity::Type::FACE_N_ROT_TRANS:
-            case Entity::Type::FACE_N_ROT_AA:
             case Entity::Type::FACE_N_TRANS:
+            case Entity::Type::FACE_N_ROT_AA:
+            case Entity::Type::FACE_ROT_NORMAL_PT:
+            case Entity::Type::FACE_N_ROT_AXIS_TRANS:
                 Printf(false, "%FtPLANE FACE%E");
                 p = e->FaceGetNormalNum();
                 Printf(true,  "   normal = " PT_AS_NUM, CO(p));

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -26,6 +26,9 @@ bool EntityBase::HasVector() const {
 }
 
 ExprVector EntityBase::VectorGetExprsInWorkplane(hEntity wrkpl) const {
+    if(IsFace()) {
+        return FaceGetNormalExprs();
+    }
     switch(type) {
         case Type::LINE_SEGMENT:
             return (SK.GetEntity(point[0])->PointGetExprsInWorkplane(wrkpl)).Minus(
@@ -62,6 +65,9 @@ ExprVector EntityBase::VectorGetExprs() const {
 }
 
 Vector EntityBase::VectorGetNum() const {
+    if(IsFace()) {
+        return FaceGetNormalNum();
+    }
     switch(type) {
         case Type::LINE_SEGMENT:
             return (SK.GetEntity(point[0])->PointGetNum()).Minus(
@@ -79,6 +85,9 @@ Vector EntityBase::VectorGetNum() const {
 }
 
 Vector EntityBase::VectorGetRefPoint() const {
+    if(IsFace()) {
+        return FaceGetPointNum();
+    }
     switch(type) {
         case Type::LINE_SEGMENT:
             return ((SK.GetEntity(point[0])->PointGetNum()).Plus(


### PR DESCRIPTION
This is WIP. It works for making 90 degree revolves, and also in assembly groups!  Looking for feedback.
Some of my comments:

I don't like all the checking IsFace() that needed to be added here. OTOH by doing that there was almost nothing needed to add the constraint. This should also be applicable to a new face-face-angle constraint.

The little purple perpendicular constraint on the sketch is drawn OK I suppose? If we made a new constraint type we'd have to add more code to draw it. not sure how to display face-face-angle anyway.

Message box text is not updated to indicate face-face as an option for perpendicular constraint.

The additional cases in describescreen.cpp are needed independently of this feature - they were missing. I'll make a different PR for those and maybe some other missing cases in there...