### PR TITLE
Show details for comments associated with points

### DIFF
--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -428,14 +428,19 @@ void TextWindow::DescribeSelection() {
             double d = (p1.Minus(p0)).Dot(n0);
             Printf(true,  "      distance = %Fi%s", SS.MmToString(d).c_str());
         }
-    } else if(gs.n == 0 && gs.stylables > 0) {
-        Printf(false, "%FtSELECTED:%E comment text");
     } else if(gs.n == 0 && gs.constraints == 1) {
         Constraint *c = SK.GetConstraint(gs.constraint[0]);
         const std::string &desc = c->DescriptionString().c_str();
 
         if(c->type == Constraint::Type::COMMENT) {
             Printf(false, "%FtCOMMENT%E  %s", desc.c_str());
+            if(c->ptA != Entity::NO_ENTITY) {
+                Vector p = SK.GetEntity(c->ptA)->PointGetNum();
+                Printf(true,  "  attached to point at: " PT_AS_STR, COSTR(SK.GetEntity(c->ptA), p));
+                Vector dv = c->disp.offset;
+                Printf(false, "    distance = %Fi%s", SS.MmToString(dv.Magnitude()).c_str());
+                Printf(false, "  d(x, y, z) = " PT_AS_STR_NO_LINK, COSTR_NO_LINK(dv));
+            }
         } else if(c->HasLabel()) {
             if(c->reference) {
                 Printf(false, "%FtREFERENCE%E  %s", desc.c_str());


### PR DESCRIPTION
Since 7e08b02de1d91580f691dbe5eed08e2ccfd24eed comments can be attached to
points.

Now when such a comment is selected the point (entity) it is associated to
will be shown in the text window together with it's coordinates and the
distance (offset) from the point to the comment.

Most of this was already prepared by Whitequark here
https://github.com/solvespace/solvespace/commit/afa9e2890ef7ab46242d5f67f7bab1e58e80c2ba
I just had to to remove the original 12 year old code by jwesthues that
showed "SELECTED: comment text" for comments.
(https://github.com/solvespace/solvespace/commit/6750995ef0b79c9ee83244fe34797f24e8aed582)

Fixes #1072