### PR TITLE
Add ability to select 3 faces

### DIFF
--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -274,22 +274,29 @@ void Constraint::MenuConstrain(Command id) {
                 c.type = Type::POINTS_COINCIDENT;
                 c.ptA = gs.point[0];
                 c.ptB = gs.point[1];
+                newcons.push_back(c);
             } else if(gs.points == 1 && gs.workplanes == 1 && gs.n == 2) {
                 c.type = Type::PT_IN_PLANE;
                 c.ptA = gs.point[0];
                 c.entityA = gs.entity[0];
+                newcons.push_back(c);
             } else if(gs.points == 1 && gs.lineSegments == 1 && gs.n == 2) {
                 c.type = Type::PT_ON_LINE;
                 c.ptA = gs.point[0];
                 c.entityA = gs.entity[0];
+                newcons.push_back(c);
             } else if(gs.points == 1 && gs.circlesOrArcs == 1 && gs.n == 2) {
                 c.type = Type::PT_ON_CIRCLE;
                 c.ptA = gs.point[0];
                 c.entityA = gs.entity[0];
-            } else if(gs.points == 1 && gs.faces == 1 && gs.n == 2) {
+                newcons.push_back(c);
+            } else if(gs.points == 1 && gs.faces >= 1 && gs.n == gs.points+gs.faces) {
                 c.type = Type::PT_ON_FACE;
                 c.ptA = gs.point[0];
-                c.entityA = gs.face[0];
+                for (int k=0; k<gs.faces; k++) {
+                    c.entityA = gs.face[k];
+                    newcons.push_back(c);
+                }
             } else {
                 Error(_("Bad selection for on point / curve / plane constraint. "
                         "This constraint can apply to:\n\n"
@@ -300,8 +307,8 @@ void Constraint::MenuConstrain(Command id) {
                         "    * a point and a plane face (point on face)\n"));
                 return;
             }
-            AddConstraint(&c);
-            newcons.push_back(c);
+            for (auto&& nc : newcons)
+              AddConstraint(&nc);
             break;
 
         case Command::EQUAL:

--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -428,6 +428,26 @@ void TextWindow::DescribeSelection() {
             double d = (p1.Minus(p0)).Dot(n0);
             Printf(true,  "      distance = %Fi%s", SS.MmToString(d).c_str());
         }
+    } else if(gs.n == 3 && gs.faces == 3) {
+        Printf(false, "%FtTHREE PLANE FACES");
+
+        Vector n0 = SK.GetEntity(gs.face[0])->FaceGetNormalNum();
+        Printf(true,  " planeA normal = " PT_AS_NUM, CO(n0));
+        Vector p0 = SK.GetEntity(gs.face[0])->FaceGetPointNum();
+        Printf(false, "   planeA thru = " PT_AS_STR, COSTR(SK.GetEntity(gs.face[0]), p0));
+
+        Vector n1 = SK.GetEntity(gs.face[1])->FaceGetNormalNum();
+        Printf(true,  " planeB normal = " PT_AS_NUM, CO(n1));
+        Vector p1 = SK.GetEntity(gs.face[1])->FaceGetPointNum();
+        Printf(false, "   planeB thru = " PT_AS_STR, COSTR(SK.GetEntity(gs.face[1]), p1));
+
+        Vector n2 = SK.GetEntity(gs.face[2])->FaceGetNormalNum();
+        Printf(true,  " planeC normal = " PT_AS_NUM, CO(n2));
+        Vector p2 = SK.GetEntity(gs.face[2])->FaceGetPointNum();
+        Printf(false, "   planeB thru = " PT_AS_STR, COSTR(SK.GetEntity(gs.face[2]), p2));
+
+        // We should probably compute and show the intersection point if there is onw.
+
     } else if(gs.n == 0 && gs.constraints == 1) {
         Constraint *c = SK.GetConstraint(gs.constraint[0]);
         const std::string &desc = c->DescriptionString().c_str();

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -185,7 +185,7 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
 
     if(stog->entity.v != 0 && SK.GetEntity(stog->entity)->IsFace()) {
         // In the interest of speed for the triangle drawing code,
-        // only two faces may be selected at a time.
+        // only three faces may be selected at a time.
         int c = 0;
         Selection *s;
         selection.ClearTags();
@@ -193,7 +193,7 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
             hEntity he = s->entity;
             if(he.v != 0 && SK.GetEntity(he)->IsFace()) {
                 c++;
-                if(c >= 2) s->tag = 1;
+                if(c >= 3) s->tag = 1;
             }
         }
         selection.RemoveTagged();

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -193,6 +193,8 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
             hEntity he = s->entity;
             if(he.v != 0 && SK.GetEntity(he)->IsFace()) {
                 c++;
+                // Modify also Group::DrawMesh "case DrawMeshAs::SELECTED:"
+                // Magic numers are ugly :-(
                 if(c >= 3) s->tag = 1;
             }
         }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -185,7 +185,7 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
 
     if(stog->entity.v != 0 && SK.GetEntity(stog->entity)->IsFace()) {
         // In the interest of speed for the triangle drawing code,
-        // only three faces may be selected at a time.
+        // only MAX_SELECTABLE_FACES faces may be selected at a time.
         int c = 0;
         Selection *s;
         selection.ClearTags();
@@ -193,9 +193,9 @@ void GraphicsWindow::MakeSelected(Selection *stog) {
             hEntity he = s->entity;
             if(he.v != 0 && SK.GetEntity(he)->IsFace()) {
                 c++;
-                // Modify also Group::DrawMesh "case DrawMeshAs::SELECTED:"
-                // Magic numers are ugly :-(
-                if(c >= 3) s->tag = 1;
+                // See also GraphicsWindow::GroupSelection "if(e->IsFace())"
+                // and Group::DrawMesh "case DrawMeshAs::SELECTED:"
+                if(c >= MAX_SELECTABLE_FACES) s->tag = 1;
             }
         }
         selection.RemoveTagged();

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -635,11 +635,11 @@ void Group::DrawMesh(DrawMeshAs how, Canvas *canvas) {
             std::vector<uint32_t> faces;
             SS.GW.GroupSelection();
             auto const &gs = SS.GW.gs;
-            // Modify also GraphicsWindow::MakeSelected "if(c >= 3) s->tag = 1;"
-            // Magic numers are ugly :-(
-            if(gs.faces > 0) faces.push_back(gs.face[0].v);
-            if(gs.faces > 1) faces.push_back(gs.face[1].v);
-            if(gs.faces > 2) faces.push_back(gs.face[2].v);
+            // See also GraphicsWindow::MakeSelected "if(c >= MAX_SELECTABLE_FACES)"
+            // and GraphicsWindow::GroupSelection "if(e->IsFace())"
+            for(auto &fc : gs.face) {
+                faces.push_back(fc.v);
+            }
             canvas->DrawFaces(displayMesh, faces, hcf);
             break;
         }

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -635,8 +635,11 @@ void Group::DrawMesh(DrawMeshAs how, Canvas *canvas) {
             std::vector<uint32_t> faces;
             SS.GW.GroupSelection();
             auto const &gs = SS.GW.gs;
+            // Modify also GraphicsWindow::MakeSelected "if(c >= 3) s->tag = 1;"
+            // Magic numers are ugly :-(
             if(gs.faces > 0) faces.push_back(gs.face[0].v);
             if(gs.faces > 1) faces.push_back(gs.face[1].v);
+            if(gs.faces > 2) faces.push_back(gs.face[2].v);
             canvas->DrawFaces(displayMesh, faces, hcf);
             break;
         }

--- a/src/ui.h
+++ b/src/ui.h
@@ -750,6 +750,7 @@ public:
     Selection hover;
     bool hoverWasSelectedOnMousedown;
     List<Selection> selection;
+    const unsigned MAX_SELECTABLE_FACES = 3u;
 
     Selection ChooseFromHoverToSelect();
     Selection ChooseFromHoverToDrag();


### PR DESCRIPTION
This allows the user to select 3 faces vs the old limit of 2.  I would like to allow constraining a point to more than one face at a time, and 3 would be the maximum. This is a prerequisite to that.

The remaining problem is that the 3rd selected face is not shown as selected. The selection code indicates that the limit of 2 was for rendering performance reasons, which may or may not be a problem today. I'm not sure where the relevant rendering code is to show the selected faces. Help would be appreciated but this is a low priority. Might be a good way for someone to dig into more obscure parts of the code.