### PR TITLE
Stamp source tarballs with the commit hash

### DIFF
--- a/.github/workflows/source-tarball.yml
+++ b/.github/workflows/source-tarball.yml
@@ -21,7 +21,12 @@ jobs:
         dir_name="solvespace-${version}"
         archive_name="${dir_name}.tar.xz"
         archive_path="${HOME}/${archive_name}"
-        
+        commit_sha="$GITHUB_SHA"
+
+        sed -e 's/^\(include(GetGitCommitHash)\)/#\1/' \
+            -e 's/^# \(set(GIT_COMMIT_HASH\).*/\1 '"$commit_sha"')/' \
+            -i CMakeLists.txt
+
         echo "::set-output name=archive_name::${archive_name}"
         echo "::set-output name=archive_path::${archive_path}"
 


### PR DESCRIPTION
As suggested by someone helping with the flathub packaging: https://github.com/rpavlik/flathub/pull/1#discussion_r911211382  Too late for 3.1 but having it in place for the next release will make life easier for packagers (including flatpak)