### PR TITLE
ci: re-enable arm64 snap builds via remote-build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -142,6 +142,46 @@ jobs:
         snap: ${{ steps.build.outputs.snap }}
         release: edge,beta
 
+  deploy_snap_arm64:
+    needs: [test_ubuntu, test_windows, test_macos]
+    concurrency: launchpad-remote-build
+    name: Deploy ARM64 Snap
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install snapcraft
+      run: sudo snap install --classic snapcraft
+    - name: Set up Launchpad credentials & git
+      env:
+        LAUNCHPAD_CREDENTIALS: ${{ secrets.LAUNCHPAD_CREDENTIALS }}
+      run: |
+        mkdir -p  ~/.local/share/snapcraft/provider/launchpad
+        echo "$LAUNCHPAD_CREDENTIALS" > ~/.local/share/snapcraft/provider/launchpad/credentials
+        git config --global user.email "github-actions@github.com"
+        git config --global user.name "Github Actions"
+    - name: Build Snap
+      id: build
+      run: |
+        ./pkg/snap/build.sh remote-build --launchpad-accept-public-upload --build-on=arm64
+        snap_file=$(readlink -f ./pkg/snap/solvespace*.snap | head -1)
+        echo "Snap: $snap_file"
+        echo "::set-output name=snap::$snap_file"
+        cat  ./pkg/snap/solvespace_arm64.txt
+    - name: Upload & Release to Edge
+      if: github.event_name == 'push'
+      uses: snapcore/action-publish@v1
+      with:
+        store_login: ${{ secrets.SNAPSTORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge
+    - name: Upload & Release to Beta + Edge
+      if: github.event_name == 'release'
+      uses: snapcore/action-publish@v1
+      with:
+        store_login: ${{ secrets.SNAPSTORE_LOGIN }}
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge,beta
+
   upload_release_assets:
     name: Upload Release Assets
     needs: [build_release_windows, build_release_windows_openmp, build_release_macos]

--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -2,6 +2,7 @@ name: solvespace
 base: core20
 summary: Parametric 2d/3d CAD
 adopt-info: solvespace
+grade: stable
 description: |
   SOLVESPACE is a free (GPLv3) parametric 3d CAD tool.
   Applications include
@@ -38,6 +39,7 @@ parts:
     source-type: local
     override-pull: |
       snapcraftctl pull
+      chown -R $USER .
       git submodule update --init extlib/libdxfrw extlib/mimalloc extlib/eigen
     override-build: |
       snapcraftctl build
@@ -45,8 +47,6 @@ parts:
       cd $SNAPCRAFT_PART_SRC
       version="$project_version~$(git rev-parse --short=8 HEAD)"
       snapcraftctl set-version "$version"
-      git describe --exact-match HEAD && grade="stable" || grade="devel"
-      snapcraftctl set-grade "$grade"
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Use snapcraft's remote-build feature to outsource building
on arm64 to Launchpad's build servers.

This needs a new secret: LAUNCHPAD_CREDENTIALS
It can be sourced from a local snapcraft installation that has
performed a remote build, or a Launchpad login, before:
~/.local/share/snapcraft/launchpad/credentials

Also fix a problem related to file permissions in override-pull
and declare all snaps stable, regardless of whether they are built
from tagged commits.