### PR TITLE
Bypass desktop portal in Snap

### DIFF
--- a/pkg/snap/snap/snapcraft.yaml
+++ b/pkg/snap/snap/snapcraft.yaml
@@ -27,6 +27,8 @@ apps:
     desktop: solvespace.desktop
     extensions: [gnome]
     plugs: [opengl, unity7, home, removable-media, gsettings, network]
+    environment:
+      GTK_USE_PORTAL: "0"
   cli:
     command: usr/bin/solvespace-cli
     extensions: [gnome]


### PR DESCRIPTION
This will fix https://github.com/solvespace/solvespace/issues/1067 by setting GTK_USE_PORTAL=0 in the Snap package. This will use a file chooser from the point of view of the application to open and save files, instead of using the "desktop portal" where the chooser runs outside the snap and the file is exposed dynamically into the snap at an automatically generated path.

This will allow files used in assemblies to be seen by SolveSpace as being at their real paths, so the references to them will be saved as proper relative-path references based on where the files actually are, instead of as references to where the portal has exposed them.

The downside is that without the portal you can't point the application at files that *aren't* exposed to the Snap.