### PR TITLE
Fix French translations of "Step"

### DIFF
--- a/res/locales/fr_FR.po
+++ b/res/locales/fr_FR.po
@@ -901,11 +901,11 @@ msgstr "Dessin dans un nouveau &Plan de travail"
 
 #: graphicswin.cpp:113
 msgid "Step &Translating"
-msgstr "Espacement &Linéaire"
+msgstr "Répétiter par &Translation"
 
 #: graphicswin.cpp:114
 msgid "Step &Rotating"
-msgstr "Espacement &Circulaire"
+msgstr "Répétiter par &Rotation"
 
 #: graphicswin.cpp:116
 msgid "E&xtrude"
@@ -1117,7 +1117,7 @@ msgstr "&Arrêt Tracé..."
 
 #: graphicswin.cpp:181
 msgid "Step &Dimension..."
-msgstr "Espacement &Dimension..."
+msgstr "&Dimension pas-à-pas..."
 
 #: graphicswin.cpp:183
 msgid "&Help"

--- a/res/locales/fr_FR.po
+++ b/res/locales/fr_FR.po
@@ -901,11 +901,11 @@ msgstr "Dessin dans un nouveau &Plan de travail"
 
 #: graphicswin.cpp:113
 msgid "Step &Translating"
-msgstr "Répétiter par &Translation"
+msgstr "Répéter par &Translation"
 
 #: graphicswin.cpp:114
 msgid "Step &Rotating"
-msgstr "Répétiter par &Rotation"
+msgstr "Répéter par &Rotation"
 
 #: graphicswin.cpp:116
 msgid "E&xtrude"


### PR DESCRIPTION
"Step" has plenty of meanings, and the wrong one was used here: "espacement" roughly means "spacing", which is very confusing for the "Step dimension" feature, and weird for "Step translation"/"Step rotation".

Instead, I chose to translate it as:

* "Pas-à-pas" for the former, which is a noun for lack of a verb that fully captures the meaning, which literally translates to "step-by-step". "Pas-à-pas" is also the common translation of "Step debugging" in programming.
* "Répétiter par" for the latter, which is a verb (+ adverb) which literally translates to "Repeat by" and is the most natural way to phrase this.

As a side-effect, I made a key binding consistent with English.