### PR TITLE
Fix inconsistent French translation of "Rotate Imported"

### DIFF
--- a/res/locales/fr_FR.po
+++ b/res/locales/fr_FR.po
@@ -761,7 +761,7 @@ msgstr "Accrocher la sélection à la &Grille"
 
 #: graphicswin.cpp:66
 msgid "Rotate Imported &90°"
-msgstr "Rotation importation &90°"
+msgstr "Tourner l'import de &90°"
 
 #: graphicswin.cpp:68
 msgid "Cu&t"


### PR DESCRIPTION
"Rotation Importation 90°" was the only noun group in this part of the menu.

This replaces it with an infinitive group like the rest of the menu, which is also easier to understand.