### PR TITLE
Allow all linkable files as missing files to fix #1297

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -918,7 +918,7 @@ try_again:
             switch(LocateImportedFile(linkFileRelative, canCancel)) {
                 case Platform::MessageDialog::Response::YES: {
                     Platform::FileDialogRef dialog = Platform::CreateOpenFileDialog(SS.GW.window);
-                    dialog->AddFilters(Platform::SolveSpaceModelFileFilters);
+                    dialog->AddFilters(Platform::SolveSpaceLinkFileFilters);
                     dialog->ThawChoices(settings, "LinkSketch");
                     dialog->SuggestFilename(linkFileRelative);
                     if(dialog->RunModal()) {


### PR DESCRIPTION
This appears to fix #1297. Using this on top of #1296, I was able to fix up my `.slvs` file with desktop portal paths to STLs to use proper relative paths instead.

I still see extra dialog boxes about how the original, desktop portal path files could not be read, but the re-linking works and my file seems fine afterward.