### PR TITLE
Fix "Constraintes" typo in French locale

### DIFF
--- a/res/locales/fr_FR.po
+++ b/res/locales/fr_FR.po
@@ -997,7 +997,7 @@ msgstr "Diviser les Courbes à l'&Intersection"
 
 #: graphicswin.cpp:145
 msgid "&Constrain"
-msgstr "&Constraintes"
+msgstr "&Contraintes"
 
 #: graphicswin.cpp:146
 msgid "&Distance / Diameter"


### PR DESCRIPTION
Source: https://www.wordreference.com/enfr/constraint