### PR TITLE
Platform: Fix GUI scaling on devices with non-integer pixel ratio

### DIFF
--- a/src/platform/gui.h
+++ b/src/platform/gui.h
@@ -230,7 +230,7 @@ public:
     virtual double GetPixelDensity() = 0;
     // Returns raster graphics and coordinate scale (already applied on the platform side),
     // i.e. size of logical pixel in physical pixels, or device pixel ratio.
-    virtual int GetDevicePixelRatio() = 0;
+    virtual double GetDevicePixelRatio() = 0;
     // Returns (fractional) font scale, to be applied on top of (integral) device pixel ratio.
     virtual double GetDeviceFontScale() {
         return GetPixelDensity() / GetDevicePixelRatio() / 96.0;

--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -889,7 +889,7 @@ public:
         return gtkWindow.get_screen()->get_resolution();
     }
 
-    int GetDevicePixelRatio() override {
+    double GetDevicePixelRatio() override {
         return gtkWindow.get_scale_factor();
     }
 

--- a/src/platform/guihtml.cpp
+++ b/src/platform/guihtml.cpp
@@ -970,8 +970,8 @@ public:
         return 96.0 * emscripten_get_device_pixel_ratio();
     }
 
-    int GetDevicePixelRatio() override {
-        return (int)emscripten_get_device_pixel_ratio();
+    double GetDevicePixelRatio() override {
+        return emscripten_get_device_pixel_ratio();
     }
 
     bool IsVisible() override {

--- a/src/platform/guihtml.cpp
+++ b/src/platform/guihtml.cpp
@@ -808,13 +808,18 @@ public:
         MouseEvent event = {};
         if(emEvent->deltaY != 0) {
             event.type = MouseEvent::Type::SCROLL_VERT;
-            event.scrollDelta = -emEvent->deltaY * 0.1;
+            // FIXME(emscripten):
+            // Pay attention to:
+            //   dbp("Mouse wheel delta mode: %lu", emEvent->deltaMode);
+            //     https://emscripten.org/docs/api_reference/html5.h.html#id11
+            //     https://www.w3.org/TR/DOM-Level-3-Events/#dom-wheelevent-deltamode
+            // and adjust the 0.01 below. deltaMode == 0 on a Firefox on a Windows.
+            event.scrollDelta = -emEvent->deltaY * 0.01;
         } else {
             return EM_FALSE;
         }
 
-        EmscriptenMouseEvent emStatus = {};
-        sscheck(emscripten_get_mouse_status(&emStatus));
+        const EmscriptenMouseEvent &emStatus = emEvent->mouse;
         event.x           = emStatus.targetX;
         event.y           = emStatus.targetY;
         event.shiftDown   = emStatus.shiftKey;

--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -987,10 +987,10 @@ public:
         return (displayPixelSize.width / displayPhysicalSize.width) * 25.4f;
     }
 
-    int GetDevicePixelRatio() override {
+    double GetDevicePixelRatio() override {
         NSSize unitSize = { 1.0f, 0.0f };
         unitSize = [ssView convertSizeToBacking:unitSize];
-        return (int)unitSize.width;
+        return unitSize.width;
     }
 
     bool IsVisible() override {


### PR DESCRIPTION
The fuction GetDevicePixelRatio now returns a `double` instead of an `int`. This should allow the scaling of the GUI on devices where the pixel ratio is non integer to work properly. For example a monitor on Windows where the DPI is not a multiple of 96. It may help with the Web Emscripten port on tablets and phones as well.

In addition on Windows the mouse wheel delta calculation is fixed.