### PR TITLE
Fix equal angle constraints when 3 or 4 lines selected.

### DIFF
--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -312,7 +312,21 @@ void Constraint::MenuConstrain(Command id) {
             break;
 
         case Command::EQUAL:
-            if(gs.lineSegments >= 2 && gs.lineSegments == gs.n) {
+            if(gs.vectors == 3 && gs.n == 3) {
+                c.type = Type::EQUAL_ANGLE;
+                c.entityA = gs.vector[0];
+                c.entityB = gs.vector[1];
+                c.entityC = gs.vector[1];
+                c.entityD = gs.vector[2];
+                newcons.push_back(c);
+            } else if(gs.vectors == 4 && gs.n == 4) {
+                c.type = Type::EQUAL_ANGLE;
+                c.entityA = gs.vector[0];
+                c.entityB = gs.vector[1];
+                c.entityC = gs.vector[2];
+                c.entityD = gs.vector[3];
+                newcons.push_back(c);
+            } else if(gs.lineSegments >= 2 && gs.lineSegments == gs.n) {
                 c.type = Type::EQUAL_LENGTH_LINES;
                 c.entityA = gs.entity[0];
                 for (std::vector<hEntity>::size_type k = 1;k < gs.entity.size(); ++k){
@@ -341,21 +355,7 @@ void Constraint::MenuConstrain(Command id) {
                 c.entityB = gs.entity[1];
                 c.ptA = gs.point[0];
                 newcons.push_back(c);
-            } else if(gs.vectors == 4 && gs.n == 4) {
-                c.type = Type::EQUAL_ANGLE;
-                c.entityA = gs.vector[0];
-                c.entityB = gs.vector[1];
-                c.entityC = gs.vector[2];
-                c.entityD = gs.vector[3];
-                newcons.push_back(c);
-            } else if(gs.vectors == 3 && gs.n == 3) {
-                c.type = Type::EQUAL_ANGLE;
-                c.entityA = gs.vector[0];
-                c.entityB = gs.vector[1];
-                c.entityC = gs.vector[1];
-                c.entityD = gs.vector[2];
-                newcons.push_back(c);
-            } else if(gs.circlesOrArcs >= 2 && gs.circlesOrArcs == gs.n) {
+            } else  if(gs.circlesOrArcs >= 2 && gs.circlesOrArcs == gs.n) {
                 c.type = Type::EQUAL_RADIUS;
                 c.entityA = gs.entity[0];
                 for (std::vector<hEntity>::size_type k = 1;k < gs.entity.size(); ++k){


### PR DESCRIPTION
Variadic constraints broke the cases when 3 or 4 lines were selected, which indicated equal angles. This should fix existing sketches that use that convention.