### PR TITLE
Fix MessageBox Avalanches due to Message blocking

### DIFF
--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -301,12 +301,14 @@ void SolveSpaceUI::Exit() {
 void SolveSpaceUI::Refresh() {
     // generateAll must happen bfore updating displays
     if(scheduledGenerateAll) {
-        GenerateAll(Generate::DIRTY, /*andFindFree=*/false, /*genForBBox=*/false);
+		// Clear the flag so that if the call to GenerateAll is blocked by a Message or Error, 
+		// subsequent refreshes do not try to Generate again.
         scheduledGenerateAll = false;
+        GenerateAll(Generate::DIRTY, /*andFindFree=*/false, /*genForBBox=*/false);   
     }
     if(scheduledShowTW) {
-        TW.Show();
         scheduledShowTW = false;
+        TW.Show();
     }
 }
 


### PR DESCRIPTION
This fixes #1320, but not #1239. The root cause for the avalanche of messages is due to how the refresh timer system calls GenerateAll. When GenerateAll is called by Refresh, if a Message occurs, that Message will block GenerateAll. It _doesn't_ block subsequent calls from the timer to Refresh (presumably from a separate thread). Because the "scheduledGenerateAll" flag is not cleared until after the generation is unblocked, each following refresh triggers another call to GenerateAll. By reversing the flag clear and call, it breaks the cycle. I don't think this matters for scheduledShowTW, but I updated it as well. 

I am going to look into what might be causing #1239 next, but I think it is due to something unrelated.

P.S. I am still getting my bearings on the codebase, so please nitpick away! 