### PR TITLE
Treat group as mesh only if a linked file has a mesh and no shell.

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -412,7 +412,9 @@ bool Group::IsForcedToMesh() const {
 }
 
 bool Group::IsTriangleMeshAssembly() const {
-    return type == Type::LINKED && linkFile.Extension() == "stl";
+    if (type != Type::LINKED) return false;
+    if (!impMesh.IsEmpty() && impShell.IsEmpty()) return true;
+    return false;
 }
 
 std::string Group::DescriptionString() {


### PR DESCRIPTION
Fixes #1269