### PR TITLE
mac: Setting to explicitly choose pan or zoom for mouse wheel (#1339)

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -135,6 +135,13 @@ void TextWindow::ScreenChangeCanvasSizeAuto(int link, uint32_t v) {
     SS.GW.Invalidate();
 }
 
+void TextWindow::ScreenChangeMouseScrollAction(int link, uint32_t v) {
+    if(link == 'c') {
+        SS.mouseScrollAction = (SolveSpaceUI::MouseScrollAction)v;
+    }
+    SS.GW.Invalidate();
+}
+
 void TextWindow::ScreenChangeCanvasSize(int link, uint32_t v) {
     double d;
     switch(v) {
@@ -352,6 +359,23 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "%Ft redundant constraint timeout (in ms)%E");
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
         SS.timeoutRedundantConstr, &ScreenChangeFindConstraintTimeout);
+
+    #if defined(__APPLE__)
+        Printf(false, "");
+        Printf(false, "%Ft mouse scroll / touch pad action");
+        Printf(false, "%Ba   %f%D%Lc%Fd%s auto%E  "
+                            "%f%D%Lc%Fd%s pan%E  "
+                            "%f%D%Lc%Fd%s zoom%E",
+            &ScreenChangeMouseScrollAction,
+            SolveSpaceUI::MouseScrollAction::AUTO,
+            (SS.mouseScrollAction == SolveSpaceUI::MouseScrollAction::AUTO) ? RADIO_TRUE : RADIO_FALSE,
+            &ScreenChangeMouseScrollAction,
+            SolveSpaceUI::MouseScrollAction::PAN,
+            (SS.mouseScrollAction == SolveSpaceUI::MouseScrollAction::PAN) ? RADIO_TRUE : RADIO_FALSE,
+            &ScreenChangeMouseScrollAction,
+            SolveSpaceUI::MouseScrollAction::ZOOM,
+            (SS.mouseScrollAction == SolveSpaceUI::MouseScrollAction::ZOOM) ? RADIO_TRUE : RADIO_FALSE);
+    #endif
 
     if(canvas) {
         const char *gl_vendor, *gl_renderer, *gl_version;

--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -586,8 +586,9 @@ MenuBarRef GetOrCreateMainMenu(bool *unique) {
             nsEvent.subtype == NSEventSubtypeTabletPoint &&
             kind == Platform::Window::Kind::TOPLEVEL;
     }
-    // Check if we are scrolling on trackpad and handle things differently.
-    if(scrollFromTrackpadTouch) {
+    // Check if we are scrolling on trackpad or asked to always pan and then handle things differently.
+    if((SS.mouseScrollAction == SolveSpaceUI::MouseScrollAction::AUTO && scrollFromTrackpadTouch) ||
+       (SS.mouseScrollAction == SolveSpaceUI::MouseScrollAction::PAN && kind == Platform::Window::Kind::TOPLEVEL)) {
         // This is how Cocoa represents 2 finger trackpad drag gestures, rather than going via
         // NSPanGestureRecognizer which is how you might expect this to work... We complicate this
         // further by also handling shift-two-finger-drag to mean rotate. Fortunately we're using

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -95,6 +95,8 @@ void SolveSpaceUI::Init() {
     backgroundColor = settings->ThawColor("BackgroundColor", RGBi(0, 0, 0));
     // Whether export canvas size is fixed or derived from bbox
     exportCanvasSizeAuto = settings->ThawBool("ExportCanvasSizeAuto", true);
+    // Mouse scroll action
+    mouseScrollAction = (MouseScrollAction)settings->ThawInt("MouseScrollAction", (uint32_t)MouseScrollAction::AUTO);
     // Margins for automatic canvas size
     exportMargin.left   = settings->ThawFloat("ExportMargin_Left",   5.0);
     exportMargin.right  = settings->ThawFloat("ExportMargin_Right",  5.0);
@@ -295,6 +297,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeBool("ShowToolbar", showToolbar);
     // Autosave timer
     settings->FreezeInt("AutosaveInterval", autosaveInterval);
+    // Mouse scroll action
+    settings->FreezeInt("MouseScrollAction", (uint32_t)mouseScrollAction);
 
     // And the default styles, colors and line widths and such.
     Style::FreezeDefaultStyles(settings);

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -608,6 +608,12 @@ public:
         double  feed;
         double  plungeFeed;
     }        gCode;
+    enum class MouseScrollAction : uint32_t {
+        AUTO,
+        PAN,
+        ZOOM,
+    };
+    MouseScrollAction mouseScrollAction;
 
     Unit     viewUnits;
     int      afterDecimalMm;

--- a/src/ui.h
+++ b/src/ui.h
@@ -455,6 +455,7 @@ public:
     static void ScreenChangeCanvasSizeAuto(int link, uint32_t v);
     static void ScreenChangeCanvasSize(int link, uint32_t v);
     static void ScreenChangeShadedTriangles(int link, uint32_t v);
+    static void ScreenChangeMouseScrollAction(int link, uint32_t v);
 
     static void ScreenAllowRedundant(int link, uint32_t v);
 


### PR DESCRIPTION
While auto remains the default, we now support explicit choice of doing pan or zoom when scrolling with mouse wheel or touch pad.

This can be also adapted for other (non-macOS) platforms.