### PR TITLE
Fix a crash when constraining a line segment symmetric

### DIFF
--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -580,8 +580,8 @@ void Constraint::MenuConstrain(Command id) {
                         Entity::NO_ENTITY);
                     DeleteAllConstraintsFor(Type::VERTICAL, (gs.entity[0]),
                         Entity::NO_ENTITY);
-                    newcons.push_back(c);
                     AddConstraint(&c, /*rememberForUndo=*/false);
+                    newcons.push_back(c);
                     break;
                 }
             }


### PR DESCRIPTION
This was a regression Introduced in 3d3d5c7.
Fixes #1345