### PR TITLE
UI: Add Ctrl+Shift+S keyboard shortuct for Save As

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -43,7 +43,7 @@ const MenuEntry Menu[] = {
 { 1, N_("&Open..."),                    Command::OPEN,             C|'o',   KN, mFile  },
 { 1, N_("Open &Recent"),                Command::OPEN_RECENT,      0,       KN, mFile  },
 { 1, N_("&Save"),                       Command::SAVE,             C|'s',   KN, mFile  },
-{ 1, N_("Save &As..."),                 Command::SAVE_AS,          0,       KN, mFile  },
+{ 1, N_("Save &As..."),                 Command::SAVE_AS,          C|S|'s', KN, mFile  },
 { 1,  NULL,                             Command::NONE,             0,       KN, NULL   },
 { 1, N_("Export &Image..."),            Command::EXPORT_IMAGE,     0,       KN, mFile  },
 { 1, N_("Export 2d &View..."),          Command::EXPORT_VIEW,      0,       KN, mFile  },


### PR DESCRIPTION
Many desktop programs use this shortcut for the "Save As" dialog, so it makes sense to add it here so that different variants of parts can be quickly created.

Examples of using Ctrl+Shift+S in other programs:

Openscad:

![image](https://github.com/solvespace/solvespace/assets/5400940/4e0f8493-3c4d-4947-8cba-148454a7dc8d)

LibreOffice:

![image](https://github.com/solvespace/solvespace/assets/5400940/99bb0054-602a-40b1-a960-3d6266395b02)

