### PR TITLE
Update the issue template to show where to look for SolveSpace version on macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### System information
 
-- **SolveSpace version:** <!--e.g. 3.0~3dd2fc00; go to Help → About...-->
+- **SolveSpace version:** <!--e.g. 3.1~70bde63c; go to Help → About… / SolveSpace → About SolveSpace (macOS)-->
 - **Operating system:** <!--e.g. Debian testing-->
 
 ### Expected behavior


### PR DESCRIPTION
macOS SolveSpace has the Help menu but it lacks the About menu item in it and instead the way to find the SolveSpace version is to go to SolveSpace > About SolveSpace. This PR updates the issue template to show that.

I have also replaced the `...` with an ellipsis (`…`) as it IMO looks better (can revert this if it doesn't match the menu item on Windows/Linux) and updated the example version to the current SolveSpace version.