### PR TITLE
Win32: Fix for compiling with MinGW.org GCC-6.3.0-1

### DIFF
--- a/src/platform/platform.cpp
+++ b/src/platform/platform.cpp
@@ -645,6 +645,12 @@ std::vector<std::string> InitCli(int argc, char **argv) {
 
 #if defined(WIN32)
 
+#if !defined(_alloca)
+// Fix for compiling with MinGW.org GCC-6.3.0-1
+#define _alloca alloca
+#include <malloc.h>
+#endif
+
 void DebugPrint(const char *fmt, ...)
 {
     va_list va;


### PR DESCRIPTION
MinGW-w64 MinGW-Builds 13.1.0 on the other hand does not need this.