### PR TITLE
Do not include construction images in extrude/lathe/revolve/helix

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1180,6 +1180,11 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
             break;
 
         default: {
+            if((Entity::Type::IMAGE == ep->type) && (true == ep->construction)) {
+                // Do not copy image entities if they are construction.
+                return;
+            }
+
             int i, points;
             bool hasNormal, hasDistance;
             EntReqTable::GetEntityInfo(ep->type, ep->extraPoints,

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1138,6 +1138,7 @@ void GraphicsWindow::MouseLeftDown(double mx, double my, bool shiftDown, bool ct
                     AddToPending(hr);
                     Request *r = SK.GetRequest(hr);
                     r->file = pending.filename;
+                    r->construction = true;
 
                     for(int i = 1; i <= 4; i++) {
                         SK.GetEntity(hr.entity(i))->PointForceTo(v);


### PR DESCRIPTION
To avoid unnecessary/annoying copies of images added in 2d sketches if they are marked "construction" they will not be copied when creating solids.

Fixes: #1418