### PR TITLE
Keep old entities when splitting lines/curves

### DIFF
--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -461,8 +461,8 @@ hEntity GraphicsWindow::SplitLine(hEntity he, Vector pinter) {
     SK.GetEntity(ei1->point[0])->PointForceTo(pinter);
     SK.GetEntity(ei1->point[1])->PointForceTo(p1);
 
-    ReplacePointInConstraints(hep0, e0i->point[0]);
-    ReplacePointInConstraints(hep1, ei1->point[1]);
+    Constraint::ConstrainCoincident(hep0, e0i->point[0]);
+    Constraint::ConstrainCoincident(hep1, ei1->point[1]);
     Constraint::ConstrainCoincident(e0i->point[1], ei1->point[0]);
     return e0i->point[1];
 }
@@ -508,8 +508,8 @@ hEntity GraphicsWindow::SplitCircle(hEntity he, Vector pinter) {
         SK.GetEntity(arc1->point[1])->PointForceTo(pinter);
         SK.GetEntity(arc1->point[2])->PointForceTo(finish);
 
-        ReplacePointInConstraints(hs, arc0->point[1]);
-        ReplacePointInConstraints(hf, arc1->point[2]);
+        Constraint::ConstrainCoincident(hs, arc0->point[1]);
+        Constraint::ConstrainCoincident(hf, arc1->point[2]);
         Constraint::ConstrainCoincident(arc0->point[2], arc1->point[1]);
         return arc0->point[2];
     }
@@ -575,8 +575,8 @@ hEntity GraphicsWindow::SplitCubic(hEntity he, Vector pinter) {
 
     sbl.Clear();
 
-    ReplacePointInConstraints(hep0, hep0n);
-    ReplacePointInConstraints(hep1, hep1n);
+    Constraint::ConstrainCoincident(hep0, hep0n);
+    Constraint::ConstrainCoincident(hep1, hep1n);
     return hepin;
 }
 
@@ -598,21 +598,18 @@ hEntity GraphicsWindow::SplitEntity(hEntity he, Vector pinter) {
 
     // Finally, delete the request that generated the original entity.
     Request::Type reqType = EntReqTable::GetRequestForEntity(entityType);
-    SK.request.ClearTags();
     for(auto &r : SK.request) {
         if(r.group != activeGroup)
             continue;
         if(r.type != reqType)
             continue;
 
-        // If the user wants to keep the old entities around, they can just
-        // mark them construction first.
+        // Mark old entities as construction
         if(he == r.h.entity(0) && !r.construction) {
-            r.tag = 1;
+            r.construction = true;
             break;
         }
     }
-    DeleteTaggedRequests();
 
     return ret;
 }


### PR DESCRIPTION
I mostly did this as an exercise to introduce myself to working with Solvespace's code. I've probably managed to do something weird or overlook something, and I don't claim to know what other peoples' use cases are. No hard feelings if this isn't something you want merged :)

This fixes a couple issues I had with it:
- `Tangent arc at point` marks old entities as construction, and this (new way) is more consistent with that
- Deleting the old entities means you lose their constraints, and lose anything else that depends on them* (you can mark them as construction to keep them as-is, but you still have to replace the coincident constraints on the endpoints. And I didn't even know you could do this until I looked through the code)
- If you don't realize you're deleting the old entities (if you expect it to behave like `tangent arc at point`, or if you don't realize that you lose the old coincident constraints), you risk messing up your sketch/model.

**This is somewhat off topic, but it feels way to easy to accidentally delete a group without realizing it, unless you're paying close attention to all the dialog boxes. Not sure what good solution there would be, though.*

The problems I still have with the new approach:
- There's no way to not keep the old entities - but this isn't really a problem, because you can just delete the old ones afterwards if you don't want them.
- New entities are constrained to the *endpoints* of the old ones, but not constrained to them at the point where they meet. I would have tried to add this except for that there's no "point on spline" constraint, which would mean that only some parts could be constrained.
- If you split the same entity a bunch of times, you get a bunch of extra entities. This becomes pretty annoying unless you keep on top of deleting the ones you don't want, and it becomes *really* messy if you start dragging points around. Idk how many people are going around doing things like this. Perhaps this is why the current behavior is the way it is. 

And a weird thing, that happens (and should probably be its own issue), is that splines get split at their control points, no matter what. Or is that intentional/neccesary?