### PR TITLE
[WIP] Fix MacOS Build

### DIFF
--- a/.github/scripts/install-macos.sh
+++ b/.github/scripts/install-macos.sh
@@ -1,8 +1,8 @@
 #!/bin/sh -xe
 
 if [ "$1" = "ci" ]; then
-    armloc=$(brew fetch --bottle-tag=arm64_big_sur libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
-    x64loc=$(brew fetch --bottle-tag=big_sur libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
+    armloc=$(brew fetch --bottle-tag=arm64_ventura libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
+    x64loc=$(brew fetch --bottle-tag=ventura libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
     cp $armloc /tmp/libomp-arm64.tar.gz
     mkdir /tmp/libomp-arm64 || true
     tar -xzvf /tmp/libomp-arm64.tar.gz -C /tmp/libomp-arm64


### PR DESCRIPTION
Big Sur -> Ventura

I'm trying to get solvespace to build on aarch64 MacOS Ventura. The CI Build for MacOS is failing because homebrew no longer has the big_sur tags downloaded in the macos-install.sh script