### PR TITLE
[web] Add allocate function as emscripten dep

### DIFF
--- a/cmake/Platform/Emscripten.cmake
+++ b/cmake/Platform/Emscripten.cmake
@@ -10,7 +10,7 @@ set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
 
 # FIXME(emscripten): Suppress non-c-typedef-for-linkage warnings in solvespace.h
 add_compile_options(-Wno-non-c-typedef-for-linkage)
-
+add_link_options(-s EXPORTED_RUNTIME_METHODS=[allocate])
 
 # Enable optimization. Workaround for "too many locals" error when runs on browser.
 if(CMAKE_BUILD_TYPE STREQUAL Release)


### PR DESCRIPTION
Web version crashes when you try to make a constraint. After debugging, addressed the issue with this PR. Emscripten does some optimization stuff and ends up dropping certain functions, including the alloacte function called in solvespace's C++ Unwrap method.

To reproduce/test bug:
- Open the web version
- Create a rectangle
- Create a length constraint on one the rectangle edges