### PR TITLE
fix pt-line distance constraint bug on paste transformed

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -249,8 +249,10 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
             case Constraint::Type::COMMENT:
                 c.disp.offset = c.disp.offset.Plus(trans);
                 break;
-            case Constraint::Type::PT_PT_DISTANCE:
             case Constraint::Type::PT_LINE_DISTANCE:
+                c.valA *= scale;
+                break;
+            case Constraint::Type::PT_PT_DISTANCE:
             case Constraint::Type::PROJ_PT_DISTANCE:
             case Constraint::Type::DIAMETER:
                 c.valA *= fabs(scale);


### PR DESCRIPTION
fixes issue #1372
As mentioned in issue, this bug is caused by using absolute value of `scale` when calculating constraints in paste transformed. 
I removed `fabs()` exactly for pt_line_distance case.
Tested for different geometry and it works ok now.
![screen_record](https://github.com/solvespace/solvespace/assets/55877620/d929649e-6374-40f6-8c32-875453c47dee)


I'm quite new to open-source contributions on GitHub, so excuse me if i missed something or did something wrong.