### PR TITLE
Changes to do not hide comments with a custom style when hide constraints enabled (#1070)

### DIFF
--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -449,10 +449,21 @@ void Constraint::DoArcForAngle(Canvas *canvas, Canvas::hStroke hcs,
 }
 
 bool Constraint::IsVisible() const {
-    if(SS.GW.showConstraints == GraphicsWindow::ShowConstraintMode::SCM_NOSHOW) 
-        return false;
-    bool isDim = false;
+    if (type == Type::COMMENT && disp.style.v){
+        Style *s = Style::Get(disp.style);
+        if(s->visible && (s->h.v >= Style::FIRST_CUSTOM)) {
+            return true;
+        }
+        else if (!s->visible && (s->h.v >= Style::FIRST_CUSTOM)) {
+            return false;
+        }
+    }
 
+    if(SS.GW.showConstraints == GraphicsWindow::ShowConstraintMode::SCM_NOSHOW) {
+        return false;
+    }
+
+    bool isDim = false;
     if(SS.GW.showConstraints == GraphicsWindow::ShowConstraintMode::SCM_SHOW_DIM)
         switch(type) {
         case ConstraintBase::Type::ANGLE:


### PR DESCRIPTION
This PR attempts to achieve the requested changes in the Issue #1070

This is my first contribution to an open source project. Sorry in advance if I'm doing something wrong.

#### Changes
To evaluate if the comment has to be hidden, a check is made to see that the comment has a custom style and the "show this objects on screen" option is enabled.

This check is done at the beginning of the method responsible for evaluating visibility.

#### Tests
With "show this objects on screen" enabled:
![CommentOn](https://github.com/solvespace/solvespace/assets/59566401/297c0d9d-1663-49ad-927c-2129a4978f74)

With "show this objects on screen" disabled:
![CommentOff](https://github.com/solvespace/solvespace/assets/59566401/03925c01-7360-4f93-84b1-222ab431e5cd)

#### System information:
* macOS Sonoma 14.2.1 Apple M1
