### PR TITLE
Add option to show only SLVS file name in the title of main window

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -74,6 +74,11 @@ void TextWindow::ScreenChangeArcDimDefault(int link, uint32_t v) {
     SS.arcDimDefaultDiameter = !SS.arcDimDefaultDiameter;
 }
 
+void TextWindow::ScreenChangeShowFullFilePath(int link, uint32_t v) {
+    SS.showFullFilePath = !SS.showFullFilePath;
+    SS.UpdateWindowTitles();
+}
+
 void TextWindow::ScreenChangeFixExportColors(int link, uint32_t v) {
     SS.fixExportColors = !SS.fixExportColors;
 }
@@ -351,6 +356,8 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "  %Fd%f%Ll%s  arc default is diameter%E",
         &ScreenChangeArcDimDefault,
         SS.arcDimDefaultDiameter ? CHECK_TRUE : CHECK_FALSE);
+    Printf(false, "  %Fd%f%Ll%s  show full file path in the window title%E",
+           &ScreenChangeShowFullFilePath, SS.showFullFilePath ? CHECK_TRUE : CHECK_FALSE);
     Printf(false, "");
     Printf(false, "%Ft autosave interval (in minutes)%E");
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -71,6 +71,8 @@ void SolveSpaceUI::Init() {
     exportOffset = settings->ThawFloat("ExportOffset", 0.0);
     // Dimensions on arcs default to diameter vs radius
     arcDimDefaultDiameter = settings->ThawBool("ArcDimDefaultDiameter", false);
+    // Show full file path in the menu bar
+    showFullFilePath = settings->ThawBool("ShowFullFilePath", true);
     // Rewrite exported colors close to white into black (assuming white bg)
     fixExportColors = settings->ThawBool("FixExportColors", true);
     // Export background color
@@ -254,6 +256,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeFloat("ExportOffset", exportOffset);
     // Rewrite the default arc dimension setting
     settings->FreezeBool("ArcDimDefaultDiameter", arcDimDefaultDiameter);
+    // Show full file path in the menu bar
+    settings->FreezeBool("ShowFullFilePath", showFullFilePath);
     // Rewrite exported colors close to white into black (assuming white bg)
     settings->FreezeBool("FixExportColors", fixExportColors);
     // Export background color
@@ -664,7 +668,11 @@ void SolveSpaceUI::UpdateWindowTitles() {
         GW.window->SetTitle(C_("title", "(new sketch)"));
     } else {
         if(!GW.window->SetTitleForFilename(saveFile)) {
-            GW.window->SetTitle(saveFile.raw);
+            if(SS.showFullFilePath) {
+                GW.window->SetTitle(saveFile.raw);
+            } else {
+                GW.window->SetTitle(saveFile.raw.substr(saveFile.raw.find_last_of("/\\") + 1));
+            }
         }
     }
 

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -574,6 +574,7 @@ public:
     double   exportScale;
     double   exportOffset;
     bool     arcDimDefaultDiameter;
+    bool     showFullFilePath;
     bool     fixExportColors;
     bool     exportBackgroundColor;
     bool     drawBackFaces;

--- a/src/ui.h
+++ b/src/ui.h
@@ -443,6 +443,7 @@ public:
     static void ScreenGoToWebsite(int link, uint32_t v);
 
     static void ScreenChangeArcDimDefault(int link, uint32_t v);
+    static void ScreenChangeShowFullFilePath(int link, uint32_t v);
     static void ScreenChangeFixExportColors(int link, uint32_t v);
     static void ScreenChangeExportBackgroundColor(int link, uint32_t v);
     static void ScreenChangeBackFaces(int link, uint32_t v);


### PR DESCRIPTION
This PR is for [issue #855](https://github.com/solvespace/solvespace/issues/855) and allows only the filename to display in the title bar rather than the full file path. A configuration item has been added under "arc default is diameter" for "show full file path in the window title." Toggling the configuration item will show/hide the full path and the setting persists after restart.  
This has only been tested on a Windows 11 machine. Please let me know if any tweaks need to be made. 