### PR TITLE
NFC: Remove ToDo comment that appears to be done

### DIFF
--- a/src/ttf.cpp
+++ b/src/ttf.cpp
@@ -81,9 +81,6 @@ void TtfFontList::LoadAll() {
                               [](const TtfFont &a, const TtfFont &b) { return a.name == b.name; });
     l.RemoveLast(&l[l.n] - it);
 
-    //! @todo identify fonts by their name and not filename, which may change
-    //! between OSes.
-
     loaded = true;
 }
 


### PR DESCRIPTION
The comment "@todo identify fonts by their name and not filename" was was added in https://github.com/solvespace/solvespace/commit/784f3e55481e99885f1c64b94b7cee49ea670158 but seems to have been already implemented at that time since TTF fonts are sorted and filtered by their font name instead of file name.