### PR TITLE
Fix saving assemblies when opened with a relative path on the command…

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -246,7 +246,7 @@ void SolveSpaceUI::SaveUsingTable(const Platform::Path &filename, int type) {
 
             case 'P': {
                 if(!p->P().IsEmpty()) {
-                    Platform::Path relativePath = p->P().RelativeTo(filename.Parent());
+                    Platform::Path relativePath = p->P().Expand(/*fromCurrentDirectory=*/true).RelativeTo(filename.Parent());
                     ssassert(!relativePath.IsEmpty(), "Cannot relativize path");
                     fprintf(fh, "%s", relativePath.ToPortable().c_str());
                 }
@@ -285,7 +285,7 @@ bool SolveSpaceUI::SaveToFile(const Platform::Path &filename) {
     for(Group &g : SK.group) {
         if(g.type != Group::Type::LINKED) continue;
 
-        if(g.linkFile.RelativeTo(filename).IsEmpty()) {
+        if(g.linkFile.Expand(/*fromCurrentDirectory=*/true).RelativeTo(filename).IsEmpty()) {
             Error("This sketch links the sketch '%s'; it can only be saved "
                   "on the same volume.", g.linkFile.raw.c_str());
             return false;


### PR DESCRIPTION
… line.

When a file containing linked files (an assembly) was opened by passing a relative path to it on the command line; saving it would fail with an error:
"This sketch links the sketch '%s'; it can only be saved on the same volume."

The problem stems from not `Expand`-ing paths immediately in `main` which was introduced in 3ea8ebf see here for details:
https://github.com/solvespace/solvespace/issues/1474#issuecomment-2361853738

The fix is to expand paths to linked files before making them relative to the assembly.

Fixes #1465