### PR TITLE
Win32: the Property Browser remains visible when going full screen (CTRL-F11)

### DIFF
--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1146,7 +1146,7 @@ public:
             sscheck(GetMonitorInfo(MonitorFromWindow(hWindow, MONITOR_DEFAULTTONEAREST), &mi));
 
             sscheck(SetWindowLong(hWindow, GWL_STYLE, style & ~WS_OVERLAPPEDWINDOW));
-            sscheck(SetWindowPos(hWindow, HWND_TOP,
+            sscheck(SetWindowPos(hWindow, HWND_NOTOPMOST,
                                  mi.rcMonitor.left, mi.rcMonitor.top,
                                  mi.rcMonitor.right - mi.rcMonitor.left,
                                  mi.rcMonitor.bottom - mi.rcMonitor.top,


### PR DESCRIPTION
On Windows when going full screen by pressing CTRL-F11 the Property Browser window remained hidden behind the main window until one ALT-Tab-ed to it or to another application and back.

This commit fixes it.

The fix is not mine. It comes from this Chinese fork: https://gitee.com/zhongzhiSys/SolveSpace
where they mostly took 2.3 and started selectively merging fixes from 3.x with their own commit messages. There are however original fixes like this one interspersed with the merges. I have not finished going through everything.