### PR TITLE
GUI: Allow ESC to finish drawing bezier curves instead of deleting them.

### DIFF
--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -1106,7 +1106,6 @@ void GraphicsWindow::MenuEdit(Command id) {
             if ( (SS.GW.pending.operation == Pending::DRAGGING_NEW_POINT)
               || (SS.GW.pending.operation == Pending::DRAGGING_NEW_LINE_POINT)
               || (SS.GW.pending.operation == Pending::DRAGGING_NEW_ARC_POINT)
-              || (SS.GW.pending.operation == Pending::DRAGGING_NEW_CUBIC_POINT)
               || (SS.GW.pending.operation == Pending::DRAGGING_NEW_RADIUS) )
             {
               SS.GW.ClearSuper();


### PR DESCRIPTION
With this pressing ESC while drawing a bezier curve finishes it instead of deleting it. This reverts the behaviour introduced in b34d9a2f1161362f049a4e380cc81acd3262bedd (p.r. #1386). ESC still deletes the last segment of line segments and cancels arcs and circles.

This makes it easier to draw non closed curves - otherwise the only way to finish them was with a right-click.