### PR TITLE
Make the animation speed configurable

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -372,7 +372,7 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
         SS.timeoutRedundantConstr, &ScreenChangeFindConstraintTimeout);
     Printf(false, "");
-    Printf(false, "%Ft animation speed (in ms)%E");
+    Printf(false, "%Ft animation speed (in ms; 0 to disable)%E");
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
         SS.animationSpeed, &ScreenChangeAnimationSpeed);
 
@@ -574,12 +574,10 @@ bool TextWindow::EditControlDoneForConfiguration(const std::string &s) {
         }
         case Edit::ANIMATION_SPEED: {
             int speed = atoi(s.c_str());
-            if(speed) {
-                if(speed >= 1) {
-                    SS.animationSpeed = speed;
-                } else {
-                    SS.animationSpeed = 1000;
-                }
+            if(speed >= 0) {
+                SS.animationSpeed = speed;
+            } else {
+                SS.animationSpeed = 800;
             }
             break;
         }

--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -207,6 +207,11 @@ void TextWindow::ScreenChangeFindConstraintTimeout(int link, uint32_t v) {
     SS.TW.edit.meaning = Edit::FIND_CONSTRAINT_TIMEOUT;
 }
 
+void TextWindow::ScreenChangeAnimationSpeed(int link, uint32_t v) {
+    SS.TW.ShowEditControl(3, std::to_string(SS.animationSpeed));
+    SS.TW.edit.meaning = Edit::ANIMATION_SPEED;
+}
+
 void TextWindow::ShowConfiguration() {
     int i;
     Printf(true, "%Ft user color (r, g, b)");
@@ -366,6 +371,10 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "%Ft redundant constraint timeout (in ms)%E");
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
         SS.timeoutRedundantConstr, &ScreenChangeFindConstraintTimeout);
+    Printf(false, "");
+    Printf(false, "%Ft animation speed (in ms)%E");
+    Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",
+        SS.animationSpeed, &ScreenChangeAnimationSpeed);
 
     if(canvas) {
         const char *gl_vendor, *gl_renderer, *gl_version;
@@ -559,6 +568,17 @@ bool TextWindow::EditControlDoneForConfiguration(const std::string &s) {
                     SS.timeoutRedundantConstr = timeout;
                 } else {
                     SS.timeoutRedundantConstr = 1000;
+                }
+            }
+            break;
+        }
+        case Edit::ANIMATION_SPEED: {
+            int speed = atoi(s.c_str());
+            if(speed) {
+                if(speed >= 1) {
+                    SS.animationSpeed = speed;
+                } else {
+                    SS.animationSpeed = 1000;
                 }
             }
             break;

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -503,12 +503,18 @@ void GraphicsWindow::AnimateOnto(Quaternion quatf, Vector offsetf) {
 
     // Animate transition, unless it's a tiny move.
     int64_t t0 = GetMilliseconds();
-    int32_t dt = (mp < 0.01 && mo < 10) ? (-20) :
-                     (int32_t)(100 + 600*mp + 0.4*mo);
-    // Don't ever animate for longer than 800 ms; we can get absurdly
+    int32_t dt = (mp < 0.01 && mo < 10) ? 0 :
+                     (int32_t)(SS.animationSpeed*0.75*mp + SS.animationSpeed*0.0005*mo);
+    // Apply a minimum animation time, for small moves. This gets overridden by the maximum setting
+    // so setting the animation speed to 0 disables animations entirely.
+    dt = std::max(dt, 100 /* ms */);
+    // Don't ever animate for longer than animationSpeed ms; we can get absurdly
     // long translations (as measured in pixels) if the user zooms out, moves,
     // and then zooms in again.
-    if(dt > 800) dt = 800;
+    dt = std::min(dt, SS.animationSpeed);
+    // If the resulting animation time is very short, disable it completely.
+    if (dt < 100) dt = -20;
+    
     Quaternion dq = quatf.Times(quat0.Inverse());
 
     if(!animateTimer) {

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -513,7 +513,7 @@ void GraphicsWindow::AnimateOnto(Quaternion quatf, Vector offsetf) {
     // and then zooms in again.
     dt = std::min(dt, SS.animationSpeed);
     // If the resulting animation time is very short, disable it completely.
-    if (dt < 100) dt = -20;
+    if (dt < 10) dt = -20;
     
     Quaternion dq = quatf.Times(quat0.Inverse());
 

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -54,6 +54,8 @@ void SolveSpaceUI::Init() {
     exportMaxSegments = settings->ThawInt("ExportMaxSegments", 64);
     // Timeout value for finding redundant constrains (ms)
     timeoutRedundantConstr = settings->ThawInt("TimeoutRedundantConstraints", 1000);
+    // Animation speed calculation base time (ms)
+    animationSpeed = settings->ThawInt("AnimationSpeed", 1000);
     // View units
     viewUnits = (Unit)settings->ThawInt("ViewUnits", (uint32_t)Unit::MM);
     // Number of digits after the decimal point
@@ -239,6 +241,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeInt("ExportMaxSegments", (uint32_t)exportMaxSegments);
     // Timeout for finding which constraints to fix Jacobian
     settings->FreezeInt("TimeoutRedundantConstraints", (uint32_t)timeoutRedundantConstr);
+    // Animation speed
+    settings->FreezeInt("AnimationSpeed", (uint32_t)animationSpeed);
     // View units
     settings->FreezeInt("ViewUnits", (uint32_t)viewUnits);
     // Number of digits after the decimal point

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -55,7 +55,7 @@ void SolveSpaceUI::Init() {
     // Timeout value for finding redundant constrains (ms)
     timeoutRedundantConstr = settings->ThawInt("TimeoutRedundantConstraints", 1000);
     // Animation speed calculation base time (ms)
-    animationSpeed = settings->ThawInt("AnimationSpeed", 1000);
+    animationSpeed = settings->ThawInt("AnimationSpeed", 800);
     // View units
     viewUnits = (Unit)settings->ThawInt("ViewUnits", (uint32_t)Unit::MM);
     // Number of digits after the decimal point

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -569,6 +569,7 @@ public:
     double   exportChordTol;
     int      exportMaxSegments;
     int      timeoutRedundantConstr; //milliseconds
+    int      animationSpeed; //milliseconds
     double   cameraTangent;
     double   gridSpacing;
     double   exportScale;

--- a/src/ui.h
+++ b/src/ui.h
@@ -323,6 +323,7 @@ public:
         LIGHT_AMBIENT         = 118,
         FIND_CONSTRAINT_TIMEOUT = 119,
         EXPLODE_DISTANCE      = 120,
+        ANIMATION_SPEED       = 121,
         // For TTF text
         TTF_TEXT              = 300,
         // For the step dimension screen
@@ -505,6 +506,7 @@ public:
     static void ScreenChangeGCodeParameter(int link, uint32_t v);
     static void ScreenChangeAutosaveInterval(int link, uint32_t v);
     static void ScreenChangeFindConstraintTimeout(int link, uint32_t v);
+    static void ScreenChangeAnimationSpeed(int link, uint32_t v);
     static void ScreenChangeStyleName(int link, uint32_t v);
     static void ScreenChangeStyleMetric(int link, uint32_t v);
     static void ScreenChangeStyleTextAngle(int link, uint32_t v);


### PR DESCRIPTION
This is a minor adjustment to add a configuration setting for the animation speed, including disabling them completely.

![image](https://github.com/user-attachments/assets/cca37252-1d22-4e0f-9c64-41bec5e2cf9b)

The animation time equation has been slightly changed to accommodate this, but it should behave mostly the same as before. With the default setting of 800ms you should get approximately the same as before.