### PR TITLE
Build cleanup

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -285,6 +285,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
                 }
                 break;
             }
+                // Fall through...
             case Constraint::Type::HORIZONTAL:
             case Constraint::Type::VERTICAL:
                 // When rotating 90 or 270 degrees, swap the vertical / horizontal constraints

--- a/src/dsc.h
+++ b/src/dsc.h
@@ -7,8 +7,6 @@
 #ifndef SOLVESPACE_DSC_H
 #define SOLVESPACE_DSC_H
 
-#include "solvespace.h"
-
 #include <type_traits>
 #include <vector>
 

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -179,9 +179,15 @@ enum class SolveResult : uint32_t {
 
 
 // Utility functions that are provided in the platform-independent code.
-class utf8_iterator : std::iterator<std::forward_iterator_tag, char32_t> {
+class utf8_iterator {
     const char *p, *n;
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = char32_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = char32_t*;
+    using reference = char32_t&;
+
     utf8_iterator(const char *p) : p(p), n(NULL) {}
     bool           operator==(const utf8_iterator &i) const { return p==i.p; }
     bool           operator!=(const utf8_iterator &i) const { return p!=i.p; }


### PR DESCRIPTION
The [libdxfrw](https://github.com/solvespace/libdxfrw/pull/14) change allows the `DEBUG` macro to be used when building Solvespace.

The circular solvespace.h include is part of the [Qt pull request](https://github.com/solvespace/solvespace/pull/1451), but since that is stuck in limbo I'll try including it here.