### PR TITLE
Add an option for GraphicsWindow zoom to stay centered in view.

### DIFF
--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -105,6 +105,10 @@ void TextWindow::ScreenChangeCameraNav(int link, uint32_t v) {
     SS.cameraNav = !SS.cameraNav;
 }
 
+void TextWindow::ScreenChangeZoomNav(int link, uint32_t v) {
+    SS.zoomCenterNav = !SS.zoomCenterNav;
+}
+
 void TextWindow::ScreenChangeImmediatelyEditDimension(int link, uint32_t v) {
     SS.immediatelyEditDimension = !SS.immediatelyEditDimension;
     SS.GW.Invalidate(/*clearPersistent=*/true);
@@ -355,6 +359,8 @@ void TextWindow::ShowConfiguration() {
         SS.cameraNav ? CHECK_TRUE : CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  use turntable mouse navigation%E", &ScreenChangeTurntableNav,
         SS.turntableNav ? CHECK_TRUE : CHECK_FALSE);
+    Printf(false, "  %Fd%f%Ll%s  zoom keeping view centered%E", &ScreenChangeZoomNav,
+        SS.zoomCenterNav ? CHECK_TRUE : CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  edit newly added dimensions%E",
         &ScreenChangeImmediatelyEditDimension,
         SS.immediatelyEditDimension ? CHECK_TRUE : CHECK_FALSE);

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -725,14 +725,19 @@ double GraphicsWindow::ZoomToFit(const Camera &camera,
 
 
 void GraphicsWindow::ZoomToMouse(double zoomMultiplyer) {
-    double offsetRight = offset.Dot(projRight);
-    double offsetUp    = offset.Dot(projUp);
+    double offsetRight, offsetUp;
+    double righti, upi;
 
-    double width, height;
-    window->GetContentSize(&width, &height);
+    if (! SS.zoomCenterNav) {
+        offsetRight = offset.Dot(projRight);
+        offsetUp    = offset.Dot(projUp);
 
-    double righti = currentMousePosition.x / scale - offsetRight;
-    double upi    = currentMousePosition.y / scale - offsetUp;
+        double width, height;
+        window->GetContentSize(&width, &height);
+
+        righti = currentMousePosition.x / scale - offsetRight;
+        upi    = currentMousePosition.y / scale - offsetUp;
+    }
 
     // zoomMultiplyer of 1 gives a default zoom factor of 1.2x: zoomMultiplyer * 1.2
     // zoom = adjusted zoom negative zoomMultiplyer will zoom out, positive will zoom in
@@ -740,11 +745,13 @@ void GraphicsWindow::ZoomToMouse(double zoomMultiplyer) {
 
     scale *= exp(0.1823216 * zoomMultiplyer); // ln(1.2) = 0.1823216
 
-    double rightf = currentMousePosition.x / scale - offsetRight;
-    double upf    = currentMousePosition.y / scale - offsetUp;
+    if (! SS.zoomCenterNav) {
+        double rightf = currentMousePosition.x / scale - offsetRight;
+        double upf    = currentMousePosition.y / scale - offsetUp;
 
-    offset = offset.Plus(projRight.ScaledBy(rightf - righti));
-    offset = offset.Plus(projUp.ScaledBy(upf - upi));
+        offset = offset.Plus(projRight.ScaledBy(rightf - righti));
+        offset = offset.Plus(projUp.ScaledBy(upf - upi));
+    }
 
     if(SS.TW.shown.screen == TextWindow::Screen::EDIT_VIEW) {
         if(havePainted) {

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -85,6 +85,8 @@ void SolveSpaceUI::Init() {
     cameraNav = settings->ThawBool("CameraNav", false);
     // Use turntable mouse navigation
     turntableNav = settings->ThawBool("TurntableNav", false);
+    // Zoom keeping view centered
+    zoomCenterNav = settings->ThawBool("ZoomCenterNav", false);
     // Immediately edit dimension
     immediatelyEditDimension = settings->ThawBool("ImmediatelyEditDimension", true);
     // Check that contours are closed and not self-intersecting
@@ -276,6 +278,8 @@ void SolveSpaceUI::Exit() {
     settings->FreezeBool("CameraNav", cameraNav);
     // Use turntable mouse navigation
     settings->FreezeBool("TurntableNav", turntableNav);
+    // Zoom keeping view centered
+    settings->FreezeBool("ZoomCenterNav", zoomCenterNav);
     // Immediately edit dimensions
     settings->FreezeBool("ImmediatelyEditDimension", immediatelyEditDimension);
     // Enable automatic constrains for lines

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -583,6 +583,7 @@ public:
     bool     checkClosedContour;
     bool     cameraNav;
     bool     turntableNav;
+    bool     zoomCenterNav;
     bool     immediatelyEditDimension;
     bool     automaticLineConstraints;
     bool     showToolbar;

--- a/src/ui.h
+++ b/src/ui.h
@@ -452,6 +452,7 @@ public:
     static void ScreenChangeShowContourAreas(int link, uint32_t v);
     static void ScreenChangeCheckClosedContour(int link, uint32_t v);
     static void ScreenChangeCameraNav(int link, uint32_t v);
+    static void ScreenChangeZoomNav(int link, uint32_t v);
     static void ScreenChangeTurntableNav(int link, uint32_t v);
     static void ScreenChangeImmediatelyEditDimension(int link, uint32_t v);
     static void ScreenChangeAutomaticLineConstraints(int link, uint32_t v);


### PR DESCRIPTION
Since the mouse is always moved in order to rotate, constantly mixing zooming and rotating will cause the view to drift away from the model. The new option prevents this drift.