### PR TITLE
add handling for STL file instead of only stl file

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -716,6 +716,8 @@ bool SolveSpaceUI::LoadEntitiesFromFile(const Platform::Path &filename, EntityLi
 {
     if(strcmp(filename.Extension().c_str(), "emn")==0) {
         return LinkIDF(filename, le, m, sh);
+^    } else if(strcmp(filename.Extension().c_str(), "EMN")==0) {
+        return LinkIDF(filename, le, m, sh);
     } else if(strcmp(filename.Extension().c_str(), "stl")==0) {
         return LinkStl(filename, le, m, sh);    
     } else if(strcmp(filename.Extension().c_str(), "STL")==0) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -716,7 +716,7 @@ bool SolveSpaceUI::LoadEntitiesFromFile(const Platform::Path &filename, EntityLi
 {
     if(strcmp(filename.Extension().c_str(), "emn")==0) {
         return LinkIDF(filename, le, m, sh);
-^    } else if(strcmp(filename.Extension().c_str(), "EMN")==0) {
+    } else if(strcmp(filename.Extension().c_str(), "EMN")==0) {
         return LinkIDF(filename, le, m, sh);
     } else if(strcmp(filename.Extension().c_str(), "stl")==0) {
         return LinkStl(filename, le, m, sh);    

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -718,6 +718,8 @@ bool SolveSpaceUI::LoadEntitiesFromFile(const Platform::Path &filename, EntityLi
         return LinkIDF(filename, le, m, sh);
     } else if(strcmp(filename.Extension().c_str(), "stl")==0) {
         return LinkStl(filename, le, m, sh);    
+    } else if(strcmp(filename.Extension().c_str(), "STL")==0) {
+        return LinkStl(filename, le, m, sh);    
     } else {
         return LoadEntitiesFromSlvs(filename, le, m, sh);
     }


### PR DESCRIPTION
If the file name is written in capital letter solvespace crashes on my system.

Some applications do export with "STL" instead of "stl".

This would solve this.