### PR TITLE
Add a forgotten `break` statement. Should be and NFC.

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -283,6 +283,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
                         c.other2 = !c.other2;
                     }
                 }
+                break;
             }
             case Constraint::Type::HORIZONTAL:
             case Constraint::Type::VERTICAL:


### PR DESCRIPTION
In dedc6d48f475790006f672e6ffd1b2470a6fdd60 I missed a break statement. GCC caught it with a warning.

It was not causing an observable bug, but it is better to fix it.