### PR TITLE
CI: disable Python CI on `macos-x86_64` and `macos-arm64`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,8 +47,8 @@ jobs:
           "windows-ia32",
           "windows-x64",
           # "windows-arm64",
-          "macos-x86_64",
-          "macos-arm64",
+          # "macos-x86_64",
+          # "macos-arm64",
           "linux-x86_64",
           "linux-aarch64",
         ]
@@ -81,16 +81,16 @@ jobs:
           #   architecture: "arm64"
           #   cibuildwheel_architecture: "ARM64"
           #   cmake_generator_platform: "ARM64"
-          - os_arch: "macos-x86_64"
-            os: "macos-11.0"
-            os_short: "macos"
-            cibuildwheel_architecture: "x86_64"
-            architecture: "x86_64"
-          - os_arch: "macos-arm64"
-            os: "macos-11.0"
-            os_short: "macos"
-            cibuildwheel_architecture: "arm64"
-            architecture: "arm64"
+          #- os_arch: "macos-x86_64"
+          #  os: "macos-11.0"
+          #  os_short: "macos"
+          #  cibuildwheel_architecture: "x86_64"
+          #  architecture: "x86_64"
+          #- os_arch: "macos-arm64"
+          #  os: "macos-11.0"
+          #  os_short: "macos"
+          #  cibuildwheel_architecture: "arm64"
+          #  architecture: "arm64"
           - os_arch: linux-x86_64
             os: "ubuntu-22.04"
             os_short: "linux"


### PR DESCRIPTION
The Python CI jobs for the targets `macos-x86_64` and `macos-arm64` fail systematically with the error:

`This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.`

Here is and example: 
 - https://github.com/solvespace/solvespace/actions/runs/12977807252
   - https://github.com/solvespace/solvespace/actions/runs/12977807252/job/36191642761

Disable the above jobs to allow the CI for Python to pass normally.

As a side note the Python CI uses a huge amount of our "Action budget" - I do not know how much free CI time GitHub currently provides but we should consider this. https://github.com/solvespace/solvespace/actions/metrics/usage