### PR TITLE
mac: don't crash on file ops without changing dir

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -1428,8 +1428,10 @@ public:
     }
 
     void FreezeChoices(SettingsRef settings, const std::string &key) override {
-        settings->FreezeString("Dialog_" + key + "_Folder",
-                               [nsPanel.directoryURL.absoluteString UTF8String]);
+        if (nsPanel.directoryURL != nil) {
+            settings->FreezeString("Dialog_" + key + "_Folder",
+                                   [nsPanel.directoryURL.absoluteString UTF8String]);
+        }
     }
 
     void ThawChoices(SettingsRef settings, const std::string &key) override {


### PR DESCRIPTION
Fixes #1494, by only saving the last navigated directory when one actually exists.

I'd originally written the following as a reply to that issue, but decided to fix the bug myself instead.

---

I repro'd using 3.1~70bde63c — it happened when saving to the default directory the first few times. After I navigated to a different directory on a subsequent save, the crash no longer occurred; I'd say it's because `Dialog_Sketch_Folder` gets set and so `nsPanel.directoryURL` gets a value when thawed.

To reproduce:

1. Ensure SolveSpace is closed.
2. Run:
    ```shell
    plutil -remove Dialog_Sketch_Folder ~/Library/Preferences/com.solvespace.plist
    ```
3. Open SolveSpace.
4. Choose File → Save.
5. Click Save in the opened dialog. SolveSpace crashes.

You can repeat steps 3 to 5 after this. To stop the crash from repeating, choose a directory after step 4.

