### PR TITLE
Add showing 'only unconstrained' groups

### DIFF
--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -57,11 +57,13 @@ void TextWindow::ScreenToggleGroupShown(int link, uint32_t v) {
     SS.GenerateAll();
 }
 void TextWindow::ScreenShowGroupsSpecial(int link, uint32_t v) {
-    bool state = link == 's';
     for(hGroup hg : SK.groupOrder) {
         Group *g = SK.GetGroup(hg);
-
-        g->visible = state;
+        switch(link) {
+        case 's': g->visible = true; break;
+        case 'c': g->visible = g->solved.dof != 0; break;
+        case 'h': g->visible = false; break;
+        }
     }
     SS.GW.persistentDirty = true;
 }
@@ -159,7 +161,8 @@ void TextWindow::ShowListOfGroups() {
         backgroundParity = !backgroundParity;
     }
 
-    Printf(true,  "  %Fl%Ls%fshow all%E / %Fl%Lh%fhide all%E",
+    Printf(true, "  %Fl%Ls%fshow all%E / %Fl%Lc%fonly unconstrained%E / %Fl%Lh%fhide all%E",
+        &(TextWindow::ScreenShowGroupsSpecial),
         &(TextWindow::ScreenShowGroupsSpecial),
         &(TextWindow::ScreenShowGroupsSpecial));
     Printf(true,  "  %Fl%Ls%fline styles%E /"


### PR DESCRIPTION
This PR adds a new menu entry `only unconstrained` between `show all` and `hide all` that hides all groups besides those that still have degrees of freedom.

One of Solvespace's powers is that every single sketch entity stays draggable and reference-able all the time. But this can get overwhelming as in the below video. You can manually hide individual sketches, but this is tiring as you need to untick the right groups every time.

This PR adds a quick way to do this automatically.

https://github.com/user-attachments/assets/b17a383d-98a6-4499-a9b3-9e078fc63c76

