### PR TITLE
Minor build-related fixes and enhancements

### DIFF
--- a/cmake/GetGitCommitHash.cmake
+++ b/cmake/GetGitCommitHash.cmake
@@ -3,6 +3,14 @@ function(get_git_commit_hash)
     get_filename_component(GIT_ROOT ${GIT_DESCRIBE_CMAKE_DIR} PATH)
     set(GIT_DIR "${GIT_ROOT}/.git")
 
+    if(EXISTS ${GIT_DIR} AND NOT IS_DIRECTORY ${GIT_DIR})
+        # In case we are included as a git submodule.
+        file(READ ${GIT_DIR} GIT_SUB_DIR)
+        string(REPLACE "gitdir: " "" GIT_SUB_DIR ${GIT_SUB_DIR})
+        string(STRIP ${GIT_SUB_DIR} GIT_SUB_DIR)
+        set(GIT_DIR "${GIT_ROOT}/${GIT_SUB_DIR}")
+    endif()
+
     # Add a CMake configure dependency to the currently checked out revision.
     set(GIT_DEPENDS ${GIT_DIR}/HEAD)
     file(READ ${GIT_DIR}/HEAD HEAD_REF)

--- a/include/slvs.h
+++ b/include/slvs.h
@@ -10,7 +10,7 @@
 #ifndef __SLVS_H
 #define __SLVS_H
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(STATIC_LIB)
 #   ifdef EXPORT_DLL
 #       define DLL __declspec( dllexport )
 #   else

--- a/include/slvs.h
+++ b/include/slvs.h
@@ -429,8 +429,8 @@ DLL bool Slvs_IsDistance(Slvs_Entity e);
 DLL bool Slvs_IsPoint(Slvs_Entity e);
 DLL bool Slvs_IsCircle(Slvs_Entity e);
 
-static Slvs_Entity SLVS_E_NONE = { 0 };
-static Slvs_Entity SLVS_E_FREE_IN_3D = { 0 };
+static const Slvs_Entity SLVS_E_NONE = { 0 };
+static const Slvs_Entity SLVS_E_FREE_IN_3D = { 0 };
 
 DLL Slvs_Entity Slvs_AddPoint2D(uint32_t grouph, double u, double v, Slvs_Entity workplane);
 DLL Slvs_Entity Slvs_AddPoint3D(uint32_t grouph, double x, double y, double z);

--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -3,6 +3,7 @@
 //
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
+#include <new>
 #include "solvespace.h"
 
 namespace SolveSpace {
@@ -283,16 +284,17 @@ void TextWindow::Init() {
 void TextWindow::ClearSuper() {
     // Ugly hack, but not so ugly as the next line
     Platform::WindowRef oldWindow = std::move(window);
-    std::shared_ptr<ViewportCanvas> oldCanvas = canvas;
+    std::shared_ptr<ViewportCanvas> oldCanvas = std::move(canvas);
 
     // Cannot use *this = {} here because TextWindow instances
     // are 2.4MB long; this causes stack overflows in prologue
     // when built with MSVC, even with optimizations.
-    memset(this, 0, sizeof(*this));
+    this->~TextWindow();
+    new(this) TextWindow();
 
     // Return old canvas
     window = std::move(oldWindow);
-    canvas = oldCanvas;
+    canvas = std::move(oldCanvas);
 
     HideEditControl();
 


### PR DESCRIPTION
This PR includes minor build-related fixes for warnings that were encountered when compiling with GCC 14.2, as well as the following enhancements:

* Avoid exporting functions from `slvs` if built as a static library on Windows, as this needlessly exposes them when linked into a DLL.
* Allow getting the Git hash automatically when built as a submodule. This useful enhancement was taken from https://github.com/realthunder/solvespace