### PR TITLE
Corrected ZX Plane Rotation.

### DIFF
--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -393,7 +393,7 @@ void SolveSpaceUI::ForceReferences() {
     } Quat[] = {
         { Request::HREQUEST_REFERENCE_XY, { 1,    0,    0,    0,   } },
         { Request::HREQUEST_REFERENCE_YZ, { 0.5,  0.5,  0.5,  0.5, } },
-        { Request::HREQUEST_REFERENCE_ZX, { 0.707,0.707,0,    0,   } },
+        { Request::HREQUEST_REFERENCE_ZX, { 0,    0.707,0.707,0,   } },
     };
     for(int i = 0; i < 3; i++) {
         hRequest hr = Quat[i].hr;

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -393,7 +393,7 @@ void SolveSpaceUI::ForceReferences() {
     } Quat[] = {
         { Request::HREQUEST_REFERENCE_XY, { 1,    0,    0,    0,   } },
         { Request::HREQUEST_REFERENCE_YZ, { 0.5,  0.5,  0.5,  0.5, } },
-        { Request::HREQUEST_REFERENCE_ZX, { 0,    0.707,0.707,0,   } },
+        { Request::HREQUEST_REFERENCE_ZX, { 0,    0, 0.707, 0.707,   } },
     };
     for(int i = 0; i < 3; i++) {
         hRequest hr = Quat[i].hr;

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -393,7 +393,7 @@ void SolveSpaceUI::ForceReferences() {
     } Quat[] = {
         { Request::HREQUEST_REFERENCE_XY, { 1,    0,    0,    0,   } },
         { Request::HREQUEST_REFERENCE_YZ, { 0.5,  0.5,  0.5,  0.5, } },
-        { Request::HREQUEST_REFERENCE_ZX, { 0.5, -0.5, -0.5, -0.5, } },
+        { Request::HREQUEST_REFERENCE_ZX, { 0.707,0.707,0,    0,   } },
     };
     for(int i = 0; i < 3; i++) {
         hRequest hr = Quat[i].hr;


### PR DESCRIPTION
ZX Plane is incorrectly oriented resulting in H/V constraints being swapped and having the planes label on the wrong edge. 

This has annoyed me as a user for years.