### PR TITLE
Minor refactoring of surface curve data into its own struct

### DIFF
--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -125,14 +125,18 @@ void SSurface::BlendRowOrCol(bool row, int this_ij, SSurface *a, int a_ij,
         }
     }
 }
-void SSurface::SplitInHalf(bool byU, SSurface *sa, SSurface *sb) {
-    sa->degm = sb->degm = degm;
-    sa->degn = sb->degn = degn;
-
+void SSurface::SplitInHalf(bool byU, SSurface *sa, SSurface *sb) const {
     // by de Casteljau's algorithm in a projective space; so we must work
     // on points (w*x, w*y, w*z, w) so create a temporary copy
-    SSurface st;
-    st = *this;
+    SSurface st = {};
+
+    // Only copy the data we need into the new object
+    memcpy(st.ctrl, ctrl, sizeof(ctrl));
+    memcpy(st.weight, weight, sizeof(weight));
+
+    st.degm = sa->degm = sb->degm = degm;
+    st.degn = sa->degn = sb->degn = degn;
+
     st.WeightControlPoints();
 
     switch(byU ? degm : degn) {

--- a/src/srf/shell.cpp
+++ b/src/srf/shell.cpp
@@ -524,21 +524,26 @@ void SShell::MakeFirstOrderRevolvedSurfaces(Vector pt, Vector axis, int i0) {
             if(fabs(d0 - d1) < LENGTH_EPS) {
                 // This is a cylinder; so transpose it so that we'll recognize
                 // it as a surface of extrusion.
-                SSurface sn = *srf;
 
                 // Transposing u and v flips the normal, so reverse u to
-                // flip it again and put it back where we started.
-                sn.degm = 2;
-                sn.degn = 1;
-                int dm, dn;
-                for(dm = 0; dm <= 1; dm++) {
-                    for(dn = 0; dn <= 2; dn++) {
-                        sn.ctrl  [dn][dm] = srf->ctrl  [1-dm][dn];
-                        sn.weight[dn][dm] = srf->weight[1-dm][dn];
+                // flip it again and put it back where we started (work on
+                // a copy and copy back the result in order to make the loop
+                // simpler).
+                decltype(SSurface::ctrl) ctrl = {};
+                decltype(SSurface::weight) weight = {};
+
+                srf->degm = 2;
+                srf->degn = 1;
+                for(int dm = 0; dm <= 1; dm++) {
+                    for(int dn = 0; dn <= 2; dn++) {
+                        ctrl  [dn][dm] = srf->ctrl  [1-dm][dn];
+                        weight[dn][dm] = srf->weight[1-dm][dn];
                     }
                 }
 
-                *srf = sn;
+                // Copy back the transposed data
+                memcpy(srf->ctrl, ctrl, sizeof(ctrl));
+                memcpy(srf->weight, weight, sizeof(weight));
                 continue;
             }
         }

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -317,7 +317,7 @@ public:
     void BlendRowOrCol(bool row, int this_ij, SSurface *a, int a_ij,
                                               SSurface *b, int b_ij);
     double DepartureFromCoplanar() const;
-    void SplitInHalf(bool byU, SSurface *sa, SSurface *sb);
+    void SplitInHalf(bool byU, SSurface *sa, SSurface *sb) const;
     void AllPointsIntersecting(Vector a, Vector b,
                                List<SInter> *l,
                                bool asSegment, bool trimmed, bool inclTangent);


### PR DESCRIPTION
This allows keeping its functionality together and gives us the ability to copy it separately when needed, avoiding a copy of the entire surface data.

This was the case in `MakeFirstOrderRevolvedSurfaces()` as well as in `SplitInHalf()` -- both of which have been converted to work on the curve data alone.