### PR TITLE
ui: rename `CHECK_TRUE` and `CHECK_FALSE` to avoid name conflicts

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -515,7 +515,7 @@ void TextWindow::ShowPasteTransformed() {
         &ScreenChangePasteTransformed);
     Printf(false, "%Ba   %Ftmirror%E    %Fd%Lf%f%s  flip%E",
         &ScreenChangePasteTransformed,
-        shown.paste.scale < 0 ? CHECK_TRUE : CHECK_FALSE);
+        shown.paste.scale < 0 ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(true, " %Fl%Lg%fpaste transformed now%E", &ScreenPasteTransformed);
 

--- a/src/confscreen.cpp
+++ b/src/confscreen.cpp
@@ -265,7 +265,7 @@ void TextWindow::ShowConfiguration() {
         SS.DegreeToString(1.23456789).c_str());
     Printf(false, "  %Fd%f%Ll%s  use SI prefixes for distances%E",
         &ScreenChangeUseSIPrefixes,
-        SS.useSIPrefixes ? CHECK_TRUE : CHECK_FALSE);
+        SS.useSIPrefixes ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(false, "");
     Printf(false, "%Ft export scale factor (1:1=mm, 1:25.4=inch)");
@@ -280,30 +280,30 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "");
     Printf(false, "  %Fd%f%Ll%s  export shaded 2d triangles%E",
         &ScreenChangeShadedTriangles,
-        SS.exportShadedTriangles ? CHECK_TRUE : CHECK_FALSE);
+        SS.exportShadedTriangles ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     if(fabs(SS.exportOffset) > LENGTH_EPS) {
         Printf(false, "  %Fd%s  curves as piecewise linear%E "
-                      "(since cutter radius is not zero)", CHECK_TRUE);
+                      "(since cutter radius is not zero)", UI_CHECK_TRUE);
     } else {
         Printf(false, "  %Fd%f%Ll%s  export curves as piecewise linear%E",
             &ScreenChangePwlCurves,
-            SS.exportPwlCurves ? CHECK_TRUE : CHECK_FALSE);
+            SS.exportPwlCurves ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     }
     Printf(false, "  %Fd%f%Ll%s  fix white exported lines%E",
         &ScreenChangeFixExportColors,
-        SS.fixExportColors ? CHECK_TRUE : CHECK_FALSE);
+        SS.fixExportColors ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  export background color%E",
         &ScreenChangeExportBackgroundColor,
-        SS.exportBackgroundColor ? CHECK_TRUE : CHECK_FALSE);
+        SS.exportBackgroundColor ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(false, "");
     Printf(false, "%Ft export canvas size:  "
                   "%f%Fd%Lf%s fixed%E  "
                   "%f%Fd%Lt%s auto%E",
         &ScreenChangeCanvasSizeAuto,
-        !SS.exportCanvasSizeAuto ? RADIO_TRUE : RADIO_FALSE,
+        !SS.exportCanvasSizeAuto ? UI_RADIO_TRUE : UI_RADIO_FALSE,
         &ScreenChangeCanvasSizeAuto,
-        SS.exportCanvasSizeAuto ? RADIO_TRUE : RADIO_FALSE);
+        SS.exportCanvasSizeAuto ? UI_RADIO_TRUE : UI_RADIO_FALSE);
 
     if(SS.exportCanvasSizeAuto) {
         Printf(false, "%Ft (by margins around exported geometry)");
@@ -341,28 +341,28 @@ void TextWindow::ShowConfiguration() {
     Printf(false, "");
     Printf(false, "  %Fd%f%Ll%s  draw triangle back faces in red%E",
         &ScreenChangeBackFaces,
-        SS.drawBackFaces ? CHECK_TRUE : CHECK_FALSE);
+        SS.drawBackFaces ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  check sketch for closed contour%E",
         &ScreenChangeCheckClosedContour,
-        SS.checkClosedContour ? CHECK_TRUE : CHECK_FALSE);
+        SS.checkClosedContour ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  show areas of closed contours%E",
         &ScreenChangeShowContourAreas,
-        SS.showContourAreas ? CHECK_TRUE : CHECK_FALSE);
+        SS.showContourAreas ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  enable automatic line constraints%E",
         &ScreenChangeAutomaticLineConstraints,
-        SS.automaticLineConstraints ? CHECK_TRUE : CHECK_FALSE);
+        SS.automaticLineConstraints ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  use camera mouse navigation%E", &ScreenChangeCameraNav,
-        SS.cameraNav ? CHECK_TRUE : CHECK_FALSE);
+        SS.cameraNav ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  use turntable mouse navigation%E", &ScreenChangeTurntableNav,
-        SS.turntableNav ? CHECK_TRUE : CHECK_FALSE);
+        SS.turntableNav ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  edit newly added dimensions%E",
         &ScreenChangeImmediatelyEditDimension,
-        SS.immediatelyEditDimension ? CHECK_TRUE : CHECK_FALSE);
+        SS.immediatelyEditDimension ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  arc default is diameter%E",
         &ScreenChangeArcDimDefault,
-        SS.arcDimDefaultDiameter ? CHECK_TRUE : CHECK_FALSE);
+        SS.arcDimDefaultDiameter ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Ll%s  display the full path in the title bar%E",
-           &ScreenChangeShowFullFilePath, SS.showFullFilePath ? CHECK_TRUE : CHECK_FALSE);
+           &ScreenChangeShowFullFilePath, SS.showFullFilePath ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "");
     Printf(false, "%Ft autosave interval (in minutes)%E");
     Printf(false, "%Ba   %d %Fl%Ll%f[change]%E",

--- a/src/describescreen.cpp
+++ b/src/describescreen.cpp
@@ -220,7 +220,7 @@ void TextWindow::DescribeSelection() {
                         e->str.c_str(), &ScreenEditTtfText, e->h.request().v);
                     Printf(true, "  %Fd%f%D%Ll%s  apply kerning",
                            &ScreenToggleTtfKerning, e->h.request().v,
-                           e->extraPoints ? CHECK_TRUE : CHECK_FALSE);
+                           e->extraPoints ? UI_CHECK_TRUE : UI_CHECK_FALSE);
                     Printf(true, "  select new font");
                     SS.fonts.LoadAll();
                     // Not using range-for here because we use i inside the output.
@@ -480,11 +480,11 @@ void TextWindow::DescribeSelection() {
             }
             Printf(true, "  %Fd%f%D%Ll%s  reference",
                    &ScreenConstraintToggleReference, gs.constraint[0].v,
-                   c->reference ? CHECK_TRUE : CHECK_FALSE);
+                   c->reference ? UI_CHECK_TRUE : UI_CHECK_FALSE);
             if(c->type == Constraint::Type::DIAMETER) {
                 Printf(false, "  %Fd%f%D%Ll%s  use radius",
                        &ScreenConstraintShowAsRadius, gs.constraint[0].v,
-                       c->other ? CHECK_TRUE : CHECK_FALSE);
+                       c->other ? UI_CHECK_TRUE : UI_CHECK_FALSE);
             }
         } else {
             Printf(false, "%FtCONSTRAINT%E  %s", desc.c_str());

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -797,9 +797,9 @@ void TextWindow::ShowStyleInfo() {
                             "%D%f%LW%s pixels%E  "
                             "%D%f%Lw%s %s",
             s->h.v, &ScreenChangeStyleYesNo,
-            widthpx ? RADIO_TRUE : RADIO_FALSE,
+            widthpx ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             s->h.v, &ScreenChangeStyleYesNo,
-            !widthpx ? RADIO_TRUE : RADIO_FALSE,
+            !widthpx ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             SS.UnitName());
     }
 
@@ -834,7 +834,7 @@ void TextWindow::ShowStyleInfo() {
     }
 
     for(uint32_t i = 0; i <= (uint32_t)StipplePattern::LAST; i++) {
-        const char *radio = s->stippleType == (StipplePattern)i ? RADIO_TRUE : RADIO_FALSE;
+        const char *radio = s->stippleType == (StipplePattern)i ? UI_RADIO_TRUE : UI_RADIO_FALSE;
         Printf(false, "%Bp     %D%f%Lp%s %s%E",
             (i % 2 == 0) ? 'd' : 'a',
             s->h.v, &ScreenChangeStylePatternType,
@@ -854,7 +854,7 @@ void TextWindow::ShowStyleInfo() {
 
         Printf(false, "%Bd   %D%f%Lf%s  contours are filled%E",
             s->h.v, &ScreenChangeStyleYesNo,
-            s->filled ? CHECK_TRUE : CHECK_FALSE);
+            s->filled ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     }
 
     // The text height, and its units
@@ -881,9 +881,9 @@ void TextWindow::ShowStyleInfo() {
                             "%D%f%LG%s pixels%E  "
                             "%D%f%Lg%s %s",
             s->h.v, &ScreenChangeStyleYesNo,
-            textHeightpx ? RADIO_TRUE : RADIO_FALSE,
+            textHeightpx ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             s->h.v, &ScreenChangeStyleYesNo,
-            !textHeightpx ? RADIO_TRUE : RADIO_FALSE,
+            !textHeightpx ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             SS.UnitName());
     }
 
@@ -901,11 +901,11 @@ void TextWindow::ShowStyleInfo() {
                       "%D%f%LH%s center%E  "
                       "%D%f%LR%s right%E  ",
             s->h.v, &ScreenChangeStyleYesNo,
-            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::LEFT) ? RADIO_TRUE : RADIO_FALSE,
+            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::LEFT) ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             s->h.v, &ScreenChangeStyleYesNo,
-            neither ? RADIO_TRUE : RADIO_FALSE,
+            neither ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             s->h.v, &ScreenChangeStyleYesNo,
-            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::RIGHT) ? RADIO_TRUE : RADIO_FALSE);
+            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::RIGHT) ? UI_RADIO_TRUE : UI_RADIO_FALSE);
 
         neither = !((uint32_t)s->textOrigin & ((uint32_t)Style::TextOrigin::BOT | (uint32_t)Style::TextOrigin::TOP));
         Printf(false, "%Bd   "
@@ -913,11 +913,11 @@ void TextWindow::ShowStyleInfo() {
                       "%D%f%LV%s center%E  "
                       "%D%f%LT%s top%E  ",
             s->h.v, &ScreenChangeStyleYesNo,
-            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::BOT) ? RADIO_TRUE : RADIO_FALSE,
+            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::BOT) ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             s->h.v, &ScreenChangeStyleYesNo,
-            neither ? RADIO_TRUE : RADIO_FALSE,
+            neither ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             s->h.v, &ScreenChangeStyleYesNo,
-            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::TOP) ? RADIO_TRUE : RADIO_FALSE);
+            ((uint32_t)s->textOrigin & (uint32_t)Style::TextOrigin::TOP) ? UI_RADIO_TRUE : UI_RADIO_FALSE);
     }
 
     Printf(false, "");
@@ -925,12 +925,12 @@ void TextWindow::ShowStyleInfo() {
     if(s->h.v >= Style::FIRST_CUSTOM) {
         Printf(false, "  %Fd%D%f%Lv%s  show these objects on screen%E",
                 s->h.v, &ScreenChangeStyleYesNo,
-                s->visible ? CHECK_TRUE : CHECK_FALSE);
+                s->visible ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     }
 
     Printf(false, "  %Fd%D%f%Le%s  export these objects%E",
             s->h.v, &ScreenChangeStyleYesNo,
-            s->exportable ? CHECK_TRUE : CHECK_FALSE);
+            s->exportable ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     if(s->h.v >= Style::FIRST_CUSTOM) {
         Printf(false, "");

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -95,10 +95,10 @@ void TextWindow::ScreenGoToWebsite(int link, uint32_t v) {
     Platform::OpenInBrowser("http://solvespace.com/txtlink");
 }
 void TextWindow::ShowListOfGroups() {
-    const char *radioTrue  = " " RADIO_TRUE  " ",
-               *radioFalse = " " RADIO_FALSE " ",
-               *checkTrue  = " " CHECK_TRUE  " ",
-               *checkFalse = " " CHECK_FALSE " ";
+    const char *radioTrue  = " " UI_RADIO_TRUE  " ",
+               *radioFalse = " " UI_RADIO_FALSE " ",
+               *checkTrue  = " " UI_CHECK_TRUE  " ",
+               *checkFalse = " " UI_CHECK_FALSE " ";
 
     Printf(true, "%Ft active");
     Printf(false, "%Ft    shown dof group-name%E");
@@ -420,19 +420,19 @@ void TextWindow::ShowGroupInfo() {
                   "%f%LS%Fd%s two-sided%E  "
                   "%f%Lw%Fd%s skewed%E",
             &TextWindow::ScreenChangeGroupOption,
-            one ? RADIO_TRUE : RADIO_FALSE,
+            one ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             &TextWindow::ScreenChangeGroupOption,
-            two ? RADIO_TRUE : RADIO_FALSE,
+            two ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             &TextWindow::ScreenChangeGroupOption,
-            skew ? CHECK_TRUE : CHECK_FALSE);
+            skew ? UI_CHECK_TRUE : UI_CHECK_FALSE);
         } else {
         Printf(false,
             "%Ba   %f%Ls%Fd%s one-sided%E  "
                   "%f%LS%Fd%s two-sided%E",
             &TextWindow::ScreenChangeGroupOption,
-            one ? RADIO_TRUE : RADIO_FALSE,
+            one ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             &TextWindow::ScreenChangeGroupOption,
-            two ? RADIO_TRUE : RADIO_FALSE);        
+            two ? UI_RADIO_TRUE : UI_RADIO_FALSE);
         }
         
         if(g->type == Group::Type::ROTATE || g->type == Group::Type::TRANSLATE) {
@@ -442,9 +442,9 @@ void TextWindow::ShowGroupInfo() {
                    "%Bd   %Ftstart  %f%LK%Fd%s with original%E  "
                          "%f%Lk%Fd%s with copy #1%E",
                     &ScreenChangeGroupOption,
-                    !skip ? RADIO_TRUE : RADIO_FALSE,
+                    !skip ? UI_RADIO_TRUE : UI_RADIO_FALSE,
                     &ScreenChangeGroupOption,
-                    skip ? RADIO_TRUE : RADIO_FALSE);
+                    skip ? UI_RADIO_TRUE : UI_RADIO_FALSE);
             }
 
             int times = (int)(g->valA);
@@ -488,7 +488,7 @@ void TextWindow::ShowGroupInfo() {
         }
         Printf(false, "   %Fd%f%LP%s  fixed",
             &TextWindow::ScreenChangePitchOption,
-            g->valB != 0 ? CHECK_TRUE : CHECK_FALSE);
+            g->valB != 0 ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
         Printf(false, ""); // blank line    
     }
@@ -506,18 +506,18 @@ void TextWindow::ShowGroupInfo() {
                              "%f%D%Lc%Fd%s assemble%E  ",
             &TextWindow::ScreenChangeGroupOption,
             Group::CombineAs::UNION,
-            un ? RADIO_TRUE : RADIO_FALSE,
+            un ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             &TextWindow::ScreenChangeGroupOption,
             Group::CombineAs::ASSEMBLE,
-            (asy ? RADIO_TRUE : RADIO_FALSE));
+            (asy ? UI_RADIO_TRUE : UI_RADIO_FALSE));
         Printf(false, "%Ba   %f%D%Lc%Fd%s difference%E  "
                              "%f%D%Lc%Fd%s intersection%E  ",
             &TextWindow::ScreenChangeGroupOption,
             Group::CombineAs::DIFFERENCE,
-            diff ? RADIO_TRUE : RADIO_FALSE,
+            diff ? UI_RADIO_TRUE : UI_RADIO_FALSE,
             &TextWindow::ScreenChangeGroupOption,
             Group::CombineAs::INTERSECTION,
-            intr ? RADIO_TRUE : RADIO_FALSE);
+            intr ? UI_RADIO_TRUE : UI_RADIO_FALSE);
 
         if(g->type == Group::Type::EXTRUDE || g->type == Group::Type::LATHE ||
            g->type == Group::Type::REVOLVE || g->type == Group::Type::HELIX) {
@@ -536,7 +536,7 @@ void TextWindow::ShowGroupInfo() {
            g->type == Group::Type::HELIX) {
             Printf(false, "   %Fd%f%LP%s  suppress this group's solid model",
                 &TextWindow::ScreenChangeGroupOption,
-                g->suppress ? CHECK_TRUE : CHECK_FALSE);
+                g->suppress ? UI_CHECK_TRUE : UI_CHECK_FALSE);
         }
 
         Printf(false, "");
@@ -544,31 +544,31 @@ void TextWindow::ShowGroupInfo() {
 
     Printf(false, " %f%Lv%Fd%s  show entities from this group",
         &TextWindow::ScreenChangeGroupOption,
-        g->visible ? CHECK_TRUE : CHECK_FALSE);
+        g->visible ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     if(!g->IsForcedToMeshBySource() && !g->IsTriangleMeshAssembly()) {
         Printf(false, " %f%Lf%Fd%s  force NURBS surfaces to triangle mesh",
             &TextWindow::ScreenChangeGroupOption,
-            g->forceToMesh ? CHECK_TRUE : CHECK_FALSE);
+            g->forceToMesh ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     } else {
         Printf(false, " (model already forced to triangle mesh)");
     }
 
     Printf(true, " %f%Lr%Fd%s  relax constraints and dimensions",
         &TextWindow::ScreenChangeGroupOption,
-        g->relaxConstraints ? CHECK_TRUE : CHECK_FALSE);
+        g->relaxConstraints ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(false, " %f%Le%Fd%s  allow redundant constraints",
         &TextWindow::ScreenChangeGroupOption,
-        g->allowRedundant ? CHECK_TRUE : CHECK_FALSE);
+        g->allowRedundant ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(false, " %f%LD%Fd%s  suppress dof calculation (improves solver performance)",
         &TextWindow::ScreenChangeGroupOption,
-        g->suppressDofCalculation ? CHECK_TRUE : CHECK_FALSE);
+        g->suppressDofCalculation ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(false, " %f%Ld%Fd%s  treat all dimensions as reference",
         &TextWindow::ScreenChangeGroupOption,
-        g->allDimsReference ? CHECK_TRUE : CHECK_FALSE);
+        g->allDimsReference ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     if(g->booleanFailed) {
         Printf(false, "");
@@ -812,10 +812,10 @@ void TextWindow::ShowTangentArc() {
     Printf(false, "");
     Printf(false, "  %Fd%f%La%s  choose radius automatically%E",
         &ScreenChangeTangentArc,
-        !SS.tangentArcManual ? CHECK_TRUE : CHECK_FALSE);
+        !SS.tangentArcManual ? UI_CHECK_TRUE : UI_CHECK_FALSE);
     Printf(false, "  %Fd%f%Lm%s  modify original entities%E",
         &ScreenChangeTangentArc,
-        SS.tangentArcModify ? CHECK_TRUE : CHECK_FALSE);
+        SS.tangentArcModify ? UI_CHECK_TRUE : UI_CHECK_FALSE);
 
     Printf(false, "");
     Printf(false, "To create a tangent arc at a point,");

--- a/src/ui.h
+++ b/src/ui.h
@@ -203,10 +203,10 @@ public:
         LEFT_MARGIN    = 6,
     };
 
-#define CHECK_FALSE "\xEE\x80\x80" // U+E000
-#define CHECK_TRUE  "\xEE\x80\x81"
-#define RADIO_FALSE "\xEE\x80\x82"
-#define RADIO_TRUE  "\xEE\x80\x83"
+#define UI_CHECK_FALSE "\xEE\x80\x80" // U+E000
+#define UI_CHECK_TRUE  "\xEE\x80\x81"
+#define UI_RADIO_FALSE "\xEE\x80\x82"
+#define UI_RADIO_TRUE  "\xEE\x80\x83"
 
     int scrollPos;      // The scrollbar position, in half-row units
     int halfRows;       // The height of our window, in half-row units

--- a/test/harness.h
+++ b/test/harness.h
@@ -5,10 +5,6 @@
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
 
-// Hack... we should rename the ones in ui.h instead.
-#undef CHECK_TRUE
-#undef CHECK_FALSE
-
 namespace SolveSpace {
 namespace Test {
 


### PR DESCRIPTION
Currently the test harness needs to undefine them when including `ui.h` in order to avoid a name conflict with its own definitions. Rename them so we can do away with this hack, and have better names while at it.