### PR TITLE
Update the vendored FreeType version to 2.13.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	url = https://github.com/glennrp/libpng
 [submodule "extlib/freetype"]
 	path = extlib/freetype
-	url = https://git.savannah.nongnu.org/r/freetype/freetype2.git/
+	url = https://git.savannah.nongnu.org/git/freetype/freetype2.git
 [submodule "extlib/libdxfrw"]
 	path = extlib/libdxfrw
 	url = https://github.com/solvespace/libdxfrw.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,10 +252,9 @@ if(ENABLE_GUI OR ENABLE_CLI)
         list(APPEND PNG_PNG_INCLUDE_DIR ${CMAKE_BINARY_DIR}/extlib/libpng)
 
         find_vendored_package(Freetype freetype
-            WITH_ZLIB               OFF
-            WITH_BZip2              OFF
-            WITH_PNG                OFF
-            WITH_HarfBuzz           OFF
+            FT_DISABLE_BZIP2        ON
+            FT_DISABLE_HARFBUZZ     ON
+            FT_DISABLE_BROTLI       ON
             FREETYPE_LIBRARY        freetype
             FREETYPE_INCLUDE_DIRS   ${CMAKE_SOURCE_DIR}/extlib/freetype/include)
 


### PR DESCRIPTION
The existing version (2.7.1) is using an ancient zlib version, which fails to build with modern Xcode tools on macOS.

Fixes #1539