### PR TITLE
Remove the unused and unset rank parameter from `System::Solve()` and fix it in `System::SolveRank()`

### DIFF
--- a/js/slvs.d.ts
+++ b/js/slvs.d.ts
@@ -27,7 +27,6 @@ export interface Constraint {
 export interface SolveResult {
   result: number;
   dof: number;
-  rank: number;
   bad: number;
 }
 

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -536,8 +536,7 @@ void SolveSpaceUI::SolveGroup(hGroup hg, bool andFindFree) {
     Group *g = SK.GetGroup(hg);
     g->solved.remove.Clear();
     g->solved.findToFixTimeout = SS.timeoutRedundantConstr;
-    SolveResult how = sys.Solve(g, NULL,
-                                   &(g->solved.dof),
+    SolveResult how = sys.Solve(g, &(g->solved.dof),
                                    &(g->solved.remove),
                                    /*andFindBad=*/!g->allowRedundant,
                                    /*andFindFree=*/andFindFree,

--- a/src/slvs/lib.cpp
+++ b/src/slvs/lib.cpp
@@ -854,8 +854,8 @@ Slvs_SolveResult Slvs_SolveSketch(uint32_t shg, int calculateFaileds = 0)
     List<hConstraint> badList;
     bool andFindBad = calculateFaileds ? true : false;
 
-    int rank = 0, dof = 0;
-    SolveResult status = SYS.Solve(&g, &rank, &dof, &badList, andFindBad, false, false);
+    int dof = 0;
+    SolveResult status = SYS.Solve(&g, &dof, &badList, andFindBad, false, false);
     Slvs_SolveResult sr = {};
     sr.dof = dof;
     sr.bad = badList.n;
@@ -982,7 +982,7 @@ void Slvs_Solve(Slvs_System *ssys, uint32_t shg)
 
     // Now we're finally ready to solve!
     bool andFindBad = ssys->calculateFaileds ? true : false;
-    SolveResult how = SYS.Solve(&g, NULL, &(ssys->dof), &bad, andFindBad, /*andFindFree=*/false);
+    SolveResult how = SYS.Solve(&g, &(ssys->dof), &bad, andFindBad, /*andFindFree=*/false);
 
     switch(how) {
         case SolveResult::OKAY:

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -268,7 +268,7 @@ public:
 
     static const double CONVERGE_TOLERANCE;
     int CalculateRank();
-    bool TestRank(int *dof = NULL);
+    bool TestRank(int *dof = NULL, int *rank = NULL);
     static bool SolveLinearSystem(const Eigen::SparseMatrix<double> &A,
                                   const Eigen::VectorXd &B, Eigen::VectorXd *X);
     bool SolveLeastSquares();
@@ -287,8 +287,7 @@ public:
 
     void MarkParamsFree(bool findFree);
 
-    SolveResult Solve(Group *g, int *rank = NULL, int *dof = NULL,
-                      List<hConstraint> *bad = NULL,
+    SolveResult Solve(Group *g, int *dof = NULL, List<hConstraint> *bad = NULL,
                       bool andFindBad = false, bool andFindFree = false,
                       bool forceDofCheck = false);
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -229,12 +229,15 @@ int System::CalculateRank() {
     return result;
 }
 
-bool System::TestRank(int *dof) {
+bool System::TestRank(int *dof, int *rank) {
     EvalJacobian();
     int jacobianRank = CalculateRank();
     // We are calculating dof based on real rank, not mat.m.
     // Using this approach we can calculate real dof even when redundant is allowed.
     if(dof != NULL) *dof = mat.n - jacobianRank;
+    if(rank) {
+        *rank = jacobianRank;
+    }
     return jacobianRank == mat.m;
 }
 
@@ -414,7 +417,7 @@ void System::FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad, bo
     }
 }
 
-SolveResult System::Solve(Group *g, int *rank, int *dof, List<hConstraint> *bad,
+SolveResult System::Solve(Group *g, int *dof, List<hConstraint> *bad,
                           bool andFindBad, bool andFindFree, bool forceDofCheck)
 {
     WriteEquationsExceptFor(Constraint::NO_CONSTRAINT, g);
@@ -546,7 +549,7 @@ SolveResult System::SolveRank(Group *g, int *rank, int *dof, List<hConstraint> *
         return SolveResult::TOO_MANY_UNKNOWNS;
     }
 
-    bool rankOk = TestRank(dof);
+    bool rankOk = TestRank(dof, rank);
     if(!rankOk) {
         // When we are testing with redundant allowed, we don't want to have additional info
         // about redundants since this test is working only for single redundant constraint


### PR DESCRIPTION
It wasn't set inside `System::Solve()`, and it's not useful anyway when rank testing is fully or partially suppressed.

OTOH, in `System::SolveRank()` it is useful, and although it wasn't set, it was actually checked in `Constraint::TryConstrain()` (through the call to `SolveSpaceUI::TestRankForGroup()`), so fix it by letting `System::TestRank()` set it if provided.