### PR TITLE
Add group suppression feature

### DIFF
--- a/MISSING_FEATURES.md
+++ b/MISSING_FEATURES.md
@@ -1,0 +1,449 @@
+# SolveSpace Missing Features Analysis
+
+This document identifies features commonly found in modern CAD systems that are currently limited or missing in SolveSpace, compares SolveSpace with other open-source alternatives, and suggests priority areas for development.
+
+## Market Position and Comparison
+
+SolveSpace occupies a unique position in the open-source CAD ecosystem as a lightweight yet powerful parametric 2D/3D CAD tool. Here's how it compares to similar tools:
+
+### SolveSpace Strengths
+- **Constraint-based parametric modeling** with a robust geometric solver
+- **Extremely lightweight** (10-20MB vs. 500MB+ for competitors)
+- **Low system requirements** runs efficiently on modest hardware
+- **Fast learning curve** compared to more complex alternatives
+- **Clean, focused interface** without unnecessary complexity
+- **Cross-platform** support (Windows, macOS, Linux, and web)
+
+### Comparison to Alternatives
+
+#### FreeCAD
+- **Size/Complexity**: FreeCAD is significantly larger (~700MB vs ~15MB)
+- **Features**: FreeCAD offers more extensive workbenches (FEM, architecture, etc.)
+- **Learning Curve**: Much steeper learning curve with more complex UI
+- **Extensibility**: More extensible with Python scripting and add-ons
+- **Assembly Support**: Better multi-part assembly capabilities
+- **Performance**: SolveSpace is considerably faster and more responsive
+
+#### OpenSCAD
+- **Approach**: Code-based modeling vs. SolveSpace's visual interface
+- **User Base**: Programmers vs. traditional CAD users
+- **Strength**: Better for algorithmic designs; SolveSpace better for constraint-based modeling
+- **Learning**: Different learning curves (programming vs. CAD concepts)
+
+#### LibreCAD
+- **Dimension**: 2D-only vs. SolveSpace's 2D/3D capabilities
+- **Legacy Support**: Better AutoCAD DXF compatibility
+- **Constraints**: Fewer constraint-based features
+
+## Priority Development Areas
+
+Based on SolveSpace's market position and the missing features documented below, these are the most important areas for future contributions:
+
+1. **Basic Assembly Management**
+   - Implementing a lightweight mate-based assembly system would address SolveSpace's biggest competitive gap while maintaining its performance advantage
+   - This would significantly expand usability for multi-part mechanical designs without bloating the core
+
+2. **Feature Tree Improvements**
+   - Enhancing the ability to modify operation history and rearrange operations
+   - Adding feature suppression capabilities
+   - These improvements would leverage SolveSpace's constraint-solver foundation while making models more flexible
+
+3. **Performance Optimizations**
+   - Further enhancing the constraint solver's performance
+   - Multi-threading more operations
+   - This would reinforce SolveSpace's key advantage as a lightweight, efficient alternative
+
+4. **Basic Documentation Tools**
+   - Automated dimensioning from 3D models
+   - Improved drawing annotation tools:
+     - Enhanced text positioning and alignment options
+     - Basic leaders and callouts for part labeling
+     - Additional dimension types useful for maker projects
+     - Simple revision tracking for iterative designs
+   - This would add practical value for makers documenting their designs
+
+These priorities maintain SolveSpace's identity as a lightweight parametric CAD tool while addressing the most significant functional gaps that limit its practical use.
+
+## Missing Features Detail
+
+### Assembly Management
+- No structured hierarchical assembly system
+- Lacks mate-based assembly capabilities
+- No BOM (Bill of Materials) generation
+- No interference detection between components
+- Only basic file-based "linking" for assemblies
+
+### Feature Tree Management
+- Cannot rearrange or modify operation history
+- Limited ability to break dependencies
+- Limited rollback capabilities
+- Basic group-based approach versus sophisticated history tree
+- Limited patterns for operations
+- Group suppression is supported (added in 3.x)
+
+### Advanced Surfacing
+- Missing Class-A surfacing tools
+- No surface continuity control (G0/G1/G2)
+- Limited surface creation tools (no complex blending)
+- No lofting with guide curves
+- Missing surface from boundary curves functionality
+- Basic extrude/revolve but missing advanced surface manipulation
+
+### Simulation & Analysis
+- No FEA (Finite Element Analysis)
+- No motion simulation
+- No thermal or stress analysis
+- Limited mass property calculations
+- No CFD (Computational Fluid Dynamics)
+
+### Sheet Metal Design
+- No dedicated sheet metal design features
+- Missing bend calculations
+- No flat pattern generation
+- No folding/unfolding simulation
+
+### Direct Modeling
+- Primarily parametric modeling approach
+- Lacks push/pull and direct manipulation tools
+- No free-form deformation
+
+### Collaboration Features
+- No built-in version control
+- No multi-user editing capabilities
+- No design review or markup tools
+- No branching/merging of design iterations
+
+### Documentation Tools
+- Limited drawing annotation tools:
+  - Basic text positioning and leader lines
+  - Limited dimension types
+  - No callouts or balloon labels for parts
+  - Minimal alignment tools for annotations
+- No automated dimensioning from 3D model
+- Missing drawing standards compliance features
+- No automated BOM table creation
+
+### Additional Missing Features
+- Mold/Die design tools
+- Large assembly management
+- Advanced rendering capabilities
+- Simulation-driven design tools
+- Generative design / topology optimization
+- Cloud-based computing resources
+
+### Strengths
+- Lightweight and focused codebase
+- Open source and customizable
+- Cross-platform compatibility
+- Solid constraint-based parametric foundation
+- Good geometric constraint system for its size
+
+### Implementation Plans
+
+#### Multi-threaded Jacobian Evaluation
+
+This feature will significantly improve performance when solving complex constraint systems by parallelizing the Jacobian matrix evaluation, which is one of the most computationally intensive parts of the constraint solver.
+
+**Phase 1: Preparation and Environment Setup**
+- Add thread support to build system (CMake configuration)
+- Create thread pool implementation
+- Design interface for task submission and synchronization
+
+**Phase 2: Redesign Jacobian Evaluation for Parallelism**
+- Refactor System::EvalJacobian method for parallel processing
+- Implement batch processing logic to divide work
+- Create thread-safe caching for intermediate results
+
+**Phase 3: Configuration and Tuning**
+- Add user configuration options (enable/disable threading, thread count)
+- Benchmark and optimize batch sizes and scheduling strategies
+- Implement automatic thread count detection
+
+**Phase 4: Testing and Validation**
+- Create performance benchmarks for various model complexities
+- Implement regression testing to ensure solution accuracy
+- Test across different platforms and core counts
+
+**Phase 5: Documentation and Integration**
+- Update code documentation with thread safety considerations
+- Document new user configuration options
+- Provide performance expectations guidelines
+
+**Technical Goals:**
+- 1.5-3x speedup on quad-core systems for complex constraint systems
+- Near-linear scaling with core count for Jacobian evaluation
+- Automatic disabling for small problems to avoid overhead
+- Maintain identical numerical behavior for backward compatibility
+
+**Risk Analysis:**
+
+*High-Risk Areas:*
+
+1. **Expression Evaluation and Shared State**
+   - Risk: The `Eval()` method in expressions is called extensively during Jacobian evaluation but may not be thread-safe
+   - Mitigation: Implement thread-local caching, ensure immutable expressions during evaluation
+
+2. **Memory Management**
+   - Risk: Current memory model assumes single-threaded access (`AllocTemporary`, etc.)
+   - Mitigation: Use thread-local storage for temporary allocations, implement per-thread memory pools
+
+3. **Jacobian Sparsity Pattern**
+   - Risk: Sparse matrix construction assumes sequential updates
+   - Mitigation: Separate matrix construction from numerical evaluation, use thread-local construction with synchronized merging
+
+*Medium-Risk Areas:*
+
+1. **Eigen Library Integration**
+   - Risk: Potential thread-safety issues with Eigen matrix operations
+   - Mitigation: Review Eigen documentation, use thread-local Eigen objects where possible
+
+2. **Numerical Stability**
+   - Risk: Changed order of operations affecting numerical precision
+   - Mitigation: Comprehensive regression testing, deterministic thread assignment
+
+3. **Performance Overhead**
+   - Risk: Thread management overhead outweighing benefits for small problems
+   - Mitigation: Adaptive threading based on problem size, benchmarking
+
+*Implementation Strategy:*
+
+1. Incremental approach with comprehensive testing at each stage
+2. Create isolation layer for thread management
+3. Implement defensive thread safety with explicit synchronization
+4. Build extensive test suite for multi-threading correctness
+
+#### Basic Assembly Management System
+
+This feature will add structured assembly capabilities to SolveSpace while maintaining its lightweight nature. The implementation will focus on a mate-based approach that leverages the existing constraint system.
+
+**Phase 1: Core Assembly Data Structure**
+- Design and implement Assembly entity type
+- Create hierarchical component management system
+- Implement instance transformation tracking
+- Design persistent storage format for assembly data
+- Add UI elements for assembly tree view
+
+**Phase 2: Component Management**
+- Implement file reference system for external parts
+- Create component insertion workflow
+- Develop component positioning tools
+- Add support for component instances (multiple copies)
+- Implement visibility and selection filtering
+
+**Phase 3: Mate-Based Constraints**
+- Design mate constraint system based on existing geometric constraints
+- Implement standard mate types:
+  - Coincident (point-point, point-line, point-plane)
+  - Concentric (circle-circle, circle-arc)
+  - Parallel (line-line, plane-plane)
+  - Perpendicular (line-line, line-plane)
+  - Tangent (circle-circle, circle-line)
+  - Distance (point-point, point-line, point-plane)
+  - Angle (line-line, plane-plane)
+- Create mate constraint solver integration
+- Develop mate editing UI
+
+**Phase 4: Assembly Analysis and Validation**
+- Implement interference detection
+- Add degrees of freedom analysis
+- Create mass property calculations for assemblies
+- Implement center of gravity visualization
+- Add assembly validation and error reporting
+
+**Phase 5: Documentation and Reporting**
+- Implement basic Bill of Materials (BOM) generation
+- Add part numbering system
+- Create assembly drawing views
+- Design exploded view capabilities
+- Develop assembly animation tools (basic kinematics)
+
+**Technical Goals:**
+- Support assemblies with 50-100 components without performance degradation
+- Maintain sub-second response time for mate operations
+- Keep file size overhead minimal (target <20% increase for typical assemblies)
+- Ensure backward compatibility with existing SolveSpace files
+- Provide a migration path for existing "file-link" assemblies
+
+**Risk Analysis:**
+
+*High-Risk Areas:*
+
+1. **Performance with Large Assemblies**
+   - Risk: The lightweight nature of SolveSpace could be compromised when handling many components
+   - Mitigation: Implement level-of-detail system, selective loading, and lazy constraint evaluation
+
+2. **Solver Integration**
+   - Risk: The existing constraint solver may not efficiently handle inter-component constraints
+   - Mitigation: Develop a hierarchical solving approach, with local and global solving phases
+
+3. **File Format Changes**
+   - Risk: Major changes to file format could break compatibility
+   - Mitigation: Design an extension to the existing format rather than replacing it, ensure graceful degradation
+
+*Medium-Risk Areas:*
+
+1. **User Interface Complexity**
+   - Risk: Adding assembly management could complicate the currently clean UI
+   - Mitigation: Design a progressive disclosure interface, maintain current workflow for non-assembly operations
+
+2. **Reference Management**
+   - Risk: External file references could become invalid or circular
+   - Mitigation: Implement robust path handling, reference validation, and circular dependency detection
+
+3. **Memory Management**
+   - Risk: Multiple component instances could significantly increase memory requirements
+   - Mitigation: Implement instance sharing for geometry data, load/unload components based on visibility
+
+*Implementation Strategy:*
+
+1. Start with a minimal viable implementation focusing on core assembly structure
+2. Leverage existing constraint system for mates when possible
+3. Implement proper separation between component definitions and instances
+4. Ensure early and frequent testing with realistic assemblies
+5. Maintain SolveSpace's identity as a lightweight tool by avoiding feature creep
+
+#### Feature Tree Improvements
+
+This feature will enhance SolveSpace's history-based parametric modeling capabilities by improving the feature tree management system, allowing for more flexible editing and organization of the design history.
+
+**Phase 1: Feature Tree Data Structure Enhancements**
+- Refactor the Group data structure to support non-linear dependencies
+- Implement richer metadata for feature tree nodes
+- Design a more flexible dependency tracking system
+- Add support for feature reordering
+- Create a persistent storage format for enhanced tree data
+
+**Phase 2: Feature Management UI**
+- Redesign the feature tree UI for improved usability
+- Implement drag-and-drop reordering of operations
+- Create visual dependency indicators
+- Add context menus for feature operations
+- Implement search and filtering for complex models
+
+**Phase 3: Advanced Feature Operations**
+- Implement feature reordering with dependency validation
+- Add feature folders for organizational grouping
+- Create feature duplication functionality
+- Implement parametric patterns (linear, circular, mirror)
+- Add support for feature references across groups
+
+**Phase 4: Dependency Management**
+- Create tools for analyzing and visualizing dependencies
+- Implement dependency breaking/remapping
+- Add automatic dependency resolution for compatible operations
+- Design conflict resolution UI for invalid operations
+- Develop repair tools for broken references
+
+**Phase 5: Enhanced Feature State Management**
+- Extend group suppression capabilities 
+- Implement rollback marker for partial model viewing
+- Add feature visibility toggles
+- Create temporary feature overrides
+- Implement feature locking to prevent modification
+
+**Technical Goals:**
+- Support models with 500+ features without performance degradation
+- Maintain fast tree manipulation (< 100ms response time)
+- Keep backward compatibility with existing SolveSpace files
+- Ensure proper handling of feature dependencies
+- Provide intuitive UI for complex tree operations
+
+**Risk Analysis:**
+
+*High-Risk Areas:*
+
+1. **Dependency Management**
+   - Risk: Breaking existing dependency logic could corrupt models
+   - Mitigation: Comprehensive validation, safe mode with old behavior, automatic repair tools
+
+2. **File Format Changes**
+   - Risk: Enhanced tree structure requires file format changes
+   - Mitigation: Implement format versioning, graceful fallback for older versions
+
+3. **Solver Integration**
+   - Risk: Changes to operation order affects constraint solving
+   - Mitigation: Implement proper rebuild queueing, dependency-aware solving
+
+*Medium-Risk Areas:*
+
+1. **User Interface Complexity**
+   - Risk: Advanced tree operations could complicate the UI
+   - Mitigation: Progressive disclosure, focus on common operations, good visual feedback
+
+2. **Performance with Large Models**
+   - Risk: More complex dependency tracking could slow down large models
+   - Mitigation: Optimized data structures, lazy evaluation, incremental updates
+
+3. **Backward Compatibility**
+   - Risk: New features might not translate well to older versions
+   - Mitigation: Clear warnings when using new features, fallback behaviors
+
+*Implementation Strategy:*
+
+1. Start with core data structure improvements while maintaining existing behaviors
+2. Implement UI changes incrementally to gather user feedback
+3. Add advanced features only after core reordering functionality is solid
+4. Create extensive test cases for dependency scenarios
+5. Focus on maintaining SolveSpace's lightweight nature and performance
+
+#### Feature Implementation Synergies
+
+After analyzing the planned features, several important synergies and overlaps have been identified that could allow for more efficient and coordinated implementation:
+
+**Data Structure and Architectural Synergies:**
+
+1. **Hierarchical Data Management**
+   - Both the Assembly Management and Feature Tree Improvements require enhanced hierarchical data structures
+   - Implement a common tree node management system that can serve both features
+   - Develop shared UI components for tree visualization and manipulation
+   - Unified approach to persistence (file format changes) would reduce duplication
+
+2. **Constraint System Integration**
+   - Assembly mates and parametric model constraints use similar mathematical foundations
+   - Create a unified constraint abstraction layer that serves both single-part and assembly constraints
+   - Shared solver integration to handle both feature-level and assembly-level constraints
+   - Common approach to constraint visualization and editing
+
+3. **Performance Optimizations**
+   - Multi-threaded Jacobian evaluation directly benefits both part modeling and assembly operations
+   - Memory management improvements would help all features, especially with large assemblies or complex trees
+   - Implement a common system for selective loading/evaluation that could serve both features
+
+**User Interface Synergies:**
+
+1. **Progressive UI Improvements**
+   - Both Assembly Management and Feature Tree enhancements require UI updates
+   - Design a unified approach to tree manipulation (drag-drop, context menus)
+   - Develop consistent visual language for dependencies and relationships
+   - Create common filtering and search mechanisms
+
+2. **State Management**
+   - Feature suppression and component visibility use similar concepts
+   - Implement a unified show/hide/suppress framework that works for both features
+   - Develop common mechanisms for temporary overrides and state tracking
+
+**Implementation Approach:**
+
+1. **Foundation First**
+   - Start with the Multi-threaded Jacobian evaluation as it improves performance for all features
+   - Next, implement the core data structure improvements for the Feature Tree, as this provides a foundation for Assembly Management
+   - Finally, build the Assembly Management system, leveraging the improved tree structure and performance
+
+2. **Incremental Implementation with Shared Components**
+   - Identify and implement shared architectural components first:
+     - Enhanced tree data structures
+     - UI components for tree management
+     - Extended constraint system
+   - Develop feature-specific functionality on top of these shared components
+   - Maintain consistent UI patterns and user workflows across features
+
+3. **Coordinated File Format Changes**
+   - Plan a single, comprehensive file format update rather than separate changes for each feature
+   - Implement backward compatibility layers for all features simultaneously
+   - Create migration tools that handle both tree and assembly changes
+
+This coordinated approach would reduce development effort, create a more consistent user experience, and provide a stronger foundation for future enhancements while maintaining SolveSpace's identity as a lightweight, efficient CAD tool.
+
+---
+
+SolveSpace is a capable parametric CAD tool for basic mechanical design but lacks many advanced features of current generation commercial CAD packages like SolidWorks, Inventor, or Fusion 360.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,28 @@ make
 See the [guide for contributors](CONTRIBUTING.md) for the best way to file issues, contribute code,
 and debug SolveSpace.
 
+## Feature Guide
+
+### Group Suppression
+
+SolveSpace supports suppressing groups in your model, which allows you to temporarily disable parts of your model without deleting them. This is useful when:
+
+- You want to temporarily disable a feature to see how it affects the model
+- You're troubleshooting complex models by isolating specific parts
+- You need to create alternative versions of a design by enabling/disabling certain features
+
+To suppress a group:
+1. Select the group in the text window or select any entity in the group
+2. Press Shift+Delete or use the "suppress this group in model" checkbox in the property browser
+
+When a group is suppressed:
+- The group's contribution to the 3D model is removed
+- Any groups that depend on the suppressed group (e.g., extrusions of a suppressed sketch) will not generate geometry
+- Suppressed sketch entities remain visible but appear as dashed/dimmed lines
+- Construction entities in suppressed groups remain visible for reference
+
+This feature affects the dependency chain, meaning that if you suppress a sketch, all features that depend on that sketch will also be suppressed automatically.
+
 ## License
 
 SolveSpace is distributed under the terms of the [GPL v3](COPYING.txt) or later.

--- a/res/messages.pot
+++ b/res/messages.pot
@@ -1033,6 +1033,9 @@ msgstr ""
 msgid "&Go to GitHub commit"
 msgstr ""
 
+msgid "Toggle Group Suppression"
+msgstr ""
+
 #: graphicswin.cpp:188
 msgid "&About"
 msgstr ""

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -512,8 +512,12 @@ Vector Entity::PointGetDrawNum() const {
 }
 
 void Entity::Draw(DrawAs how, Canvas *canvas) {
+    // Get the group to check if it's suppressed
+    Group *g = SK.GetGroup(group);
+    
+    // Don't draw if not visible or if in a suppressed group (except when hovered/selected)
     if(!(how == DrawAs::HOVERED || how == DrawAs::SELECTED) &&
-       !IsVisible()) return;
+       (!IsVisible() || (g->suppress && !construction))) return;
 
     int zIndex;
     if(IsPoint()) {
@@ -542,6 +546,14 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
     switch(how) {
         case DrawAs::DEFAULT:
             stroke.layer = Canvas::Layer::NORMAL;
+            // If this entity is in a suppressed group but still visible (construction entities),
+            // show it with a stippled pattern to visually indicate suppression
+            if(g->suppress && construction) {
+                stroke.stipplePattern = StipplePattern::DASH;
+                stroke.stippleScale = 4.0;
+                // Make construction lines in suppressed groups more transparent
+                stroke.color = stroke.color.WithAlpha(stroke.color.alpha / 2);
+            }
             break;
 
         case DrawAs::OVERLAY:

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -120,6 +120,8 @@ const MenuEntry Menu[] = {
 { 1, NULL,                              Command::NONE,             0,       KN, NULL   },
 { 1, N_("Link / Assemble..."),          Command::GROUP_LINK,       S|'i',   KN, mGrp   },
 { 1, N_("Link Recent"),                 Command::GROUP_RECENT,     0,       KN, mGrp   },
+{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, N_("Toggle Group Suppression"),    Command::GROUP_TOGGLE_SUPPRESS, S|'\x7f', KN, mGrp },
 
 { 0, N_("&Sketch"),                     Command::NONE,             0,       KN, mReq   },
 { 1, N_("In &Workplane"),               Command::SEL_WORKPLANE,    '2',     KR, mReq   },

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -221,9 +221,10 @@ void Group::GenerateShellAndMesh() {
     // Don't attempt a lathe or extrusion unless the source section is good:
     // planar and not self-intersecting.
     bool haveSrc = true;
-    if(type == Type::EXTRUDE || type == Type::LATHE || type == Type::REVOLVE) {
+    if(type == Type::EXTRUDE || type == Type::LATHE || type == Type::REVOLVE || type == Type::HELIX) {
         Group *src = SK.GetGroup(opA);
-        if(src->polyError.how != PolyError::GOOD) {
+        // Skip if the source group has errors or is suppressed
+        if(src->polyError.how != PolyError::GOOD || src->suppress) {
             haveSrc = false;
         }
     }
@@ -650,6 +651,10 @@ void Group::Draw(Canvas *canvas) {
     // Everything here gets drawn whether or not the group is hidden; we
     // can control this stuff independently, with show/hide solids, edges,
     // mesh, etc.
+    
+    // We don't skip drawing just because a group is suppressed.
+    // Suppression should control the dependency chain and 3D results,
+    // but visible controls whether things are drawn on screen.
 
     GenerateDisplayItems();
     DrawMesh(DrawMeshAs::DEFAULT, canvas);

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -531,13 +531,8 @@ void TextWindow::ShowGroupInfo() {
                 &TextWindow::ScreenOpacity);
         }
 
-        if(g->type == Group::Type::EXTRUDE || g->type == Group::Type::LATHE ||
-           g->type == Group::Type::REVOLVE || g->type == Group::Type::LINKED ||
-           g->type == Group::Type::HELIX) {
-            Printf(false, "   %Fd%f%LP%s  suppress this group's solid model",
-                &TextWindow::ScreenChangeGroupOption,
-                g->suppress ? CHECK_TRUE : CHECK_FALSE);
-        }
+        // Removed the group type check - now showing suppress checkbox
+    // for all groups uniformly in the code below
 
         Printf(false, "");
     }
@@ -545,6 +540,17 @@ void TextWindow::ShowGroupInfo() {
     Printf(false, " %f%Lv%Fd%s  show entities from this group",
         &TextWindow::ScreenChangeGroupOption,
         g->visible ? CHECK_TRUE : CHECK_FALSE);
+        
+    // Always show the suppress checkbox, regardless of group type
+    // This is more consistent with the new keyboard shortcut
+    Printf(false, " %f%LP%Fd%s  suppress this group in model (Shift+Delete)",
+        &TextWindow::ScreenChangeGroupOption,
+        g->suppress ? CHECK_TRUE : CHECK_FALSE);
+        
+    // Add a note about the difference between visibility and suppression
+    if(g->suppress) {
+        Printf(false, "   (suppression affects dependencies and model generation)");
+    }
 
     if(!g->IsForcedToMeshBySource() && !g->IsTriangleMeshAssembly()) {
         Printf(false, " %f%Lf%Fd%s  force NURBS surfaces to triangle mesh",

--- a/src/ui.h
+++ b/src/ui.h
@@ -138,6 +138,7 @@ enum class Command : uint32_t {
     GROUP_TRANS,
     GROUP_LINK,
     GROUP_RECENT,
+    GROUP_TOGGLE_SUPPRESS,
     // Constrain
     DISTANCE_DIA,
     REF_DISTANCE,


### PR DESCRIPTION
This PR adds the ability to suppress 
  groups in SolveSpace:

  ## Features
  - Added keyboard shortcut Shift+Delete to toggle suppression 
  - Added group suppression checkbox in properties window
  - Suppressed groups are temporarily removed from model generation
  - Suppression affects dependent groups in the model tree
  - Construction entities remain visible (but dimmed) when suppressed
  - Added documentation for the feature in README.md

  ## Test Plan
  1. Create a sketch and extrude it
  2. Suppress the sketch (Shift+Delete) - the extrusion should disappear
  3. Unsuppress the sketch - the extrusion should reappear
  4. Suppress the extrusion - only the extrusion should disappear, sketch should remain visible
  5. Unsuppress the extrusion - the extrusion should reappear

  The feature handles the dependency chain correctly - if you suppress a sketch, all features that depend
   on it are also suppressed.