### PR TITLE
Fix: Update mimalloc CMake minimum version to 3.5

### DIFF
--- a/.github/patches/mimalloc-cmake-version.patch
+++ b/.github/patches/mimalloc-cmake-version.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8127e096..7bb6108a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ project(libmimalloc C CXX)
+ 
+ set(CMAKE_C_STANDARD 11)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index bb8dc97e..f756c6b2 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ project(mimalloc-test C CXX)
+ 
+ set(CMAKE_C_STANDARD 11)

--- a/.github/scripts/apply-patches.sh
+++ b/.github/scripts/apply-patches.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+PATCHES_DIR="$SCRIPT_DIR/../patches"
+
+# Apply mimalloc CMake version patch
+echo "Applying mimalloc CMake version patch..."
+patch -p1 -d "$REPO_ROOT/extlib/mimalloc" < "$PATCHES_DIR/mimalloc-cmake-version.patch"

--- a/.github/scripts/build-macos.sh
+++ b/.github/scripts/build-macos.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -xe
 
+# Apply patches
+.github/scripts/apply-patches.sh
+
 ENABLE_SANITIZERS="OFF"
 if [ "$1" = "release" ]; then
     BUILD_TYPE="RelWithDebInfo"

--- a/.github/scripts/build-ubuntu.sh
+++ b/.github/scripts/build-ubuntu.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -xe
 
+# Apply patches
+.github/scripts/apply-patches.sh
+
 mkdir build
 cd build
 cmake \

--- a/.github/scripts/build-windows.sh
+++ b/.github/scripts/build-windows.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -xe
 
+# Apply patches
+.github/scripts/apply-patches.sh
+
 mkdir build
 cd build
 


### PR DESCRIPTION
This PR fixes the CI build failures in all feature branches by patching the vendored mimalloc library's CMake version requirement.

## Issue
The CI builds were failing with the following error:
```
CMake Error at extlib/mimalloc/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

## Solution
- Added a patch file that updates mimalloc's CMakeLists.txt version from 3.0 to 3.5
- Created a simple apply-patches.sh script to apply patches during builds
- Updated the build scripts to apply this patch before configuring

This is a minimal, focused change that ensures CI can build without changing the submodule itself.