### PR TITLE
Add core group suppression functionality

### DIFF
--- a/res/messages.pot
+++ b/res/messages.pot
@@ -1033,6 +1033,9 @@ msgstr ""
 msgid "&Go to GitHub commit"
 msgstr ""
 
+msgid "Toggle Group Suppression"
+msgstr ""
+
 #: graphicswin.cpp:188
 msgid "&About"
 msgstr ""

--- a/src/drawentity.cpp
+++ b/src/drawentity.cpp
@@ -512,8 +512,12 @@ Vector Entity::PointGetDrawNum() const {
 }
 
 void Entity::Draw(DrawAs how, Canvas *canvas) {
+    // Get the group to check if it's suppressed
+    Group *g = SK.GetGroup(group);
+    
+    // Don't draw if not visible or if in a suppressed group (except when hovered/selected)
     if(!(how == DrawAs::HOVERED || how == DrawAs::SELECTED) &&
-       !IsVisible()) return;
+       (!IsVisible() || (g->suppress && !construction))) return;
 
     int zIndex;
     if(IsPoint()) {
@@ -542,6 +546,14 @@ void Entity::Draw(DrawAs how, Canvas *canvas) {
     switch(how) {
         case DrawAs::DEFAULT:
             stroke.layer = Canvas::Layer::NORMAL;
+            // If this entity is in a suppressed group but still visible (construction entities),
+            // show it with a stippled pattern to visually indicate suppression
+            if(g->suppress && construction) {
+                stroke.stipplePattern = StipplePattern::DASH;
+                stroke.stippleScale = 4.0;
+                // Make construction lines in suppressed groups more transparent
+                stroke.color = stroke.color.WithAlpha(stroke.color.alpha / 2);
+            }
             break;
 
         case DrawAs::OVERLAY:

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -120,6 +120,8 @@ const MenuEntry Menu[] = {
 { 1, NULL,                              Command::NONE,             0,       KN, NULL   },
 { 1, N_("Link / Assemble..."),          Command::GROUP_LINK,       S|'i',   KN, mGrp   },
 { 1, N_("Link Recent"),                 Command::GROUP_RECENT,     0,       KN, mGrp   },
+{ 1, NULL,                              Command::NONE,             0,       KN, NULL   },
+{ 1, N_("Toggle Group Suppression"),    Command::GROUP_TOGGLE_SUPPRESS, S|'\x7f', KN, mGrp },
 
 { 0, N_("&Sketch"),                     Command::NONE,             0,       KN, mReq   },
 { 1, N_("In &Workplane"),               Command::SEL_WORKPLANE,    '2',     KR, mReq   },

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -70,6 +70,57 @@ void Group::MenuGroup(Command id)  {
 
 void Group::MenuGroup(Command id, Platform::Path linkFile) {
     Platform::SettingsRef settings = Platform::GetSettings();
+    
+    // Handle the group suppression toggle command separately
+    if(id == Command::GROUP_TOGGLE_SUPPRESS) {
+        hGroup hg = SS.GW.activeGroup;
+        if(SS.GW.gs.n == 1 && SS.GW.gs.entities == 1) {
+            // If we have a selection, use the selected entity's group
+            hg = SS.GW.gs.entity[0].group();
+        }
+        
+        Group *g = SK.GetGroup(hg);
+        // Toggle the suppress status
+        g->suppress = !g->suppress;
+        
+        // We need to check all subsequent groups to see if they depend on this one
+        // and mark them as dirty
+        bool foundCurrent = false;
+        for(auto const &gh : SK.groupOrder) {
+            Group *grp = SK.GetGroup(gh);
+            if(!foundCurrent) {
+                // Keep looking until we find the current group
+                if(grp->h.v == hg.v) {
+                    foundCurrent = true;
+                }
+                continue;
+            }
+            
+            // We found the current group, so now check dependencies
+            // Groups that depend on the suppressed group include:
+            // - Extrude, Lathe, Revolve operations that use the suppressed group as a base
+            // - Step and repeat (translate/rotate) groups that use the suppressed group
+            if((grp->type == Type::EXTRUDE || 
+                grp->type == Type::LATHE || 
+                grp->type == Type::REVOLVE ||
+                grp->type == Type::HELIX) && 
+                grp->opA.v == hg.v) {
+                // This group directly depends on the suppressed group
+                SS.MarkGroupDirty(grp->h);
+            } else if((grp->type == Type::TRANSLATE || 
+                      grp->type == Type::ROTATE) && 
+                      grp->opA.v == hg.v) {
+                // This is a step-and-repeat that depends on the suppressed group
+                SS.MarkGroupDirty(grp->h);
+            }
+        }
+        
+        // Mark the suppressed group dirty too
+        SS.MarkGroupDirty(hg);
+        SS.GW.Invalidate();
+        SS.ScheduleShowTW();
+        return;
+    }
 
     Group g = {};
     g.visible = true;

--- a/src/groupmesh.cpp
+++ b/src/groupmesh.cpp
@@ -221,9 +221,10 @@ void Group::GenerateShellAndMesh() {
     // Don't attempt a lathe or extrusion unless the source section is good:
     // planar and not self-intersecting.
     bool haveSrc = true;
-    if(type == Type::EXTRUDE || type == Type::LATHE || type == Type::REVOLVE) {
+    if(type == Type::EXTRUDE || type == Type::LATHE || type == Type::REVOLVE || type == Type::HELIX) {
         Group *src = SK.GetGroup(opA);
-        if(src->polyError.how != PolyError::GOOD) {
+        // Skip if the source group has errors or is suppressed
+        if(src->polyError.how != PolyError::GOOD || src->suppress) {
             haveSrc = false;
         }
     }
@@ -650,6 +651,10 @@ void Group::Draw(Canvas *canvas) {
     // Everything here gets drawn whether or not the group is hidden; we
     // can control this stuff independently, with show/hide solids, edges,
     // mesh, etc.
+    
+    // We don't skip drawing just because a group is suppressed.
+    // Suppression should control the dependency chain and 3D results,
+    // but visible controls whether things are drawn on screen.
 
     GenerateDisplayItems();
     DrawMesh(DrawMeshAs::DEFAULT, canvas);

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -531,13 +531,8 @@ void TextWindow::ShowGroupInfo() {
                 &TextWindow::ScreenOpacity);
         }
 
-        if(g->type == Group::Type::EXTRUDE || g->type == Group::Type::LATHE ||
-           g->type == Group::Type::REVOLVE || g->type == Group::Type::LINKED ||
-           g->type == Group::Type::HELIX) {
-            Printf(false, "   %Fd%f%LP%s  suppress this group's solid model",
-                &TextWindow::ScreenChangeGroupOption,
-                g->suppress ? CHECK_TRUE : CHECK_FALSE);
-        }
+        // Removed the group type check - now showing suppress checkbox
+    // for all groups uniformly in the code below
 
         Printf(false, "");
     }
@@ -545,6 +540,16 @@ void TextWindow::ShowGroupInfo() {
     Printf(false, " %f%Lv%Fd%s  show entities from this group",
         &TextWindow::ScreenChangeGroupOption,
         g->visible ? CHECK_TRUE : CHECK_FALSE);
+        
+    // Always show the suppress checkbox, regardless of group type
+    Printf(false, " %f%LP%Fd%s  suppress this group in model (Shift+Delete)",
+        &TextWindow::ScreenChangeGroupOption,
+        g->suppress ? CHECK_TRUE : CHECK_FALSE);
+        
+    // Add a note about the difference between visibility and suppression
+    if(g->suppress) {
+        Printf(false, "   (suppression affects dependencies and model generation)");
+    }
 
     if(!g->IsForcedToMeshBySource() && !g->IsTriangleMeshAssembly()) {
         Printf(false, " %f%Lf%Fd%s  force NURBS surfaces to triangle mesh",

--- a/src/ui.h
+++ b/src/ui.h
@@ -138,6 +138,7 @@ enum class Command : uint32_t {
     GROUP_TRANS,
     GROUP_LINK,
     GROUP_RECENT,
+    GROUP_TOGGLE_SUPPRESS,
     // Constrain
     DISTANCE_DIA,
     REF_DISTANCE,


### PR DESCRIPTION
This PR adds a focused implementation of group suppression to SolveSpace. Group suppression allows users to temporarily disable specific groups in a model without deleting them.

## Implementation Details
- Added a 'suppress' flag to the Group class
- Added a command to toggle suppression (Shift+Delete shortcut)
- Modified mesh generation to skip suppressed groups
- Updated the property browser to show suppression option for all groups
- Added visual indication for suppressed construction entities (dashed lines)
- Implemented proper dependency handling for suppressed groups

## Benefits
- Allows isolating specific parts of complex models for editing
- Makes it easy to create design variations without deleting anything
- Simplifies troubleshooting by removing parts of models temporarily

## Testing
The feature can be tested by:
1. Creating a sketch and extrusion
2. Using Shift+Delete to suppress the sketch - the extrusion should disappear
3. Using Shift+Delete again to restore the sketch - the extrusion should reappear

This PR aims to be minimal and focused on just the core suppression functionality with no additional features.