### PR TITLE
Solver: clean up and optimise `SolveBySubstitution()` and `WriteJacobian()`

### DIFF
--- a/src/dsc.h
+++ b/src/dsc.h
@@ -36,6 +36,16 @@ operator<(T const &lhs, T const &rhs) {
     return lhs.v < rhs.v;
 }
 
+template<class T>
+struct HandleHasher {
+    static_assert(IsHandleOracle<T>::value, "Not a valid handle type");
+
+    inline size_t operator()(const T &h) const {
+        using Hasher = std::hash<decltype(T::v)>;
+        return Hasher{}(h.v);
+    }
+};
+
 class Vector;
 class Vector4;
 class Point2d;

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -400,16 +400,11 @@ Expr *Expr::PartialWrt(hParam p) const {
     ssassert(false, "Unexpected operation");
 }
 
-void Expr::ParamsUsedList(std::vector<hParam> *list) const {
+void Expr::ParamsUsedList(ParamSet *list) const {
     if(op == Op::PARAM || op == Op::PARAM_PTR) {
         // leaf: just add ourselves if we aren't already there
         hParam param = (op == Op::PARAM) ? parh : parp->h;
-        if(list->end() != std::find_if(list->begin(), list->end(),
-                                       [=](const hParam &p) { return p.v == param.v; })) {
-            // We found ourselves in the list already, early out.
-            return;
-        }
-        list->push_back(param);
+        list->insert(param);
         return;
     }
 

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -6,6 +6,7 @@
 //
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
+#include <limits>
 #include "solvespace.h"
 
 ExprVector ExprVector::From(Expr *x, Expr *y, Expr *z) {
@@ -542,7 +543,7 @@ void Expr::Substitute(const SubstitutionMap &subMap) {
 // If multiple params are referenced, then return MULTIPLE_PARAMS.
 //-----------------------------------------------------------------------------
 const hParam Expr::NO_PARAMS       = { 0 };
-const hParam Expr::MULTIPLE_PARAMS = { 1 };
+const hParam Expr::MULTIPLE_PARAMS = { std::numeric_limits<decltype(hParam::v)>::max() };
 hParam Expr::ReferencedParams(ParamList *pl) const {
     if(op == Op::PARAM) {
         if(pl->FindByIdNoOops(parh)) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -500,15 +500,21 @@ Expr *Expr::FoldConstants() {
     return n;
 }
 
-void Expr::Substitute(hParam oldh, hParam newh) {
+void Expr::Substitute(const SubstitutionMap &subMap) {
     ssassert(op != Op::PARAM_PTR, "Expected an expression that refer to params via handles");
 
-    if(op == Op::PARAM && parh == oldh) {
-        parh = newh;
+    if(op == Op::PARAM) {
+        auto it = subMap.find(parh);
+        if(it != subMap.end()) {
+            parh = it->second->h;
+        }
+    } else {
+        int c = Children();
+        if(c >= 1) {
+            a->Substitute(subMap);
+            if(c >= 2) b->Substitute(subMap);
+        }
     }
-    int c = Children();
-    if(c >= 1) a->Substitute(oldh, newh);
-    if(c >= 2) b->Substitute(oldh, newh);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/expr.h
+++ b/src/expr.h
@@ -76,7 +76,7 @@ public:
     bool DependsOn(hParam p) const;
     static bool Tol(double a, double b);
     bool IsZeroConst() const;
-    Expr *FoldConstants();
+    Expr *FoldConstants(bool allocCopy = true, size_t depth = std::numeric_limits<size_t>::max());
     void Substitute(const SubstitutionMap &subMap);
 
     static const hParam NO_PARAMS, MULTIPLE_PARAMS;
@@ -97,7 +97,8 @@ public:
     // resolved to pointers to the actual value. This speeds things up
     // considerably.
     Expr *DeepCopyWithParamsAsPointers(IdList<Param,hParam> *firstTry,
-                                       IdList<Param,hParam> *thenTry) const;
+                                       IdList<Param,hParam> *thenTry,
+                                       bool foldConstants = false) const;
 
     static Expr *Parse(const std::string &input, std::string *error);
     static Expr *From(const std::string &input, bool popUpError);

--- a/src/expr.h
+++ b/src/expr.h
@@ -7,6 +7,8 @@
 #ifndef SOLVESPACE_EXPR_H
 #define SOLVESPACE_EXPR_H
 
+using SubstitutionMap = std::unordered_map<hParam, Param *, HandleHasher<hParam>>;
+
 class Expr {
 public:
 
@@ -75,7 +77,7 @@ public:
     static bool Tol(double a, double b);
     bool IsZeroConst() const;
     Expr *FoldConstants();
-    void Substitute(hParam oldh, hParam newh);
+    void Substitute(const SubstitutionMap &subMap);
 
     static const hParam NO_PARAMS, MULTIPLE_PARAMS;
     hParam ReferencedParams(ParamList *pl) const;

--- a/src/expr.h
+++ b/src/expr.h
@@ -70,7 +70,7 @@ public:
 
     Expr *PartialWrt(hParam p) const;
     double Eval() const;
-    void ParamsUsedList(std::vector<hParam> *list) const;
+    void ParamsUsedList(ParamSet *list) const;
     bool DependsOn(hParam p) const;
     static bool Tol(double a, double b);
     bool IsZeroConst() const;

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -422,7 +422,7 @@ void SolveSpaceUI::UpdateCenterOfMass() {
 }
 
 void SolveSpaceUI::MarkDraggedParams() {
-    sys.dragged.Clear();
+    sys.dragged.clear();
 
     for(int i = -1; i < SS.GW.pending.points.n; i++) {
         hEntity hp;
@@ -442,14 +442,14 @@ void SolveSpaceUI::MarkDraggedParams() {
                 case Entity::Type::POINT_N_TRANS:
                 case Entity::Type::POINT_IN_3D:
                 case Entity::Type::POINT_N_ROT_AXIS_TRANS:
-                    sys.dragged.Add(&(pt->param[0]));
-                    sys.dragged.Add(&(pt->param[1]));
-                    sys.dragged.Add(&(pt->param[2]));
+                    sys.dragged.insert(pt->param[0]);
+                    sys.dragged.insert(pt->param[1]);
+                    sys.dragged.insert(pt->param[2]);
                     break;
 
                 case Entity::Type::POINT_IN_2D:
-                    sys.dragged.Add(&(pt->param[0]));
-                    sys.dragged.Add(&(pt->param[1]));
+                    sys.dragged.insert(pt->param[0]);
+                    sys.dragged.insert(pt->param[1]);
                     break;
 
                 default: // Only the entities above can be dragged.
@@ -463,7 +463,7 @@ void SolveSpaceUI::MarkDraggedParams() {
             Entity *dist = SK.GetEntity(circ->distance);
             switch(dist->type) {
                 case Entity::Type::DISTANCE:
-                    sys.dragged.Add(&(dist->param[0]));
+                    sys.dragged.insert(dist->param[0]);
                     break;
 
                 default: // Only the entities above can be dragged.
@@ -476,10 +476,10 @@ void SolveSpaceUI::MarkDraggedParams() {
         if(norm) {
             switch(norm->type) {
                 case Entity::Type::NORMAL_IN_3D:
-                    sys.dragged.Add(&(norm->param[0]));
-                    sys.dragged.Add(&(norm->param[1]));
-                    sys.dragged.Add(&(norm->param[2]));
-                    sys.dragged.Add(&(norm->param[3]));
+                    sys.dragged.insert(norm->param[0]);
+                    sys.dragged.insert(norm->param[1]);
+                    sys.dragged.insert(norm->param[2]);
+                    sys.dragged.insert(norm->param[3]);
                     break;
 
                 default: // Only the entities above can be dragged.

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -624,9 +624,6 @@ public:
     bool        known;
     bool        free;
 
-    // Used only in the solver
-    Param       *substd;
-
     static const hParam NO_PARAM;
 
     void Clear() {}

--- a/src/slvs/lib.cpp
+++ b/src/slvs/lib.cpp
@@ -827,10 +827,10 @@ Slvs_SolveResult Slvs_SolveSketch(uint32_t shg, int calculateFaileds = 0)
         ConstraintBase *c = &con;
         if(c->type == ConstraintBase::Type::WHERE_DRAGGED) {
             EntityBase *e = SK.GetEntity(c->ptA);
-            SYS.dragged.Add(&(e->param[0]));
-            SYS.dragged.Add(&(e->param[1]));
+            SYS.dragged.insert(e->param[0]);
+            SYS.dragged.insert(e->param[1]);
             if (e->type == EntityBase::Type::POINT_IN_3D) {
-                SYS.dragged.Add(&(e->param[2]));
+                SYS.dragged.insert(e->param[2]);
             }
         }
     }
@@ -971,7 +971,7 @@ void Slvs_Solve(Slvs_System *ssys, uint32_t shg)
     for(i = 0; i < ssys->ndragged; i++) {
         if(ssys->dragged[i]) {
             hParam hp = { ssys->dragged[i] };
-            SYS.dragged.Add(&hp);
+            SYS.dragged.insert(hp);
         }
     }
 

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -257,7 +257,6 @@ public:
             Eigen::SparseMatrix<double> num;
         } A;
 
-        Eigen::VectorXd scale;
         Eigen::VectorXd X;
 
         struct {

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -280,7 +280,7 @@ public:
     void WriteEquationsExceptFor(hConstraint hc, Group *g);
     void FindWhichToRemoveToFixJacobian(Group *g, List<hConstraint> *bad,
                                         bool forceDofCheck);
-    void SolveBySubstitution();
+    SubstitutionMap SolveBySubstitution();
 
     bool IsDragged(hParam p);
 
@@ -297,9 +297,6 @@ public:
                           bool andFindBad = false, bool andFindFree = false);
 
     void Clear();
-    Param *GetLastParamSubstitution(Param *p);
-    void SubstituteParamsByLast(Expr *e);
-    void SortSubstitutionByDragged(Param *p);
 };
 
 #include "ttf.h"

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -283,7 +283,7 @@ public:
 
     bool IsDragged(hParam p);
 
-    bool NewtonSolve(int tag);
+    bool NewtonSolve();
 
     void MarkParamsFree(bool findFree);
 

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -172,6 +172,7 @@ enum class SolveResult : uint32_t {
     TOO_MANY_UNKNOWNS        = 20
 };
 
+using ParamSet = std::unordered_set<hParam, HandleHasher<hParam>>;
 
 #include "sketch.h"
 #include "ui.h"
@@ -229,7 +230,7 @@ public:
 
     // A list of parameters that are being dragged; these are the ones that
     // we should put as close as possible to their initial positions.
-    List<hParam>                    dragged;
+    ParamSet                        dragged;
 
     enum {
         // In general, the tag indicates the subsys that a variable/equation

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -47,7 +47,6 @@ bool System::WriteJacobian(int tag) {
     if(mat.eq.size() >= MAX_UNKNOWNS) {
         return false;
     }
-    std::vector<hParam> paramsUsed;
     // In some experimenting, this is almost always the right size.
     // Value is usually between 0 and 20, comes from number of constraints?
     mat.B.sym.reserve(mat.eq.size());
@@ -58,10 +57,10 @@ bool System::WriteJacobian(int tag) {
         Expr *f = e->e->FoldConstants();
         f = f->DeepCopyWithParamsAsPointers(&param, &(SK.param));
 
-        paramsUsed.clear();
+        ParamSet paramsUsed;
         f->ParamsUsedList(&paramsUsed);
 
-        for(hParam &p : paramsUsed) {
+        for(hParam p : paramsUsed) {
             // Find the index of this parameter
             auto it = paramToIndex.find(p.v);
             if(it == paramToIndex.end()) continue;
@@ -74,7 +73,6 @@ bool System::WriteJacobian(int tag) {
                 continue;
             mat.A.sym.insert(i, j) = pd;
         }
-        paramsUsed.clear();
         mat.B.sym.push_back(f);
     }
     return true;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -97,9 +97,7 @@ void System::EvalJacobian() {
 }
 
 bool System::IsDragged(hParam p) {
-    const auto b = dragged.begin();
-    const auto e = dragged.end();
-    return e != std::find(b, e, p);
+    return dragged.find(p) != dragged.end();
 }
 
 Param *System::GetLastParamSubstitution(Param *p) {
@@ -566,7 +564,7 @@ void System::Clear() {
     entity.Clear();
     param.Clear();
     eq.Clear();
-    dragged.Clear();
+    dragged.clear();
     mat.A.num.setZero();
     mat.A.sym.setZero();
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -303,7 +303,7 @@ bool System::SolveLeastSquares() {
     return true;
 }
 
-bool System::NewtonSolve(int tag) {
+bool System::NewtonSolve() {
 
     int iter = 0;
     bool converged = false;
@@ -482,7 +482,7 @@ SolveResult System::Solve(Group *g, int *dof, List<hConstraint> *bad,
         e.tag  = alone;
         p->tag = alone;
         WriteJacobian(alone);
-        if(!NewtonSolve(alone)) {
+        if(!NewtonSolve()) {
             // We don't do the rank test, so let's arbitrarily return
             // the DIDNT_CONVERGE result here.
             rankOk = true;
@@ -503,7 +503,7 @@ SolveResult System::Solve(Group *g, int *dof, List<hConstraint> *bad,
     rankOk = (!g->suppressDofCalculation && !g->allowRedundant) ? TestRank(dof) : true;
 
     // And do the leftovers as one big system
-    if(!NewtonSolve(0)) {
+    if(!NewtonSolve()) {
         goto didnt_converge;
     }
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -277,19 +277,19 @@ bool System::SolveLeastSquares() {
     // Scale the columns; this scale weights the parameters for the least
     // squares solve, so that we can encourage the solver to make bigger
     // changes in some parameters, and smaller in others.
-    mat.scale = VectorXd::Ones(mat.n);
+    VectorXd scale = VectorXd::Ones(mat.n);
     for(int c = 0; c < mat.n; c++) {
         if(IsDragged(mat.param[c])) {
             // It's least squares, so this parameter doesn't need to be all
             // that big to get a large effect.
-            mat.scale[c] = 1 / 20.0;
+            scale[c] = 1 / 20.0;
         }
     }
 
     const int size = mat.A.num.outerSize();
     for(int k = 0; k < size; k++) {
         for(SparseMatrix<double>::InnerIterator it(mat.A.num, k); it; ++it) {
-            it.valueRef() *= mat.scale[it.col()];
+            it.valueRef() *= scale[it.col()];
         }
     }
 
@@ -302,7 +302,7 @@ bool System::SolveLeastSquares() {
     mat.X = mat.A.num.transpose() * z;
 
     for(int c = 0; c < mat.n; c++) {
-        mat.X[c] *= mat.scale[c];
+        mat.X[c] *= scale[c];
     }
     return true;
 }


### PR DESCRIPTION
This PR cleans up and optimises various parts of the solver, especially around `SolveBySubstitution()` and `WriteJacobian()`. The latter can result in noticeable speedups on some models (see initial numbers in my comment [here](https://github.com/solvespace/solvespace/pull/1563#issuecomment-2807422537)).

-----
 #### Original PR description (superseded)

~While trying to look into #1247 I was having trouble reproducing the issue, and the model was failing in weird ways (such as multiple constraints not satisfied, causing horizontal and vertical lines to become diagonal).~

~After staring hard at the code for a long time, I finally traced the issue down to commit 708a08f04b910337965859249b87684696369219 (merged in #1159) which made changes in order to speed up solving by substitution. However, the changes inadvertently  caused substitution to persist across solve runs and across groups, which broke multiple cases.~

~There are multiple options for fixing it, and I chose to do it by removing the `substd` member from `Param` (in order to prevent
such breakage in the future), and replacing the logic with similar runtime complexity logic that doesn't require modifying `Param` itself.~