### PR TITLE
ci: fix the broken Python and WASM library builds

### DIFF
--- a/.github/scripts/build-wasmlib.sh
+++ b/.github/scripts/build-wasmlib.sh
@@ -10,7 +10,7 @@ source ../emsdk/emsdk_env.sh
 mkdir -p build-wasmlib
 cd build-wasmlib
 emcmake cmake .. \
-  -DCMAKE_RELEASE_TYPE=RelWithDebInfo \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DENABLE_GUI="OFF" \
   -DENABLE_CLI="OFF" \
   -DENABLE_TESTS="OFF" \
@@ -18,4 +18,4 @@ emcmake cmake .. \
   -DENABLE_OPENMP="OFF" \
   -DFORCE_VENDORED_Eigen3="ON" \
   -DENABLE_LTO="ON"
-cmake --build . -j$(nproc) slvs-wasm
+cmake --build . -j$(nproc) --target slvs-wasm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "Cython", "cmake", "ninja"]
+requires = ["scikit-build-core", "Cython", "cmake==3.31.6", "ninja"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ wheel.expand-macos-universal-tags = true
 cmake.verbose = true
 cmake.build-type = "RelWithDebInfo"
 build.targets = ["slvs-py"]
+install.components = ["python"]
 sdist.include = [
   ".git/HEAD",
   ".git/refs"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -405,10 +405,12 @@ endif()
 if(NOT (WIN32 OR APPLE OR EMSCRIPTEN))
     if(ENABLE_GUI)
         install(TARGETS solvespace
+            COMPONENT   solvespace
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
     if(ENABLE_CLI)
         install(TARGETS solvespace-cli
+            COMPONENT   solvespace
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
 endif()

--- a/src/slvs/CMakeLists.txt
+++ b/src/slvs/CMakeLists.txt
@@ -26,12 +26,19 @@ if(ENABLE_PYTHON_LIB)
     )
     set_target_properties(slvs-py PROPERTIES LIBRARY_OUTPUT_NAME solvespace)
     if(SKBUILD)
-        install(TARGETS slvs-py DESTINATION ${SKBUILD_PROJECT_NAME})
+        install(TARGETS slvs-py
+            DESTINATION ${SKBUILD_PROJECT_NAME}
+            COMPONENT   python
+        )
     else()
-        install(TARGETS slvs-py DESTINATION "slvs")
+        install(TARGETS slvs-py
+            DESTINATION "slvs"
+            COMPONENT   python
+        )
         install(
             DIRECTORY ${CMAKE_SOURCE_DIR}/python/slvs/
             DESTINATION "slvs"
+            COMPONENT   python
         )
     endif()
 endif()
@@ -65,6 +72,7 @@ set_target_properties(slvs PROPERTIES
 
 # if(NOT WIN32)
 install(TARGETS slvs
+    COMPONENT     slvs
     LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Similar to #1558, the CI Python build has been failing because the CMake dependency in `pyproject.toml` was not pinned to a specific version and it was pulling version 4.0.0 with the compatibility issue.

Additionally, I inadvertently broke the CI build in #1561 by introducing more granular targets without adjusting the installation of those targets accordingly. This PR fixes it by introducing CMake components and using them in the Python build, and properly specifying the WASM target in the build script.