### PR TITLE
Add a workaround for building zlib in Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,10 +241,32 @@ if(ENABLE_GUI OR ENABLE_CLI)
         set(FORCE_VENDORED_PNG      ON)
         set(FORCE_VENDORED_Freetype ON)
 
+        # There's an issue with the zlib configuration, which doesn't provide a way to
+        # disable the shared or static library builds, and on UNIX sets the base name of
+        # the output for both the static and shared targets to `libz`. As Emscripten doesn't
+        # support shared libraries, CMake converts the shared library target to a static
+        # library and both targets end up with the name `libz.a`, causing Ninja to complain
+        # about different rules generating the same target. As a workaround, temporarily
+        # unset UNIX for Emscripten while the zlib configuration is being processed, and
+        # reset it back afterwards.
+        # NOTE: The unreleased develop branch of zlib after version 1.3.1 allows disabling
+        # the shared library build, which is the proper fix for this issue, so when the
+        # next version of zlib is released and updated as a dependency, `ZLIB_BUILD_SHARED`
+        # should be set to `OFF` instead of this hack.
+        if(EMSCRIPTEN AND UNIX)
+            set(zlib_workaround_unix_was_unset 1)
+            unset(UNIX)
+        endif()
+
         find_vendored_package(ZLIB zlib
             ZLIB_LIBRARY            zlibstatic
             ZLIB_INCLUDE_DIR        ${CMAKE_SOURCE_DIR}/extlib/zlib)
         list(APPEND ZLIB_INCLUDE_DIR ${CMAKE_BINARY_DIR}/extlib/zlib)
+
+        if(zlib_workaround_unix_was_unset)
+            set(UNIX 1)
+            unset(zlib_workaround_unix_was_unset)
+        endif()
 
         find_vendored_package(PNG libpng
             SKIP_INSTALL_ALL        ON

--- a/res/CMakeLists.txt
+++ b/res/CMakeLists.txt
@@ -85,13 +85,13 @@ elseif(APPLE)
             VERBATIM)
     endfunction()
 elseif(EMSCRIPTEN)
-    set(resource_dir ${CMAKE_BINARY_DIR}/src/res)
+    set(resource_dir ${CMAKE_BINARY_DIR}/res)
 
     function(add_resource name)
         set(source ${CMAKE_CURRENT_SOURCE_DIR}/${name})
         set(target ${resource_dir}/${name})
         set(resource_list  "${resource_list};${target}" PARENT_SCOPE)
-        set(resource_names "${resource_names};${target}@res/${name}" PARENT_SCOPE)
+        set(resource_names "${resource_names};res/${name}" PARENT_SCOPE)
 
         add_custom_command(
             OUTPUT ${target}


### PR DESCRIPTION
Commit 3ac128d9723c45ec9c353cd159f16e524964153a (merged in #1564) updated the Emscripten toolchain configuration to the official one, and accidentally broke the build due to a `zlib` issue that was missed (the issue is briefly described in a comment that I added for this change, but see [my comment in the other PR](https://github.com/solvespace/solvespace/pull/1564#issuecomment-2803091398) for a longer explanation).

In the next `zlib` version this can be properly fixed, but until it's released we can work around it by unsetting `UNIX` for Emscripten right before including `zlib` and resetting it back again.