### PR TITLE
slvs: don't mark `WHERE_DRAGGED` constraints as dragged

### DIFF
--- a/include/slvs.h
+++ b/include/slvs.h
@@ -498,6 +498,7 @@ DLL double Slvs_GetParamValue(uint32_t ph);
 DLL void Slvs_SetParamValue(uint32_t ph, double value);
 
 DLL void Slvs_Solve(Slvs_System *sys, uint32_t hg);
+DLL void Slvs_MarkDragged(Slvs_Entity ptA);
 /**
  * Setting `bad` to a non NULL pointer enables finding of bad constraints.
  * If such constraints are found, `bad` is set to a heap allocated array containing

--- a/src/slvs/jslib.cpp
+++ b/src/slvs/jslib.cpp
@@ -201,6 +201,7 @@ EMSCRIPTEN_BINDINGS(slvs) {
 
   emscripten::function("getParamValue", &Slvs_GetParamValue);
   emscripten::function("setParamValue", &Slvs_SetParamValue);
+  emscripten::function("markDragged", &Slvs_MarkDragged);
   emscripten::function("solveSketch", &solveSketch);
   emscripten::function("clearSketch", &Slvs_ClearSketch);
 }

--- a/src/slvs/lib.pyx
+++ b/src/slvs/lib.pyx
@@ -86,6 +86,7 @@ cdef extern from "slvs.h" nogil:
     Slvs_Constraint Slvs_LengthDiff(Slvs_hGroup grouph, Slvs_Entity entityA, Slvs_Entity entityB, double value, Slvs_Entity workplane)
     Slvs_Constraint Slvs_Dragged(Slvs_hGroup grouph, Slvs_Entity ptA, Slvs_Entity workplane)
 
+    void Slvs_MarkDragged(Slvs_Entity ptA)
     Slvs_SolveResult Slvs_SolveSketch(Slvs_hGroup hg, Slvs_hConstraint **bad) nogil
     double Slvs_GetParamValue(int ph)
     double Slvs_SetParamValue(int ph, double value)
@@ -363,6 +364,9 @@ class EntityType(IntEnum):
     CUBIC = _SLVS_E_CUBIC
     CIRCLE = _SLVS_E_CIRCLE
     ARC_OF_CIRCLE = _SLVS_E_ARC_OF_CIRCLE
+
+def mark_dragged(ptA: Slvs_Entity):
+    Slvs_MarkDragged(ptA)
 
 def solve_sketch(grouph: int, calculateFaileds: bool):
     cdef Slvs_hConstraint *badp = NULL


### PR DESCRIPTION
`WHERE_DRAGGED` locks points in place, whereas `System::dragged` merely asks the solver to move them as little as possible, so using both doesn't make much sense (see my comment [here](https://github.com/solvespace/solvespace/pull/1561#issuecomment-2787581610), where I made a similarly wrong assumption).

Instead, add a new API to mark points as dragged without constraining them with `WHERE_DRAGGED`, and expose it in the bindings as well.

NOTE: the changes in this PR conflict with #1563, so I'll rebase the PR that ends up in conflict after one of them is merged.