### PR TITLE
slvs: support getting the list of bad constraints in the sketch solving API

### DIFF
--- a/exposed/CDemo.c
+++ b/exposed/CDemo.c
@@ -43,7 +43,7 @@ void ExampleStateful()
     // Slvs_Entity c1 = Slvs_AddCircle(g, n, center, radius, wp);
 
     Slvs_Vertical(g, p1, wp, p2);
-    Slvs_SolveResult res = Slvs_SolveSketch(g, 0);
+    Slvs_SolveResult res = Slvs_SolveSketch(g, NULL);
     printf("res: %i\n", res.result);
     printf("dof: %i\n", res.dof);
     double p1x = Slvs_GetParamValue(p1.param[0]);

--- a/include/slvs.h
+++ b/include/slvs.h
@@ -207,7 +207,7 @@ typedef struct {
 typedef struct {
     int                 result;
     int                 dof;
-    int                 bad;
+    int                 nbad;
 } Slvs_SolveResult;
 
 /* Our base coordinate system has basis vectors
@@ -498,7 +498,14 @@ DLL double Slvs_GetParamValue(uint32_t ph);
 DLL void Slvs_SetParamValue(uint32_t ph, double value);
 
 DLL void Slvs_Solve(Slvs_System *sys, uint32_t hg);
-DLL Slvs_SolveResult Slvs_SolveSketch(uint32_t hg, int calculateFaileds);
+/**
+ * Setting `bad` to a non NULL pointer enables finding of bad constraints.
+ * If such constraints are found, `bad` is set to a heap allocated array containing
+ * the handles of those constraints, while the `nbad` member of the returned
+ * `Slvs_SolveResult` struct is set to the number of the bad constraints.
+ * NOTE: the user is responsible for freeing the heap allocated memory using `free()`.
+ */
+DLL Slvs_SolveResult Slvs_SolveSketch(uint32_t hg, Slvs_hConstraint **bad);
 DLL void Slvs_ClearSketch();
 
 #ifdef __cplusplus

--- a/js/slvs.d.ts
+++ b/js/slvs.d.ts
@@ -27,7 +27,8 @@ export interface Constraint {
 export interface SolveResult {
   result: number;
   dof: number;
-  bad: number;
+  nbad: number;
+  bad: Uint32Array;
 }
 
 export interface Vector {

--- a/src/slvs/lib.cpp
+++ b/src/slvs/lib.cpp
@@ -780,7 +780,7 @@ void Slvs_ClearSketch()
     SK.constraint.Clear();
 }
 
-Slvs_SolveResult Slvs_SolveSketch(uint32_t shg, int calculateFaileds = 0)
+Slvs_SolveResult Slvs_SolveSketch(uint32_t shg, Slvs_hConstraint **bad = nullptr)
 {
     SYS.Clear();
 
@@ -852,13 +852,23 @@ Slvs_SolveResult Slvs_SolveSketch(uint32_t shg, int calculateFaileds = 0)
     // }
 
     List<hConstraint> badList;
-    bool andFindBad = calculateFaileds ? true : false;
+    bool andFindBad = bad != nullptr;
 
     int dof = 0;
     SolveResult status = SYS.Solve(&g, &dof, &badList, andFindBad, false, false);
     Slvs_SolveResult sr = {};
     sr.dof = dof;
-    sr.bad = badList.n;
+    sr.nbad = badList.n;
+    if(bad) {
+        if(sr.nbad <= 0) {
+            *bad = nullptr;
+        } else {
+            *bad = static_cast<Slvs_hConstraint *>(malloc(sizeof(Slvs_hConstraint) * sr.nbad));
+            for(int i = 0; i < sr.nbad; ++i) {
+                (*bad)[i] = badList[i].v;
+            }
+        }
+    }
     sr.result = 0;
     switch(status) {
         case SolveResult::OKAY: {


### PR DESCRIPTION
This functionality was only available in the system solving API until now, and that made the sketch solving API less usable, even though it's the only API available through the Cython and Emscripten bindings.

In this initial implementation there's a redundant allocation and copy of the bad constraint list, but it was done this way in order to make a minimal change that would be the most ergonomic to use from both the C interface as well as the FFI binding interfaces.

Fixes #1546