### PR TITLE
build: fix MinGW build failures and update documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,12 @@ endif()
 if(MINGW)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -static-libgcc")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
-    # Link 32 bit SolveSpace with --large-address-aware which allows it to access
-    # up to 3GB on a properly configured 32 bit Windows and up to 4GB on 64 bit.
-    # See https://msdn.microsoft.com/en-us/library/aa366778
-    set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        # Link 32 bit SolveSpace with --large-address-aware which allows it to access
+        # up to 3GB on a properly configured 32 bit Windows and up to 4GB on 64 bit.
+        # See https://msdn.microsoft.com/en-us/library/aa366778
+        set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
+    endif()
 endif()
 
 # Ensure that all platforms use 64-bit IEEE floating point operations for consistency;

--- a/README.md
+++ b/README.md
@@ -307,19 +307,34 @@ nmake
 It is also possible to build SolveSpace using [MinGW][mingw], though
 Space Navigator support will be disabled.
 
-First, ensure that git and gcc are in your `$PATH`. Then, run the following
-in bash:
+The easiest way to build using MinGW is with [MSYS2][msys2]. If you're not using MSYS2, skip
+the installation instructions and ensure that git, cmake, ninja, and gcc are in your `$PATH`.
+
+With MSYS2, you can build either a 32-bit binary or a 64-bit one, depending on the compiler
+used. The following instructions assume you're running the commands inside an `MSYS2 MINGW64`
+terminal window and building a 64-bit version. If you want to build a 32-bit version, you'll
+need to run the commands in an `MSYS2 MINGW32` terminal window and replace `x86_64`
+with `i686` in the installation commands.
+
+First, install Git, GCC, CMake, and Ninja:
+
+```sh
+pacman -Sy mingw-w64-x86_64-git mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+```
+
+Then, run the following in bash:
 
 ```sh
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make
+cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja
+ninja
 ```
 
 [gitwin]: https://git-scm.com/download/win
-[cmakewin]: http://www.cmake.org/download/#latest
+[cmakewin]: https://www.cmake.org/download/#latest
 [mingw]: http://www.mingw.org/
+[msys2]: https://www.msys2.org/
 
 ## Contributing
 


### PR DESCRIPTION
This includes updating the ANGLE dependency to the latest commit in our fork which fixes a build issue with GCC.

Additionally, a minor change to the build configuration was needed for building under 64-bit MinGW, which doesn't support `--large-address-aware`.

With those in place, the documentation for building under MinGW is updated with working instructions and a recommendation to use MSYS2 for easier installation of the required tools.

@phkahler had reservations regarding the change to ANGLE in https://github.com/solvespace/angle/pull/2, which this PR relies on, so I'm just opening this PR in order to put the fix out there in case this is acceptable, but please feel free to close it if not.

Fixes #1570.