### PR TITLE
Minor cleanup: use the ParamList and EntityList type aliases

### DIFF
--- a/src/constrainteq.cpp
+++ b/src/constrainteq.cpp
@@ -247,7 +247,7 @@ void ConstraintBase::AddEq(IdList<Equation,hEquation> *l, const ExprVector &v,
     }
 }
 
-void ConstraintBase::Generate(IdList<Param,hParam> *l) {
+void ConstraintBase::Generate(ParamList *l) {
     switch(type) {
         case Type::PARALLEL:
         case Type::CUBIC_LINE_TANGENT:

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -307,8 +307,8 @@ Expr *Expr::DeepCopy() const {
     return n;
 }
 
-Expr *Expr::DeepCopyWithParamsAsPointers(IdList<Param,hParam> *firstTry,
-                                         IdList<Param, hParam> *thenTry, bool foldConstants) const {
+Expr *Expr::DeepCopyWithParamsAsPointers(ParamList *firstTry, ParamList *thenTry,
+                                         bool foldConstants) const {
     Expr *n = AllocExpr();
     if(op == Op::PARAM) {
         // A param that is referenced by its hParam gets rewritten to go

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -581,8 +581,8 @@ void SolveSpaceUI::UpgradeLegacyData() {
             // at workplane origin, and the solver will mess up the sketch if
             // it is not fully constrained.
             case Request::Type::TTF_TEXT: {
-                IdList<Entity,hEntity> entity = {};
-                IdList<Param,hParam>   param = {};
+                EntityList entity = {};
+                ParamList  param = {};
                 r.Generate(&entity, &param);
 
                 // If we didn't load all of the entities and params that this
@@ -621,12 +621,12 @@ void SolveSpaceUI::UpgradeLegacyData() {
     // Constraints saved in versions prior to 3.0 never had any params;
     // version 3.0 introduced params to constraints to avoid the hairy ball problem,
     // so force them where they belong.
-    IdList<Param,hParam> oldParam = {};
+    ParamList oldParam = {};
     SK.param.DeepCopyInto(&oldParam);
     SS.GenerateAll(SolveSpaceUI::Generate::REGEN);
 
     auto AllParamsExistFor = [&](Constraint &c) {
-        IdList<Param,hParam> param = {};
+        ParamList param = {};
         c.Generate(&param);
         bool allParamsExist = true;
         for(Param &p : param) {

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -225,7 +225,7 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
     PruneOrphans();
 
     // Don't lose our numerical guesses when we regenerate.
-    IdList<Param,hParam> prev = {};
+    ParamList prev = {};
     SK.param.MoveSelfInto(&prev);
     SK.param.ReserveMore(prev.n);
     int oldEntityCount = SK.entity.n;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -34,7 +34,7 @@ void Group::Clear() {
     remap.clear();
 }
 
-void Group::AddParam(IdList<Param,hParam> *param, hParam hp, double v) {
+void Group::AddParam(ParamList *param, hParam hp, double v) {
     Param pa = {};
     pa.h = hp;
     pa.val = v;
@@ -435,8 +435,7 @@ void Group::Activate() {
     SS.ScheduleShowTW();
 }
 
-void Group::Generate(IdList<Entity,hEntity> *entity,
-                     IdList<Param,hParam> *param)
+void Group::Generate(EntityList *entity, ParamList *param)
 {
     Vector gn = (SS.GW.projRight).Cross(SS.GW.projUp);
     Vector gp = SS.GW.projRight.Plus(SS.GW.projUp);
@@ -868,7 +867,7 @@ hEntity Group::Remap(hEntity in, int copyNumber) {
     return h.entity(it->second.v);
 }
 
-void Group::MakeExtrusionLines(IdList<Entity,hEntity> *el, hEntity in) {
+void Group::MakeExtrusionLines(EntityList *el, hEntity in) {
     Entity *ep = SK.GetEntity(in);
 
     Entity en = {};
@@ -904,7 +903,7 @@ void Group::MakeExtrusionLines(IdList<Entity,hEntity> *el, hEntity in) {
     }
 }
 
-void Group::MakeLatheCircles(IdList<Entity,hEntity> *el, IdList<Param,hParam> *param, hEntity in, Vector pt, Vector axis) {
+void Group::MakeLatheCircles(EntityList *el, ParamList *param, hEntity in, Vector pt, Vector axis) {
     Entity *ep = SK.GetEntity(in);
 
     Entity en = {};
@@ -951,7 +950,7 @@ void Group::MakeLatheCircles(IdList<Entity,hEntity> *el, IdList<Param,hParam> *p
     }
 }
 
-void Group::MakeLatheSurfacesSelectable(IdList<Entity, hEntity> *el, hEntity in, Vector axis) {
+void Group::MakeLatheSurfacesSelectable(EntityList *el, hEntity in, Vector axis) {
     Entity *ep = SK.GetEntity(in);
 
     Entity en = {};
@@ -986,7 +985,7 @@ void Group::MakeLatheSurfacesSelectable(IdList<Entity, hEntity> *el, hEntity in,
 // For Revolve and Helix groups the end faces are remapped from an arbitrary
 // point on the sketch. We reference the transformed point but there is
 // no existing normal so we need to define the rotation and timesApplied.
-void Group::MakeRevolveEndFaces(IdList<Entity,hEntity> *el, hEntity pt, int ai, int af)
+void Group::MakeRevolveEndFaces(EntityList *el, hEntity pt, int ai, int af)
 {
     if(pt.v == 0) return;
     Group *src = SK.GetGroup(opA);
@@ -1023,7 +1022,7 @@ void Group::MakeRevolveEndFaces(IdList<Entity,hEntity> *el, hEntity pt, int ai, 
     el->Add(&en);
 }
 
-void Group::MakeExtrusionTopBottomFaces(IdList<Entity,hEntity> *el, hEntity pt)
+void Group::MakeExtrusionTopBottomFaces(EntityList *el, hEntity pt)
 {
     if(pt.v == 0) return;
     Group *src = SK.GetGroup(opA);
@@ -1049,7 +1048,7 @@ void Group::MakeExtrusionTopBottomFaces(IdList<Entity,hEntity> *el, hEntity pt)
     el->Add(&en);
 }
 
-void Group::CopyEntity(IdList<Entity,hEntity> *el,
+void Group::CopyEntity(EntityList *el,
                        Entity *ep, int timesApplied, int remap,
                        hParam dx, hParam dy, hParam dz,
                        hParam qw, hParam qvx, hParam qvy, hParam qvz, hParam dist,

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -78,8 +78,7 @@ Request::Type EntReqTable::GetRequestForEntity(Entity::Type ent) {
     return req;
 }
 
-void Request::Generate(IdList<Entity,hEntity> *entity,
-                       IdList<Param,hParam> *param)
+void Request::Generate(EntityList *entity, ParamList *param)
 {
     int points = 0;
     Entity::Type et = (Entity::Type)0;
@@ -239,7 +238,7 @@ int Request::IndexOfPoint(hEntity he) const {
     return -1;
 }
 
-hParam Request::AddParam(IdList<Param,hParam> *param, hParam hp) {
+hParam Request::AddParam(ParamList *param, hParam hp) {
     Param pa = {};
     pa.h = hp;
     param->Add(&pa);

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -293,9 +293,9 @@ public:
     };
     hEntity Remap(hEntity in, int copyNumber);
     void MakeExtrusionLines(EntityList *el, hEntity in);
-    void MakeLatheCircles(IdList<Entity,hEntity> *el, IdList<Param,hParam> *param, hEntity in, Vector pt, Vector axis);
-    void MakeLatheSurfacesSelectable(IdList<Entity, hEntity> *el, hEntity in, Vector axis);
-    void MakeRevolveEndFaces(IdList<Entity,hEntity> *el, hEntity pt, int ai, int af);
+    void MakeLatheCircles(EntityList *el, ParamList *param, hEntity in, Vector pt, Vector axis);
+    void MakeLatheSurfacesSelectable(EntityList *el, hEntity in, Vector axis);
+    void MakeRevolveEndFaces(EntityList *el, hEntity pt, int ai, int af);
     void MakeExtrusionTopBottomFaces(EntityList *el, hEntity pt);
     void CopyEntity(EntityList *el,
                     Entity *ep, int timesApplied, int remap,
@@ -722,7 +722,7 @@ public:
     bool HasLabel() const;
     bool IsProjectible() const;
 
-    void Generate(IdList<Param, hParam> *param);
+    void Generate(ParamList *param);
 
     void GenerateEquations(IdList<Equation,hEquation> *entity,
                            bool forReference = false) const;

--- a/src/slvs/lib.cpp
+++ b/src/slvs/lib.cpp
@@ -1000,7 +1000,7 @@ void Slvs_Solve(Slvs_System *ssys, uint32_t shg)
 
         SK.entity.Add(&e);
     }
-    IdList<Param, hParam> params = {};
+    ParamList params = {};
     for(i = 0; i < ssys->constraints; i++) {
         Slvs_Constraint *sc = &(ssys->constraint[i]);
         ConstraintBase c = {};

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -495,7 +495,7 @@ public:
 
     // These are generated from the above.
     IdList<ENTITY,hEntity>          entity;
-    IdList<Param,hParam>            param;
+    ParamList                       param;
 
     inline CONSTRAINT *GetConstraint(hConstraint h)
         { return constraint.FindById(h); }
@@ -525,7 +525,7 @@ public:
         List<hGroup>                    groupOrder;
         IdList<Request,hRequest>        request;
         IdList<Constraint,hConstraint>  constraint;
-        IdList<Param,hParam>            param;
+        ParamList                       param;
         IdList<Style,hStyle>            style;
         hGroup                          activeGroup;
 


### PR DESCRIPTION
For some reason, even though the `ParamList` and `EntityList` aliases exist, parts of the code still spell the full type names (`IdList<Param, hParam>` and `IdList<Entity, hEntity>`, respectively). This makes the code verbose, less readable, and inconsistent. This PR changes it so that they use the aliases for better readability and consistency.