### PR TITLE
freetype: update the submodule URL to the official GitHub mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	url = https://github.com/glennrp/libpng
 [submodule "extlib/freetype"]
 	path = extlib/freetype
-	url = https://git.savannah.nongnu.org/git/freetype/freetype2.git
+	url = https://github.com/freetype/freetype.git
 [submodule "extlib/libdxfrw"]
 	path = extlib/libdxfrw
 	url = https://github.com/solvespace/libdxfrw.git


### PR DESCRIPTION
For the past few weeks there have been multiple times where CI failed because it encountered 502 errors while cloning the FreeType repository from its current URL.

The official FreeType repository is now hosted in the freedesktop GitLab instance, but in order to reduce the load on their servers, and to also hopefully reduce the chance that CI fails again due to unavailability, I chose to use the official GitHub mirror instead.

Related: https://github.com/solvespace/solvespace/pull/1575#issuecomment-2845257449, https://github.com/solvespace/solvespace/pull/1563#issuecomment-2787364549