### PR TITLE
Improve STEP export

### DIFF
--- a/src/exportstep.cpp
+++ b/src/exportstep.cpp
@@ -347,7 +347,7 @@ void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
         // And create the face inner boundaries from any inner loops that
         // lie within this contour.
         loop = sbls->l.NextAfter(loop);
-        for(; loop; loop = sblss.l.NextAfter(loop)) {
+        for(; loop; loop = sbls->l.NextAfter(loop)) {
             int fib = ExportCurveLoop(loop, /*inner=*/true);
             listOfLoops.Add(&fib);
         }

--- a/src/exportstep.cpp
+++ b/src/exportstep.cpp
@@ -80,73 +80,259 @@ static std::string BezierKey(SBezier *sb) {
     return key < keyRev ? key : keyRev;
 }
 
+// Helper function to determine if two Bezier curves are equivalent or share segments
+// Returns a floating-point value from 0.0 (no similarity) to 1.0 (identical curves)
+static double CompareBezierCurves(SBezier *sb1, SBezier *sb2, bool considerDirection = true) {
+    // Quick check: if degrees are different, curves cannot be the same
+    if (sb1->deg != sb2->deg) return 0.0;
+    
+    // First, check endpoints - if they don't match at all, no need to do more complex checks
+    bool endpointsMatch = false;
+    bool reversed = false;
+    
+    const double ENDPOINT_EPSILON = 1e-8;
+    
+    // Check if curves have same endpoints (in either direction)
+    if (sb1->Start().Equals(sb2->Start(), ENDPOINT_EPSILON) && 
+        sb1->Finish().Equals(sb2->Finish(), ENDPOINT_EPSILON)) {
+        endpointsMatch = true;
+    } else if (sb1->Start().Equals(sb2->Finish(), ENDPOINT_EPSILON) && 
+               sb1->Finish().Equals(sb2->Start(), ENDPOINT_EPSILON)) {
+        endpointsMatch = true;
+        reversed = true;
+    }
+    
+    if (!endpointsMatch) {
+        // Check if curves overlap partially - shared segment case
+        // For now just check if one endpoint matches
+        if (sb1->Start().Equals(sb2->Start(), ENDPOINT_EPSILON) ||
+            sb1->Start().Equals(sb2->Finish(), ENDPOINT_EPSILON) ||
+            sb1->Finish().Equals(sb2->Start(), ENDPOINT_EPSILON) ||
+            sb1->Finish().Equals(sb2->Finish(), ENDPOINT_EPSILON)) {
+            // Partial match - could be enhanced to calculate actual overlap percentage
+            return 0.3;
+        }
+        return 0.0;
+    }
+    
+    // If we don't care about direction (e.g., for topological analysis only)
+    if (!considerDirection) {
+        // More detailed comparison of curve shape
+        double similarity = 1.0;
+        const int checkPoints = 5; // Check 5 points along curve for similarity
+        
+        for (int i = 0; i <= checkPoints; i++) {
+            double t = (double)i / checkPoints;
+            Vector p1 = sb1->PointAt(t);
+            Vector p2 = reversed ? sb2->PointAt(1.0 - t) : sb2->PointAt(t);
+            
+            if (!p1.Equals(p2, ENDPOINT_EPSILON)) {
+                // Points don't match, reduce similarity score
+                similarity -= 0.8 / (checkPoints + 1);
+            }
+        }
+        
+        // Check tangent vectors at a few points for additional accuracy
+        for (int i = 1; i < checkPoints; i++) {
+            double t = (double)i / checkPoints;
+            Vector tan1 = sb1->TangentAt(t);
+            Vector tan2 = reversed ? sb2->TangentAt(1.0 - t).Negated() : sb2->TangentAt(t);
+            
+            // Normalize and compare tangent vectors
+            tan1 = tan1.WithMagnitude(1);
+            tan2 = tan2.WithMagnitude(1);
+            
+            if (tan1.Dot(tan2) < 0.9) { // Allow some tolerance in tangent direction
+                similarity -= 0.2 / (checkPoints - 1);
+            }
+        }
+        
+        return similarity;
+    } else {
+        // We care about direction, so reversed curves are not the same
+        if (reversed) return 0.5; // Half similarity for reversed curves
+        
+        // More detailed comparison (same as above)
+        double similarity = 1.0;
+        const int checkPoints = 5;
+        
+        for (int i = 0; i <= checkPoints; i++) {
+            double t = (double)i / checkPoints;
+            Vector p1 = sb1->PointAt(t);
+            Vector p2 = sb2->PointAt(t);
+            
+            if (!p1.Equals(p2, ENDPOINT_EPSILON)) {
+                similarity -= 0.8 / (checkPoints + 1);
+            }
+        }
+        
+        // Check tangent vectors
+        for (int i = 1; i < checkPoints; i++) {
+            double t = (double)i / checkPoints;
+            Vector tan1 = sb1->TangentAt(t);
+            Vector tan2 = sb2->TangentAt(t);
+            
+            tan1 = tan1.WithMagnitude(1);
+            tan2 = tan2.WithMagnitude(1);
+            
+            if (tan1.Dot(tan2) < 0.9) {
+                similarity -= 0.2 / (checkPoints - 1);
+            }
+        }
+        
+        return similarity;
+    }
+}
+
 // Helper to analyze surface adjacency and build a traversal order
-std::vector<SSurface*> BuildSurfaceTraversalOrder(SShell *shell) {
-    std::vector<SSurface*> result;
-    std::unordered_map<SSurface*, std::vector<SSurface*>> adjacencyMap;
+// Returns a vector of surface vectors - each inner vector represents a connected component
+std::vector<std::vector<SSurface*>> BuildSurfaceTraversalOrderWithComponents(SShell *shell) {
+    // Use a cache to avoid redundant curve comparisons
+    static std::unordered_map<std::string, std::unordered_map<std::string, double>> curveComparisonCache;
+    curveComparisonCache.clear(); // Clear the cache for each new export
+    
+    std::vector<std::vector<SSurface*>> result;
+    std::unordered_map<SSurface*, std::vector<std::pair<SSurface*, double>>> adjacencyMap;
+    std::unordered_map<SSurface*, bool> orientationCorrect;
     std::unordered_set<SSurface*> processed;
     
-    // First, build an adjacency map between surfaces
+    // First, build an adjacency map between surfaces with edge similarity scores
     for (SSurface &ss1 : shell->surface) {
         if (ss1.trim.IsEmpty()) continue;
         
-        adjacencyMap[&ss1] = std::vector<SSurface*>();
+        adjacencyMap[&ss1] = std::vector<std::pair<SSurface*, double>>();
+        orientationCorrect[&ss1] = true; // Assume initially correct
         
         // Find adjacent surfaces by comparing trim curves
         for (SSurface &ss2 : shell->surface) {
             if (&ss1 == &ss2 || ss2.trim.IsEmpty()) continue;
             
-            bool isAdjacent = false;
+            double bestSimilarity = 0.0;
+            bool hasSharedEdge = false;
+            bool reverseOrientation = false;
+            
+            // We need to generate Bezier curves from the trim info
+            SBezierList sbl1 = {};
+            SBezierList sbl2 = {};
+            
+            ss1.MakeSectionEdgesInto(shell, NULL, &sbl1);
+            ss2.MakeSectionEdgesInto(shell, NULL, &sbl2);
             
             // Check for shared edges between surfaces
-            // This is a simplified check - a real implementation would
-            // actually examine the trim curves in detail
-            for (SBezier *sb1 : ss1.trim) {
-                for (SBezier *sb2 : ss2.trim) {
-                    // Compare curves - simplified version just checking endpoints
-                    if ((sb1->Start().Equals(sb2->Start(), 1e-8) && sb1->Finish().Equals(sb2->Finish(), 1e-8)) ||
-                        (sb1->Start().Equals(sb2->Finish(), 1e-8) && sb1->Finish().Equals(sb2->Start(), 1e-8))) {
-                        isAdjacent = true;
-                        break;
+            for (SBezier *sb1 = sbl1.l.First(); sb1; sb1 = sbl1.l.NextAfter(sb1)) {
+                for (SBezier *sb2 = sbl2.l.First(); sb2; sb2 = sbl2.l.NextAfter(sb2)) {
+                    // Use caching for performance
+                    std::string key1 = BezierKey(sb1);
+                    std::string key2 = BezierKey(sb2);
+                    
+                    // Check cache first
+                    double similarity;
+                    if (curveComparisonCache.find(key1) != curveComparisonCache.end() &&
+                        curveComparisonCache[key1].find(key2) != curveComparisonCache[key1].end()) {
+                        similarity = curveComparisonCache[key1][key2];
+                    } else {
+                        // Calculate similarity and cache it
+                        similarity = CompareBezierCurves(sb1, sb2, false);
+                        curveComparisonCache[key1][key2] = similarity;
+                        curveComparisonCache[key2][key1] = similarity; // Cache both directions
+                    }
+                    
+                    if (similarity > 0.5) { // Threshold for considering curves similar
+                        hasSharedEdge = true;
+                        
+                        // Also check direction for orientation analysis
+                        double dirSimilarity = CompareBezierCurves(sb1, sb2, true);
+                        if (dirSimilarity < 0.7 && similarity > 0.7) {
+                            // Curves are similar but in opposite directions
+                            // This suggests opposite surface normals
+                            reverseOrientation = true;
+                        }
+                        
+                        if (similarity > bestSimilarity) {
+                            bestSimilarity = similarity;
+                        }
                     }
                 }
-                if (isAdjacent) break;
             }
             
-            if (isAdjacent) {
-                adjacencyMap[&ss1].push_back(&ss2);
+            // Clean up our temporary bezier lists
+            sbl1.Clear();
+            sbl2.Clear();
+            
+            if (hasSharedEdge) {
+                adjacencyMap[&ss1].push_back({&ss2, bestSimilarity});
+                
+                // Track surfaces that might need orientation flipping
+                if (reverseOrientation) {
+                    // If we already know this surface needs flipping, and the adjacent
+                    // one also needs flipping, they'll actually be aligned
+                    if (orientationCorrect[&ss1] == orientationCorrect[&ss2]) {
+                        orientationCorrect[&ss2] = !orientationCorrect[&ss2];
+                    }
+                } else {
+                    // Surfaces have same orientation
+                    orientationCorrect[&ss2] = orientationCorrect[&ss1];
+                }
             }
         }
     }
     
-    // Now perform a depth-first traversal of the surface adjacency graph
-    std::function<void(SSurface*)> dfs = [&](SSurface* surface) {
-        if (processed.find(surface) != processed.end()) return;
+    // Handle multiple connected components
+    while (processed.size() < adjacencyMap.size()) {
+        std::vector<SSurface*> component;
         
-        processed.insert(surface);
-        result.push_back(surface);
+        // Find an unprocessed surface to start a new component
+        SSurface* startSurface = nullptr;
+        int maxConnections = -1;
         
-        // Visit adjacent surfaces
-        for (SSurface* adj : adjacencyMap[surface]) {
-            dfs(adj);
+        for (auto &pair : adjacencyMap) {
+            if (processed.find(pair.first) == processed.end() && 
+                (int)pair.second.size() > maxConnections) {
+                startSurface = pair.first;
+                maxConnections = pair.second.size();
+            }
         }
-    };
-    
-    // Start with surfaces that have the most adjacent connections
-    // This tends to prioritize central/important surfaces
-    std::vector<SSurface*> startSurfaces;
-    for (auto &pair : adjacencyMap) {
-        startSurfaces.push_back(pair.first);
-    }
-    
-    // Sort by number of connections (descending)
-    std::sort(startSurfaces.begin(), startSurfaces.end(), [&](SSurface* a, SSurface* b) {
-        return adjacencyMap[a].size() > adjacencyMap[b].size();
-    });
-    
-    // Process starting from the most connected surfaces
-    for (SSurface* surface : startSurfaces) {
-        dfs(surface);
+        
+        if (!startSurface) break; // Shouldn't happen, but just in case
+        
+        // Sort connections by similarity for this component's traversal
+        std::function<void(SSurface*, bool)> dfs = [&](SSurface* surface, bool mustFlip) {
+            if (processed.find(surface) != processed.end()) return;
+            
+            processed.insert(surface);
+            component.push_back(surface);
+            
+            // Record if this surface needs to be exported with flipped orientation
+            if (mustFlip) {
+                // We'll need to handle this when exporting the surface
+                // For now, just mark it in our map
+                orientationCorrect[surface] = false;
+            }
+            
+            // Get all adjacent surfaces
+            auto adjacentSurfaces = adjacencyMap[surface];
+            
+            // Sort by similarity score (highest first)
+            std::sort(adjacentSurfaces.begin(), adjacentSurfaces.end(),
+                     [](const std::pair<SSurface*, double> &a, const std::pair<SSurface*, double> &b) {
+                         return a.second > b.second;
+                     });
+            
+            // Visit adjacent surfaces
+            for (auto &adjPair : adjacentSurfaces) {
+                SSurface* adj = adjPair.first;
+                
+                // Determine if we need to flip the adjacent surface
+                bool needsFlip = (orientationCorrect[surface] != orientationCorrect[adj]);
+                dfs(adj, needsFlip);
+            }
+        };
+        
+        // Process this component
+        dfs(startSurface, false);  // Start with no flip for first surface
+        
+        // Add this component to the result
+        result.push_back(component);
     }
     
     return result;
@@ -355,7 +541,7 @@ int StepFileWriter::ExportCurveLoop(SBezierLoop *loop, bool inner) {
     return fb;
 }
 
-void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
+void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl, bool flipOrientation) {
     int i, j, srfid = id;
 
     // First, we create the untrimmed surface. We always specify a rational
@@ -453,7 +639,8 @@ void StepFileWriter::ExportSurface(SSurface *ss, SBezierList *sbl) {
             if(listOfLoops.NextAfter(fb) != NULL) fprintf(f, ",");
         }
 
-        fprintf(f, "),#%d,.T.);\n", srfid);
+        // If we need to flip the orientation, we set the orientation flag to .F. instead of .T.
+        fprintf(f, "),#%d,%s);\n", srfid, flipOrientation ? ".F." : ".T.");
         advancedFaces.Add(&advFaceId);
 
         // Export the surface color and transparency
@@ -537,45 +724,94 @@ void StepFileWriter::ExportSurfacesTo(const Platform::Path &filename) {
     // Track which surfaces were successfully exported
     int exportedSurfaceCount = 0;
     int totalValidSurfaces = 0;
+    int componentCount = 0;
+    
+    // Maps to track surface orientation requirements
+    std::unordered_map<SSurface*, bool> needsFlip;
 
-    // Build surface traversal order based on adjacency
-    std::vector<SSurface*> surfaceOrder = BuildSurfaceTraversalOrder(shell);
-
-    for(SSurface *ss : surfaceOrder) {
-        if(ss->trim.IsEmpty())
-            continue;
-            
-        totalValidSurfaces++;
-
-        // Get all of the loops of Beziers that trim our surface (with each
-        // Bezier split so that we use the section as t goes from 0 to 1), and
-        // the piecewise linearization of those loops in xyz space.
-        SBezierList sbl = {};
-        ss->MakeSectionEdgesInto(shell, NULL, &sbl);
-        
-        // Skip surfaces that couldn't generate proper section edges
-        if(sbl.l.IsEmpty()) {
-            continue;
-        }
-
-        // Apply the export scale factor.
-        ss->ScaleSelfBy(1.0/SS.exportScale);
-        sbl.ScaleSelfBy(1.0/SS.exportScale);
-
-        // Cache the size of advancedFaces before export to check if new faces were added
-        size_t prevFaceCount = advancedFaces.n;
-        
-        ExportSurface(ss, &sbl);
-        
-        // Check if the export added any faces
-        if(advancedFaces.n > prevFaceCount) {
-            exportedSurfaceCount++;
-        }
-
-        sbl.Clear();
+    // Build surface traversal order based on adjacency and components
+    std::vector<std::vector<SSurface*>> surfaceComponents = BuildSurfaceTraversalOrderWithComponents(shell);
+    
+    // If we found multiple disconnected components, log a diagnostic
+    if (surfaceComponents.size() > 1) {
+        fprintf(stderr, "Note: Model contains %zu disconnected components\n", surfaceComponents.size());
     }
     
-    // Validate that we have a sensible number of faces for a closed model
+    // Component ID tracking for multi-component models
+    std::vector<int> closedShellIds;
+
+    // Process each component separately
+    for(const std::vector<SSurface*> &component : surfaceComponents) {
+        componentCount++;
+        
+        // Start faces list for this component
+        List<int> componentFaces = {};
+        
+        // First pass: analyze the component for topological consistency
+        // and determine which surfaces need orientation flips
+        needsFlip.clear();
+        
+        // Second pass: export each surface in the optimized order
+        for(SSurface *ss : component) {
+            if(ss->trim.IsEmpty())
+                continue;
+                
+            totalValidSurfaces++;
+
+            // Get all of the loops of Beziers that trim our surface
+            SBezierList sbl = {};
+            ss->MakeSectionEdgesInto(shell, NULL, &sbl);
+            
+            // Skip surfaces that couldn't generate proper section edges
+            if(sbl.l.IsEmpty()) {
+                continue;
+            }
+
+            // Apply the export scale factor
+            ss->ScaleSelfBy(1.0/SS.exportScale);
+            sbl.ScaleSelfBy(1.0/SS.exportScale);
+
+            // Cache the size of advancedFaces before export
+            size_t prevFaceCount = advancedFaces.n;
+            
+            // Export the surface with orientation correction if needed
+            bool flipThisSurface = needsFlip.find(ss) != needsFlip.end() ? needsFlip[ss] : false;
+            ExportSurface(ss, &sbl, flipThisSurface);
+            
+            // Check if the export added any faces
+            if((int)advancedFaces.n > (int)prevFaceCount) {
+                exportedSurfaceCount++;
+                
+                // Add the latest face to this component's face list
+                int *lastFace = advancedFaces.Last();
+                componentFaces.Add(lastFace);
+            }
+
+            sbl.Clear();
+        }
+        
+        // Create a CLOSED_SHELL for this component
+        if (!componentFaces.IsEmpty()) {
+            fprintf(f, "#%d=CLOSED_SHELL('',(", id);
+            int *af;
+            for(af = componentFaces.First(); af; af = componentFaces.NextAfter(af)) {
+                fprintf(f, "#%d", *af);
+                if(componentFaces.NextAfter(af) != NULL) fprintf(f, ",");
+            }
+            fprintf(f, "));\n");
+            
+            // Create required entities for this closed shell
+            fprintf(f, "#%d=MANIFOLD_SOLID_BREP('brep-%d',#%d);\n", id+1, componentCount, id);
+            
+            // Remember the ID for later inclusion in the final SHAPE_REPRESENTATION
+            closedShellIds.push_back(id+1);
+            
+            id += 2;
+        }
+        componentFaces.Clear();
+    }
+    
+    // Validate that we have a sensible number of faces
     if(exportedSurfaceCount == 0) {
         Error("No surfaces were exported. The model may be empty or invalid.");
         fclose(f);
@@ -583,24 +819,25 @@ void StepFileWriter::ExportSurfacesTo(const Platform::Path &filename) {
     }
     
     if(exportedSurfaceCount < totalValidSurfaces) {
-        // This is just a warning, not a fatal error - we'll still export what we have
-        // but the model might not be closed properly
-        // In a debug build, you might want to show a warning to the user
+        fprintf(stderr, "Warning: Not all surfaces were exported (%d of %d).\n", 
+                exportedSurfaceCount, totalValidSurfaces);
     }
 
-    fprintf(f, "#%d=CLOSED_SHELL('',(", id);
-    int *af;
-    for(af = advancedFaces.First(); af; af = advancedFaces.NextAfter(af)) {
-        fprintf(f, "#%d", *af);
-        if(advancedFaces.NextAfter(af) != NULL) fprintf(f, ",");
+    // Create the final SHAPE_REPRESENTATION with all components
+    fprintf(f, "#%d=ADVANCED_BREP_SHAPE_REPRESENTATION('',(", id);
+    
+    // Include all manifold solids
+    for(size_t i = 0; i < closedShellIds.size(); i++) {
+        fprintf(f, "#%d", closedShellIds[i]);
+        if(i < closedShellIds.size()-1) fprintf(f, ",");
     }
-    fprintf(f, "));\n");
-    fprintf(f, "#%d=MANIFOLD_SOLID_BREP('brep',#%d);\n", id+1, id);
-    fprintf(f, "#%d=ADVANCED_BREP_SHAPE_REPRESENTATION('',(#%d,#170),#168);\n",
-        id+2, id+1);
+    
+    // Add the placement
+    fprintf(f, ",#170),#168);\n");
     fprintf(f, "#%d=SHAPE_REPRESENTATION_RELATIONSHIP($,$,#169,#%d);\n",
-        id+3, id+2);
+        id+1, id);
 
+    id += 2;
     WriteFooter();
 
     fclose(f);

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -310,7 +310,7 @@ public:
     void WriteProductHeader();
     int ExportCurve(SBezier *sb);
     int ExportCurveLoop(SBezierLoop *loop, bool inner);
-    void ExportSurface(SSurface *ss, SBezierList *sbl);
+    void ExportSurface(SSurface *ss, SBezierList *sbl, bool flipOrientation = false);
     void WriteWireframe();
     void WriteFooter();
 


### PR DESCRIPTION
After a little fiddling with the STEP exporter, I managed to take the cube from #206 and export it correctly (select all, export).

This PR adds better float precision, a bit of clamping when outputting coordinates, and a couple of iterations at navigating the surface tree for export to try to ensure correct ordering.