### PR TITLE
build: silence "maybe uninitialised" warnings

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -93,8 +93,8 @@ void GraphicsWindow::CopySelection() {
             if(!e->h.isFromRequest()) continue;
             Request *r = SK.GetRequest(e->h.request());
             if(r->type != Request::Type::DATUM_POINT) continue;
-            EntReqTable::GetEntityInfo((Entity::Type)0, e->extraPoints,
-                &req, &pts, NULL, &hasDistance);
+            ssassert(EntReqTable::GetEntityInfo((Entity::Type)0, e->extraPoints,
+                &req, &pts, NULL, &hasDistance), "No entity info");
         }
         if(req == Request::Type::WORKPLANE) continue;
 
@@ -195,8 +195,8 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
         SS.MarkGroupDirty(r->group);
         bool hasDistance;
         int i, pts;
-        EntReqTable::GetRequestInfo(r->type, r->extraPoints,
-            NULL, &pts, NULL, &hasDistance);
+        ssassert(EntReqTable::GetRequestInfo(r->type, r->extraPoints,
+            NULL, &pts, NULL, &hasDistance), "No request info");;
         for(i = 0; i < pts; i++) {
             Vector pt = cr->point[i];
             // We need the reflection to occur within the workplane; it may

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1188,8 +1188,8 @@ void Group::CopyEntity(IdList<Entity,hEntity> *el,
 
             int i, points;
             bool hasNormal, hasDistance;
-            EntReqTable::GetEntityInfo(ep->type, ep->extraPoints,
-                NULL, &points, &hasNormal, &hasDistance);
+            ssassert(EntReqTable::GetEntityInfo(ep->type, ep->extraPoints,
+                NULL, &points, &hasNormal, &hasDistance), "No entity info");
             for(i = 0; i < points; i++) {
                 en.point[i] = Remap(ep->point[i], remap);
             }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -57,8 +57,8 @@ void GraphicsWindow::StartDraggingByEntity(hEntity he) {
               e->type == Entity::Type::IMAGE)
     {
         int pts;
-        EntReqTable::GetEntityInfo(e->type, e->extraPoints,
-            NULL, &pts, NULL, NULL);
+        ssassert(EntReqTable::GetEntityInfo(e->type, e->extraPoints,
+            NULL, &pts, NULL, NULL), "No entity info");
         for(int i = 0; i < pts; i++) {
             AddPointToDraggedList(e->point[i]);
         }

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1515,6 +1515,7 @@ public:
     void AddButton(std::string _label, Response response, bool isDefault) override {
         int button;
         switch(response) {
+            default:
             case Response::NONE:   ssassert(false, "Invalid response");
             case Response::OK:     button = IDOK;     break;
             case Response::YES:    button = IDYES;    break;

--- a/src/render/gl3shader.cpp
+++ b/src/render/gl3shader.cpp
@@ -108,7 +108,7 @@ precision highp float;
     glShaderSource(shader, 1, glSource, glSize);
     glCompileShader(shader);
 
-    GLint infoLen;
+    GLint infoLen = 0;
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLen);
     if(infoLen > 1) {
         std::string infoStr(infoLen, '\0');
@@ -116,7 +116,7 @@ precision highp float;
         dbp(infoStr.c_str());
     }
 
-    GLint compiled;
+    GLint compiled = 0;
     glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
     if(!compiled) {
         dbp("Failed to compile shader:\n"
@@ -145,7 +145,7 @@ void Shader::Init(const std::string &vertexRes, const std::string &fragmentRes,
     }
     glLinkProgram(program);
 
-    GLint infoLen;
+    GLint infoLen = 0;
     glGetProgramiv(program, GL_INFO_LOG_LENGTH, &infoLen);
     if(infoLen > 1) {
         std::string infoStr(infoLen, '\0');
@@ -153,7 +153,7 @@ void Shader::Init(const std::string &vertexRes, const std::string &fragmentRes,
         dbp(infoStr.c_str());
     }
 
-    GLint linked;
+    GLint linked = 0;
     glGetProgramiv(program, GL_LINK_STATUS, &linked);
     ssassert(linked, "Cannot link shader");
 }
@@ -386,7 +386,7 @@ GLuint Generate(const std::vector<double> &pattern) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 
-    GLint size;
+    GLint size = 0;
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &size);
     size /= 2;
 

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -123,7 +123,8 @@ void Request::Generate(IdList<Entity,hEntity> *entity,
     }
 
     Entity e = {};
-    EntReqTable::GetRequestInfo(type, extraPoints, &et, &points, &hasNormal, &hasDistance);
+    ssassert(EntReqTable::GetRequestInfo(
+        type, extraPoints, &et, &points, &hasNormal, &hasDistance), "No request info");;
 
     // Generate the entity that's specific to this request.
     e.type = et;

--- a/src/srf/curve.cpp
+++ b/src/srf/curve.cpp
@@ -390,7 +390,10 @@ SBezierLoop SBezierLoop::FromCurves(SBezierList *sbl,
 {
     SBezierLoop loop = {};
 
-    if(sbl->l.n < 1) return loop;
+    if(sbl->l.n < 1) {
+        *allClosed = false;
+        return loop;
+    }
     sbl->l.ClearTags();
 
     SBezier *first = &(sbl->l[0]);


### PR DESCRIPTION
These pop up with GCC in the LTO build, and are easily worked around by adding initialisation or asserting, as needed.