### PR TITLE
build: clean up the workaround for building zlib in Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,31 +243,24 @@ if(ENABLE_GUI OR ENABLE_CLI)
         set(FORCE_VENDORED_PNG      ON)
         set(FORCE_VENDORED_Freetype ON)
 
-        # There's an issue with the zlib configuration, which doesn't provide a way to
-        # disable the shared or static library builds, and on UNIX sets the base name of
-        # the output for both the static and shared targets to `libz`. As Emscripten doesn't
-        # support shared libraries, CMake converts the shared library target to a static
-        # library and both targets end up with the name `libz.a`, causing Ninja to complain
-        # about different rules generating the same target. As a workaround, temporarily
-        # unset UNIX for Emscripten while the zlib configuration is being processed, and
-        # reset it back afterwards.
-        # NOTE: The unreleased develop branch of zlib after version 1.3.1 allows disabling
-        # the shared library build, which is the proper fix for this issue, so when the
-        # next version of zlib is released and updated as a dependency, `ZLIB_BUILD_SHARED`
-        # should be set to `OFF` instead of this hack.
-        if(EMSCRIPTEN AND UNIX)
-            set(zlib_workaround_unix_was_unset 1)
-            unset(UNIX)
-        endif()
-
         find_vendored_package(ZLIB zlib
             ZLIB_LIBRARY            zlibstatic
             ZLIB_INCLUDE_DIR        ${CMAKE_SOURCE_DIR}/extlib/zlib)
         list(APPEND ZLIB_INCLUDE_DIR ${CMAKE_BINARY_DIR}/extlib/zlib)
 
-        if(zlib_workaround_unix_was_unset)
-            set(UNIX 1)
-            unset(zlib_workaround_unix_was_unset)
+        # There's an issue with the zlib configuration, which doesn't provide a way to
+        # disable the shared or static library builds, and on UNIX sets the base name of
+        # the output for both the static and shared targets to `libz`. As Emscripten doesn't
+        # support shared libraries, CMake converts the shared library target to a static
+        # library and both targets end up with the name `libz.a`, causing Ninja to complain
+        # about different rules generating the same target. As a workaround, force the output
+        # name of the static library target to be different on Emscripten.
+        # NOTE: The unreleased develop branch of zlib after version 1.3.1 allows disabling
+        # the shared library build, which is the proper fix for this issue, so when the
+        # next version of zlib is released and updated as a dependency, `ZLIB_BUILD_SHARED`
+        # should be set to `OFF` instead of this hack.
+        if(EMSCRIPTEN AND UNIX)
+            set_target_properties(${ZLIB_LIBRARY} PROPERTIES OUTPUT_NAME zlibstatic)
         endif()
 
         find_vendored_package(PNG libpng


### PR DESCRIPTION
Commit 2a455285a3cc12b42197a5ca573ae5347c95d84d (merged in #1566) added an ugly workaround for building zlib with Emscripten. This commit provides a cleaner way, which doesn't require messing around with built-in variables that define the environment.