### PR TITLE
build: fix link error when building on Windows with Clang (not clang-cl)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,9 +356,24 @@ if(ENABLE_GUI)
             ${FONTCONFIG_LIBRARIES})
     endif()
 
-    if(MSVC)
-        set_target_properties(solvespace PROPERTIES
-            LINK_FLAGS "/MANIFEST:NO /SAFESEH:NO /INCREMENTAL:NO /OPT:REF")
+    if(WIN32)
+        if(MSVC)
+            set_target_properties(solvespace PROPERTIES
+                LINK_FLAGS "/MANIFEST:NO /SAFESEH:NO /INCREMENTAL:NO /OPT:REF")
+        else(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND MSVC_VERSION)
+            # Hack to fix broken build with clang (not clang-cl) on Windows with CMake >= 3.22
+            # which unconditionally adds "-Xlinker /MANIFEST:EMBED" to the command line
+            # for non-MSVC and non-MINGW compilers, and breaks the clang build where
+            # manifest are specified through resource files.
+            # See:
+            # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6929
+            # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6534
+            # https://gitlab.kitware.com/cmake/cmake/-/issues/22611
+            string(REPLACE " -Xlinker /MANIFEST:EMBED" ""
+                CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE}")
+            target_link_options(solvespace PRIVATE
+                "SHELL:-Xlinker /MANIFEST:NO")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
With CMake >= 3.22, the "-Xlinker /MANIFEST:EMBED" flag is provided even when no manifest files are added, and since we add our own manifest file through a resource file, this fails with a duplicate resource error.

Unfortunately there's no easy way to avoid it, other than special casing for CMake >= 3.22 to add the manifest as a source for non-MINGW WIN32, and exclude it from the resources, but otherwise add it to the resource file.

However, this solution requires conditionally reaching into `res/` from the `src/` directory build, which is really bad, so for now hack out the offending part from `CMAKE_CXX_LINK_EXECUTABLE`, since we actually don't want it.