### PR TITLE
group: add an explicit assertion for too many entities

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -862,6 +862,11 @@ void Group::GenerateEquations(IdList<Equation,hEquation> *l) {
 hEntity Group::Remap(hEntity in, int copyNumber) {
     auto it = remap.find({ in, copyNumber });
     if(it == remap.end()) {
+        // Due to the way the remap value is combined with the group handle into a 32-bit
+        // handle value to generate an entity handle, the mapped value must fit in a 16-bit
+        // variable.
+        // This limit can be lifted once the handle values are extended to 64-bit.
+        ssassert(remap.size() < (1 << 16) - 1, "Too many entities in group");
         std::tie(it, std::ignore) =
             remap.insert({ { in, copyNumber }, { (uint32_t)remap.size() + 1 } });
     }

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -122,7 +122,7 @@ struct IsHandleOracle<EntityId> : std::true_type {};
 struct EntityKey {
     hEntity     input;
     int         copyNumber;
-    // (input, copyNumber) gets mapped to ((Request)xxx).entity(h.v)
+    // (input, copyNumber) gets mapped to hGroup::entity(i)
 };
 struct EntityKeyHash {
     size_t operator()(const EntityKey &k) const {


### PR DESCRIPTION
This makes it clearer to users who are faced with a SolveSpace crash, instead of getting the "handle isn't unique" error from `IdList` much later in a different code-path (prompted by the discussion in #1569).

While at it, add a minor fix to the documentation of `EntityMap`, which wrongly stated that entities are remapped from requests instead of from groups.