### PR TITLE
generate: fix `PruneRequests()` to actually prune requests

### DIFF
--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -87,14 +87,27 @@ bool SolveSpaceUI::PruneGroups(hGroup hg) {
 }
 
 bool SolveSpaceUI::PruneRequests(hGroup hg) {
-    auto e = std::find_if(SK.entity.begin(), SK.entity.end(),
-                          [&](Entity &e) { return e.group == hg && !EntityExists(e.workplane); });
-    if(e != SK.entity.end()) {
-        (deleted.requests)++;
-        SK.entity.RemoveById(e->h);
-        return true;
+    const int requests = SK.request.n;
+    for(Entity &e : SK.entity) {
+        if(e.group != hg) {
+            continue;
+        }
+
+        if(!e.h.isFromRequest()) {
+            continue;
+        }
+
+        if(EntityExists(e.workplane)) {
+            continue;
+        }
+
+        Request *r = SK.GetRequest(e.h.request());
+        r->tag = 1;
     }
-    return false;
+    SK.request.RemoveTagged();
+    deleted.requests += requests - SK.request.n;
+
+    return requests > SK.request.n;
 }
 
 bool SolveSpaceUI::PruneConstraints(hGroup hg) {

--- a/src/graphicswin.cpp
+++ b/src/graphicswin.cpp
@@ -1039,14 +1039,6 @@ void GraphicsWindow::ForceTextWindowShown() {
 }
 
 void GraphicsWindow::DeleteTaggedRequests() {
-    // Delete any requests that were affected by this deletion.
-    for(Request &r : SK.request) {
-        if(r.workplane == Entity::FREE_IN_3D) continue;
-        if(!r.workplane.isFromRequest()) continue;
-        Request *wrkpl = SK.GetRequest(r.workplane.request());
-        if(wrkpl->tag)
-            r.tag = 1;
-    }
     // Rewrite any point-coincident constraints that were affected by this
     // deletion.
     for(Request &r : SK.request) {

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -765,8 +765,7 @@ public:
     bool EntityExists(hEntity he);
     bool GroupsInOrder(hGroup before, hGroup after);
     bool PruneGroups(hGroup hg);
-    bool PruneRequests(hGroup hg);
-    bool PruneConstraints(hGroup hg);
+    bool PruneRequestsAndConstraints(hGroup hg);
     static void ShowNakedEdges(bool reportOnlyWhenNotOkay);
 
     enum class Generate : uint32_t {


### PR DESCRIPTION
Commit 86f20cc7e5061d14323fdc0d814980922425e152 (merged in #428) was marked NFC, even though it didn't just convert loops to ranged-for, but also introduced a functional change in the request pruning logic to prune entities instead.

This doesn't make much sense, since the requests will stay, and their entities will simply be regenerated, leading to an infinite recursion and resulting in a crash with stack overflow. I'm not sure how it slipped past code review, but this was the cause of #628 and is the reason for the additional workplane deletion code that whitequark added in 586b0477d2be31b2ac24c351f5eeeb90f86a7c2b, so this PR also reverts that code as well.