### PR TITLE
Export volumes to STEP files

### DIFF
--- a/src/exportstep.cpp
+++ b/src/exportstep.cpp
@@ -4,47 +4,11 @@
 // Copyright 2008-2013 Jonathan Westhues.
 //-----------------------------------------------------------------------------
 #include "solvespace.h"
-#include <vector>
-#include <iostream>
 
 const double PRECISION = 2*LENGTH_EPS;
 
 //-----------------------------------------------------------------------------
-// Structs to keep track of duplicated entities
-//-----------------------------------------------------------------------------
-// Basic alias.
-typedef struct {
-    int reference;
-    std::vector<int> aliases;
-} alias_t;
-
-// Cartesian points.
-typedef struct {
-    alias_t alias;
-    alias_t vertexAlias;
-    Vector v;
-} pointAliases_t;
-
-// Curves.
-typedef struct {
-    alias_t alias;
-    std::vector<int> memberPoints;
-} curveAliases_t;
-
-// Edges.
-typedef struct {
-    alias_t alias;
-    int prevFinish;
-    int thisFinish;
-    int curveId;
-} edgeAliases_t;
-
-std::vector<pointAliases_t> pointAliases;
-std::vector<edgeAliases_t> edgeAliases;
-std::vector<curveAliases_t> curveAliases;
-
-//-----------------------------------------------------------------------------
-// Functions for STEP export
+// Functions for STEP export: duplication check.
 //-----------------------------------------------------------------------------
 // Check if this point was already defined with a different ID number.
 // inputs:
@@ -141,11 +105,11 @@ bool StepFileWriter::HasBSplineCurveAnAlias(int number, std::vector<int> points)
         if(points.size() != c.memberPoints.size()) {
             continue;
         } else {
-            uint matches = 0; // is this the same curve?
+            size_t matches = 0; // is this the same curve?
             // FIXME: this hack should work _most_ of the times
-            for(uint i = 0; i < points.size(); i++) {
-                for(uint j = 0; j < points.size(); j++) {
-                    if(points.at(i) == c.memberPoints.at(j)) {
+            for(size_t i = 0; i < points.size(); i++) {
+                for(size_t j = 0; j < points.size(); j++) {
+                    if(points[i] == c.memberPoints[j]) {
                         matches++;
                     }
                 }
@@ -231,6 +195,9 @@ int StepFileWriter::InsertOrientedEdge(int number) {
     return -1;
 }
 
+//-----------------------------------------------------------------------------
+// Functions for STEP export: print to file.
+//-----------------------------------------------------------------------------
 void StepFileWriter::WriteHeader() {
     fprintf(f,
 "ISO-10303-21;\n"

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -305,6 +305,13 @@ public:
 
 class StepFileWriter {
 public:
+    bool HasCartesianPointAnAlias(int number, Vector v, int vertex);
+    int InsertPoint(int number);
+    int InsertVertex(int number);
+    bool HasBSplineCurveAnAlias(int number, std::vector<int> points);
+    int InsertCurve(int number);
+    bool HasEdgeAnAlias(int number, int prevFinish, int thisFinish, int curveId);
+    int InsertOrientedEdge(int number);
     void ExportSurfacesTo(const Platform::Path &filename);
     void WriteHeader();
     void WriteProductHeader();

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -325,6 +325,38 @@ public:
     List<int> advancedFaces;
     FILE *f;
     int id;
+
+    // Structs to keep track of duplicated entities.
+    // Basic alias.
+    typedef struct {
+        int reference;
+        std::vector<int> aliases;
+    } alias_t;
+
+    // Cartesian points.
+    typedef struct {
+        alias_t alias;
+        alias_t vertexAlias;
+        Vector v;
+    } pointAliases_t;
+
+    // Curves.
+    typedef struct {
+        alias_t alias;
+        std::vector<int> memberPoints;
+    } curveAliases_t;
+
+    // Edges.
+    typedef struct {
+        alias_t alias;
+        int prevFinish;
+        int thisFinish;
+        int curveId;
+    } edgeAliases_t;
+
+    std::vector<pointAliases_t> pointAliases;
+    std::vector<edgeAliases_t> edgeAliases;
+    std::vector<curveAliases_t> curveAliases;
 };
 
 class VectorFileWriter {


### PR DESCRIPTION
A simple workaround to export valid volumes in STEP format. Quick description:

- all code is contained in _exportstep.cpp_;
- duplicated entities are treated as aliases, so that only one copy for each entity is used in all the file;
- if two points are within the same distance accuracy, they are treated as duplicated.

I tested this with a good number of drawings already and it works.

![Screenshot_20250514_204207](https://github.com/user-attachments/assets/3b8342a4-561c-480d-8bd1-1bc9f68ba7ef)


