### PR TITLE
generate: avoid message box avalanche on Windows during regeneration

### DIFF
--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -325,11 +325,14 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
         ScheduleShowTW();
         GW.ClearSuper();
 
+        auto deletedStat = deleted;
+        deleted = {};
+
         // People get annoyed if I complain whenever they delete any request,
         // and I otherwise will, since those always come with pt-coincident
         // constraints.
-        if(deleted.requests > 0 || deleted.nonTrivialConstraints > 0 ||
-           deleted.groups > 0)
+        if(deletedStat.requests > 0 || deletedStat.nonTrivialConstraints > 0 ||
+           deletedStat.groups > 0)
         {
             // Don't display any errors until we've regenerated fully. The
             // sketch is not necessarily in a consistent state until we've
@@ -343,13 +346,11 @@ void SolveSpaceUI::GenerateAll(Generate type, bool andFindFree, bool genForBBox)
                     "     %d constraint%s\n"
                     "     %d group%s"
                     "%s",
-                       deleted.requests, deleted.requests == 1 ? "" : "s",
-                       deleted.constraints, deleted.constraints == 1 ? "" : "s",
-                       deleted.groups, deleted.groups == 1 ? "" : "s",
+                       deletedStat.requests, deletedStat.requests == 1 ? "" : "s",
+                       deletedStat.constraints, deletedStat.constraints == 1 ? "" : "s",
+                       deletedStat.groups, deletedStat.groups == 1 ? "" : "s",
                        undo.cnt > 0 ? "\n\nChoose Edit -> Undo to undelete all elements." : "");
         }
-
-        deleted = {};
     }
 
     FreeAllTemporary();


### PR DESCRIPTION
Calling `Message()` can cause processing of a scheduled dirty regeneration while the message box is still shown. Since the deleted stats are only zeroed after the message box is dismissed, this can cause the message box to be shown multiple times.

Fix it by changing the code to reset the deleted stats and use a saved copy for showing the message box.

Fixes #1239.