### PR TITLE
STEP export: fix broken export - `ORIENTED_EDGE`s are properly oriented.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Constraints (new and improved):
 
 * Add Parallel and Perpendicular constraints for 2 faces.
 * The equal angle constraint is moved to the `N` shortcut and menu item to allow equal length (`Q`) to be applied to three or four lines.
+* Allow tangent on arcs/lines/splines without coincident endpoints.
 
 Allow these constraints to be applied to more entities at once:
 
@@ -54,6 +55,9 @@ Other User interface changes:
 	* improved "є"
 	* added superscript 5 "⁵"
 	* fiexd crash when typing "£"
+* The the animation speed when changing the 3D view is configurable.
+* Add an 'only unconstrained' option on the Property Browser home screen that shows only unconstrained groups.
+
 
 Other
 
@@ -61,11 +65,17 @@ Other
 * Better Flatpack support.
 * Several bug fixes and usability improvements.
 * Allow 32 bit SolveSpace to access up to 4GB of RAM to allow working on larger projects.
+* STEP Export now exports solid bodies.
 
 Bug fixes:
 
 * `Paste Transformed` on elements that contain a point-line distance does not flip any more.
 * Fix saving assemblies when opened with a relative path on the command line.
+* Windows: The Property Browser remains visible when going full screen (CTRL-F11).
+* Fix crash when linking .STL and .EMN files with extensions in capital letters.
+* Mac: Don't crash on file ops without changing dir.
+* Fix incorrect arc handling when linking IDF files.
+* Windows: avoid (sometimes) showing multiple messages when deleting an entity causes other entities to be removed.
 
 3.1
 ---

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -302,7 +302,8 @@ public:
 
 class StepFileWriter {
 public:
-    bool HasCartesianPointAnAlias(int number, Vector v, int vertex);
+    bool HasCartesianPointAnAlias(int number, Vector v, int vertex,
+                                  bool *vertex_has_alias = nullptr);
     int InsertPoint(int number);
     int InsertVertex(int number);
     bool HasBSplineCurveAnAlias(int number, std::vector<int> points);

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -308,7 +308,10 @@ public:
     int InsertVertex(int number);
     bool HasBSplineCurveAnAlias(int number, std::vector<int> points);
     int InsertCurve(int number);
-    bool HasEdgeAnAlias(int number, int prevFinish, int thisFinish, int curveId);
+    bool HasEdgeCurveAnAlias(int number, int prevFinish, int thisFinish, int curveId,
+                        bool *flip = nullptr);
+    int InsertEdgeCurve(int number);
+    bool HasOrientedEdgeAnAlias(int number, int edgeCurveId, bool flip);
     int InsertOrientedEdge(int number);
     void ExportSurfacesTo(const Platform::Path &filename);
     void WriteHeader();
@@ -352,11 +355,19 @@ public:
         int thisFinish;
         int curveId;
         RgbaColor color;
-    } edgeAliases_t;
+    } edgeCurveAliases_t;
+
+    // Edges.
+    typedef struct {
+        alias_t alias;
+        int edgeCurveId;
+        bool flip;
+    } orientedEdgeAliases_t;
 
     std::vector<pointAliases_t> pointAliases;
-    std::vector<edgeAliases_t> edgeAliases;
+    std::vector<edgeCurveAliases_t> edgeCurveAliases;
     std::vector<curveAliases_t> curveAliases;
+    std::vector<orientedEdgeAliases_t> orientedEdgeAliases;
     bool exportParts = true;
     RgbaColor currentColor;
 };


### PR DESCRIPTION
After bb6cc1a0..d1b52cd6 in the exported STEP files "half" of the
`ORIENTED_EDGE`s were in the wrong direction. This caused some tools (e.g.
Kisters 3DViewStation) to render them incorrectly (this is understandable).

Fixed by flipping edges when required, keeping an `orientedEdgeAliases`,
list and reusing them.