### PR TITLE
Win32: Make SolveSpace grea...static again

### DIFF
--- a/cmake/c_flag_overrides.cmake
+++ b/cmake/c_flag_overrides.cmake
@@ -3,6 +3,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS_MINSIZEREL_INIT     "/MT /O1 /Ob1 /D NDEBUG")
     set(CMAKE_C_FLAGS_RELEASE_INIT        "/MT /O2 /Ob2 /D NDEBUG")
     set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "/MT /Zi /O2 /Ob1 /D NDEBUG")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 if(EMSCRIPTEN)


### PR DESCRIPTION
For some reason the [/MT options in the `CMAKE_C_FLAGS_RELEASE_INIT`](https://github.com/solvespace/solvespace/blob/0df1ba74089b41316630270c1a44070672ab1966/cmake/c_flag_overrides.cmake#L4) etc. CMake targets stopped working at some point and SolveSpace became linked to the DLL versions of the C/C++ runtime (MSVCP140.DLL, VCRUNTIME140.DLL).

We do not like this. Therefore:

Use the proper "modern" CMake incantation to make SolveSpace static again ;-)
https://cmake.org/cmake/help/latest/prop_tgt/MSVC_RUNTIME_LIBRARY.html

The OpenMP build still depends on VCOMP140.DLL but this seems unavoidable.
https://stackoverflow.com/questions/37037733/statically-link-with-microsoft-crt-and-openmp
https://github.com/godotengine/godot/issues/14935

![image](https://github.com/user-attachments/assets/fa7947a8-2435-486c-9c5b-74f9855b9c77)
