### PR TITLE
CI, Win32: Add x64 (64bit) binaries for Windows

### DIFF
--- a/.github/scripts/build-windows.sh
+++ b/.github/scripts/build-windows.sh
@@ -9,13 +9,20 @@ if [ "$1" = "release" ]; then
     else
         ENABLE_OPENMP="OFF"
     fi
+
+    if [ "$3" = "x64" ]; then
+        PLATFORM="$3"
+    else
+        PLATFORM="Win32"
+    fi
+
     BUILD_TYPE=RelWithDebInfo
     cmake \
         -G "Visual Studio 17 2022" \
         -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
         -DENABLE_OPENMP="${ENABLE_OPENMP}" \
         -DENABLE_LTO=ON \
-        -DCMAKE_GENERATOR_PLATFORM="Win32" \
+        -DCMAKE_GENERATOR_PLATFORM="${PLATFORM}" \
         ..
 else
     BUILD_TYPE=Debug
@@ -31,6 +38,14 @@ cmake --build . --config "${BUILD_TYPE}" -- -maxcpucount
 
 bin/$BUILD_TYPE/solvespace-testsuite.exe
 
-if [ "$2" = "openmp" ]; then
-    mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace-openmp.exe
+if [ "$3" = "x64" ]; then
+	if [ "$2" != "openmp" ]; then
+		mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_single_core_x64.exe
+	else
+		mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_x64.exe
+	fi
+else
+	if [ "$2" != "openmp" ]; then
+		mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_single_core.exe
+	fi
 fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows
-          path: build/bin/RelWithDebInfo/solvespace.exe
+          name: windows_single_core
+          path: build/bin/RelWithDebInfo/solvespace_single_core.exe
 
   build_release_windows_openmp:
     needs: [test_ubuntu, test_windows, test_macos]
@@ -87,8 +87,44 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-openmp
-          path: build/bin/RelWithDebInfo/solvespace-openmp.exe
+          name: windows
+          path: build/bin/RelWithDebInfo/solvespace.exe
+
+  build_release_windows_x64:
+    needs: [test_ubuntu, test_windows, test_macos]
+    name: Build Release Windows x64
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: .github/scripts/install-windows.sh
+        shell: bash
+      - name: Build & Test
+        run: .github/scripts/build-windows.sh release not_openmp x64
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows_single_core_x64
+          path: build/bin/RelWithDebInfo/solvespace_single_core_x64.exe
+
+  build_release_windows_openmp_x64:
+    needs: [test_ubuntu, test_windows, test_macos]
+    name: Build Release Windows (OpenMP) x64
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: .github/scripts/install-windows.sh
+        shell: bash
+      - name: Build & Test
+        run: .github/scripts/build-windows.sh release openmp x64
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows_x64
+          path: build/bin/RelWithDebInfo/solvespace_x64.exe
 
   build_release_macos:
     needs: [test_ubuntu, test_windows, test_macos]
@@ -147,7 +183,7 @@ jobs:
 
   upload_release_assets:
     name: Upload Release Assets
-    needs: [build_release_windows, build_release_windows_openmp, build_release_macos]
+    needs: [build_release_windows, build_release_windows_openmp, build_release_windows_x64, build_release_windows_openmp_x64, build_release_macos]
     if: "!cancelled() && github.event_name == 'release'"
     runs-on: ubuntu-latest
     steps:
@@ -171,15 +207,35 @@ jobs:
         asset_path: windows/solvespace.exe
         asset_name: solvespace.exe
         asset_content_type: binary/octet-stream
-    - name: Upload solvespace-openmp.exe
+    - name: Upload solvespace_single_core.exe
       uses: actions/upload-release-asset@v1
       continue-on-error: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
-        asset_path: windows-openmp/solvespace-openmp.exe
-        asset_name: solvespace-openmp.exe
+        asset_path: windows-openmp/solvespace_single_core.exe
+        asset_name: solvespace_single_core.exe
+        asset_content_type: binary/octet-stream
+    - name: Upload solvespace_x64.exe
+      uses: actions/upload-release-asset@v1
+      continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+        asset_path: windows/solvespace_x64.exe
+        asset_name: solvespace_x64.exe
+        asset_content_type: binary/octet-stream
+    - name: Upload solvespace_single_core_x64.exe
+      uses: actions/upload-release-asset@v1
+      continue-on-error: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
+        asset_path: windows-openmp/solvespace_single_core_x64.exe
+        asset_name: solvespace_single_core_x64.exe
         asset_content_type: binary/octet-stream
     - name: Upload SolveSpace.dmg
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
By popular demand the CI now builds 64bit binaries for Windows. This allows SolveSpace to open large models (by accessing >4GB RAM).

At the same time rename the default versions lie this:

bit/thread  | x86 (32bit) | x64 (64bit)
------ | ----- | ------
Single thread | solvespace_single_core.exe | solvespace_single_core_x64.exe
Multi thread | solvespace.exe | solvespace_x64.exe

Fixes #1261

![image](https://github.com/user-attachments/assets/5daf5842-4e8f-4054-a606-a167b9e72261)
