### PR TITLE
build: fix building with OpenMP on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(ENABLE_OPENMP)
     find_package( OpenMP REQUIRED )
     if(OPENMP_FOUND)
         add_library(slvs_openmp INTERFACE)
-        target_compile_options(slvs_openmp INTERFACE ${OpenMP_CXX_FLAGS})
+        target_compile_options(slvs_openmp INTERFACE "SHELL:${OpenMP_CXX_FLAGS}")
         target_link_libraries(slvs_openmp INTERFACE
             ${OpenMP_CXX_LIBRARIES})
         target_include_directories(slvs_openmp SYSTEM INTERFACE


### PR DESCRIPTION
Something changed in the way compiler flags are passed by CMake to the compiler, which caused the OpenMP flags to be passed as a single flag and resulting in a build failure.

Use CMake's `SHELL:` syntax to tell CMake to pass these as separate flags, but without reordering them or performing deduplication.