### PR TITLE
WIP Named Parameters

### DIFF
--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -244,6 +244,7 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
         c.reference = cc->reference;
         c.disp = cc->disp;
         c.comment = cc->comment;
+        c.expression = cc->expression;
         bool dontAddConstraint = false;
         switch(c.type) {
             case Constraint::Type::COMMENT:

--- a/src/clipboard.cpp
+++ b/src/clipboard.cpp
@@ -244,7 +244,6 @@ void GraphicsWindow::PasteClipboard(Vector trans, double theta, double scale) {
         c.reference = cc->reference;
         c.disp = cc->disp;
         c.comment = cc->comment;
-        c.expression = cc->expression;
         bool dontAddConstraint = false;
         switch(c.type) {
             case Constraint::Type::COMMENT:

--- a/src/constrainteq.cpp
+++ b/src/constrainteq.cpp
@@ -269,23 +269,28 @@ void ConstraintBase::Generate(ParamList *l) {
 }
 
 void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
-                                       bool forReference) const {
-    Expr *exA = {};
-    
+                                       bool forReference) const {    
     if(reference && !forReference) {
         return;
-    } else {
-        if(expression != "") {
-//            exA = Expr::From(expression.c_str(), false, &SK.param, NULL);
-            exA = Expr::From(expression.c_str(), false);
-        } else {
-            exA = Expr::From(valA);
-        }
     }
- 
+
+    Expr *exA = {};
+    Expr *exLen = {};
+    
+    // a numeric dimension is stored in valA. When a complex expression is used
+    // it is stored in the comment string and the unit scaled version  is in exLen
+    if(comment != "") {
+//            exA = Expr::From(comment.c_str(), false, &SK.param, NULL);
+        exA = Expr::From(comment.c_str(), false);
+        exLen = exA->Times(Expr::From(valA));
+    } else {
+        exA = Expr::From(valA);
+        exLen = Expr::From(valA);
+    }
+    
     switch(type) {
         case Type::PT_PT_DISTANCE:
-            AddEq(l, Distance(workplane, ptA, ptB)->Minus(exA), 0);
+            AddEq(l, Distance(workplane, ptA, ptB)->Minus(exLen), 0);
             return;
 
         case Type::PROJ_PT_DISTANCE: {
@@ -296,18 +301,18 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
             ExprVector pp = SK.GetEntity(entityA)->VectorGetExprs();
             pp = pp.WithMagnitude(Expr::From(1.0));
 
-            AddEq(l, (dp.Dot(pp))->Minus(exA), 0);
+            AddEq(l, (dp.Dot(pp))->Minus(exLen), 0);
             return;
         }
 
         case Type::PT_LINE_DISTANCE:
             AddEq(l,
-                PointLineDistance(workplane, ptA, entityA)->Minus(exA), 0);
+                PointLineDistance(workplane, ptA, entityA)->Minus(exLen), 0);
             return;
 
         case Type::PT_PLANE_DISTANCE: {
             ExprVector pt = SK.GetEntity(ptA)->PointGetExprs();
-            AddEq(l, (PointPlaneDistance(pt, entityA))->Minus(exA), 0);
+            AddEq(l, (PointPlaneDistance(pt, entityA))->Minus(exLen), 0);
             return;
         }
 
@@ -316,7 +321,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
             EntityBase *f = SK.GetEntity(entityA);
             ExprVector p0 = f->FaceGetPointExprs();
             ExprVector n = f->FaceGetNormalExprs();
-            AddEq(l, (pt.Minus(p0)).Dot(n)->Minus(exA), 0);
+            AddEq(l, (pt.Minus(p0)).Dot(n)->Minus(exLen), 0);
             return;
         }
 
@@ -462,7 +467,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
             EntityBase *b = SK.GetEntity(entityB);
             Expr *la = Distance(workplane, a->point[0], a->point[1]);
             Expr *lb = Distance(workplane, b->point[0], b->point[1]);
-            AddEq(l, (la->Minus(lb))->Minus(exA), 0);
+            AddEq(l, (la->Minus(lb))->Minus(exLen), 0);
             return;
         }
         
@@ -528,7 +533,7 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
                 theta2 = (Expr::From(2*PI))->Minus(costheta2->ACos());
             }
             // And write the equation; (r1*theta1) - ( r2*theta2) = some difference
-            AddEq(l, (r1->Times(theta1))->Minus(r2->Times(theta2))->Minus(exA), 0);
+            AddEq(l, (r1->Times(theta1))->Minus(r2->Times(theta2))->Minus(exLen), 0);
             return;
         }
         
@@ -566,14 +571,14 @@ void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
                 theta1 = (Expr::From(2*PI))->Minus(costheta1->ACos());
             }
             // And write the equation; (r1*theta1) - ( length) = some difference
-            AddEq(l, (r1->Times(theta1))->Minus(ll)->Minus(exA), 0);
+            AddEq(l, (r1->Times(theta1))->Minus(ll)->Minus(exLen), 0);
             return;
         }
         
         case Type::DIAMETER: {
             EntityBase *circle = SK.GetEntity(entityA);
             Expr *r = circle->CircleGetRadiusExpr();
-            AddEq(l, (r->Times(Expr::From(2)))->Minus(exA), 0);
+            AddEq(l, (r->Times(Expr::From(2)))->Minus(exLen), 0);
             return;
         }
 

--- a/src/constrainteq.cpp
+++ b/src/constrainteq.cpp
@@ -270,9 +270,19 @@ void ConstraintBase::Generate(ParamList *l) {
 
 void ConstraintBase::GenerateEquations(IdList<Equation,hEquation> *l,
                                        bool forReference) const {
-    if(reference && !forReference) return;
-
-    Expr *exA = Expr::From(valA);
+    Expr *exA = {};
+    
+    if(reference && !forReference) {
+        return;
+    } else {
+        if(expression != "") {
+//            exA = Expr::From(expression.c_str(), false, &SK.param, NULL);
+            exA = Expr::From(expression.c_str(), false);
+        } else {
+            exA = Expr::From(valA);
+        }
+    }
+ 
     switch(type) {
         case Type::PT_PT_DISTANCE:
             AddEq(l, Distance(workplane, ptA, ptB)->Minus(exA), 0);

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -11,7 +11,11 @@
 std::string Constraint::Label() const {
     std::string result;
     if(type == Type::ANGLE) {
-        result = SS.DegreeToString(valA) + "°";
+        if(comment != "") {
+            result = comment;
+        } else {
+            result = SS.DegreeToString(valA) + "°";
+        }
     } else if(type == Type::LENGTH_RATIO || type == Type::ARC_ARC_LEN_RATIO || type == Type::ARC_LINE_LEN_RATIO) {
         result = ssprintf("%.3f:1", valA);
     } else if(type == Type::COMMENT) {
@@ -31,9 +35,6 @@ std::string Constraint::Label() const {
           // valA has units of distance
           result = SS.MmToStringSI(fabs(valA));
         }
-    }
-    if(expression != "") {
-        result = expression;
     }
     if(reference) {
         result += " REF";

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -32,6 +32,9 @@ std::string Constraint::Label() const {
           result = SS.MmToStringSI(fabs(valA));
         }
     }
+    if(expression != "") {
+        result = expression;
+    }
     if(reference) {
         result += " REF";
     }

--- a/src/drawconstraint.cpp
+++ b/src/drawconstraint.cpp
@@ -17,14 +17,20 @@ std::string Constraint::Label() const {
     } else if(type == Type::COMMENT) {
         result = comment;
     } else if(type == Type::DIAMETER) {
-        if(!other) {
+        if(comment != "") {
+          result = comment;
+        } else if(!other) {
             result = "⌀" + SS.MmToStringSI(valA);
         } else {
             result = "R" + SS.MmToStringSI(valA / 2);
         }
     } else {
-        // valA has units of distance
-        result = SS.MmToStringSI(fabs(valA));
+        if(comment != "") {
+            result = comment;
+        } else {
+          // valA has units of distance
+          result = SS.MmToStringSI(fabs(valA));
+        }
     }
     if(reference) {
         result += " REF";

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 #include <limits>
 #include "solvespace.h"
+#include "sketch.h"
 
 ExprVector ExprVector::From(Expr *x, Expr *y, Expr *z) {
     ExprVector r = { x, y, z};
@@ -756,8 +757,23 @@ ExprParser::Token ExprParser::Lex(std::string *error) {
         } else if(s == "pi") {
             t = Token::From(TokenType::OPERAND, Expr::Op::CONSTANT);
             t.expr->v = PI;
-        } else {
-            *error = "'" + s + "' is not a valid variable, function or constant";
+// New stuff
+//        } else if(params != NULL) {
+        } else { // check all the named parameters
+            bool found = false;
+            for(const Request &r : SK.request ) {
+                if (r.type != Request::Type::NAMED_PARAMETER) continue;
+                if(r.str != s) continue;
+                t = Token::From(TokenType::OPERAND, Expr::Op::PARAM);
+                hParam hp = r.h.param(64);
+                t.expr->parh = hp;
+                found = true;
+            }
+            if(!found)
+            {
+              *error = "'" + s + "' is not a valid variable, function or constant";
+            }
+// End new stuff
         }
     } else if(isdigit(c) || c == '.') {
         return LexNumber(error);

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -644,6 +644,9 @@ public:
     std::string::const_iterator it, end;
     std::vector<Token> stack;
 
+    int *varCnt;
+    std::unordered_map<std::string, hParam> *vars;
+    
     char ReadChar();
     char PeekChar();
 
@@ -655,11 +658,12 @@ public:
 
     int Precedence(Token token);
     Token LexNumber(std::string *error);
+//    Token Lex(std::string *error);
     Token Lex(std::string *error);
     bool Reduce(std::string *error);
     bool Parse(std::string *error, size_t reduceUntil = 0);
-
-    static Expr *Parse(const std::string &input, std::string *error);
+    static Expr* Parse(const std::string &input, std::string *error, int *cntNames = 0,
+                                  std::unordered_map<std::string, hParam> *paramNames = NULL);
 };
 
 ExprParser::Token ExprParser::Token::From(TokenType type, Expr *expr) {
@@ -757,41 +761,21 @@ ExprParser::Token ExprParser::Lex(std::string *error) {
         } else if(s == "pi") {
             t = Token::From(TokenType::OPERAND, Expr::Op::CONSTANT);
             t.expr->v = PI;
-// New stuff
-//        } else if(params != NULL) {
-        } else { // check all the named parameters
-            // Create a map of parameter names with handles
-            std::unordered_map<std::string, hParam> vars = {};        
-            for(const Request &r : SK.request ) {
-                if (r.type != Request::Type::NAMED_PARAMETER) continue;
-                // TODO: need to check if group is less or equal to this group
-                vars[r.str] = r.h.param(64);
-            }
-            
+        } else { // check the named parameters
             bool found = false;
-            
-            if(vars.find(s) != vars.end()) {
-                t = Token::From(TokenType::OPERAND, Expr::Op::PARAM);
-                hParam hp = vars[s];
-                t.expr->parh = hp;
-                found = true;
+            if(vars) {
+                if(vars->find(s) != vars->end()) {
+                    t = Token::From(TokenType::OPERAND, Expr::Op::PARAM);
+                    hParam hp = (*vars)[s];
+                    t.expr->parh = hp;
+                    found = true;
+                    if(varCnt) *varCnt += 1;
+                }
             }
-            
-/*
-            for(const Request &r : SK.request ) {
-                if (r.type != Request::Type::NAMED_PARAMETER) continue;
-                if(r.str != s) continue;
-                t = Token::From(TokenType::OPERAND, Expr::Op::PARAM);
-                hParam hp = r.h.param(64);
-                t.expr->parh = hp;
-                found = true;
-            }
-*/
             if(!found)
             {
               *error = "'" + s + "' is not a valid variable, function or constant";
             }
-// End new stuff
         }
     } else if(isdigit(c) || c == '.') {
         return LexNumber(error);
@@ -961,8 +945,13 @@ bool ExprParser::Parse(std::string *error, size_t reduceUntil) {
     return true;
 }
 
-Expr *ExprParser::Parse(const std::string &input, std::string *error) {
+Expr* ExprParser::Parse(const std::string &input, std::string *error, int *cntNames,
+                                  std::unordered_map<std::string, hParam> *paramNames) {
+
     ExprParser parser;
+    parser.vars = paramNames;
+    parser.varCnt = cntNames;
+    
     parser.it  = input.cbegin();
     parser.end = input.cend();
     if(!parser.Parse(error)) return NULL;
@@ -972,13 +961,25 @@ Expr *ExprParser::Parse(const std::string &input, std::string *error) {
     return r.expr;
 }
 
-Expr *Expr::Parse(const std::string &input, std::string *error) {
+Expr* Expr::Parse(const std::string &input, std::string *error) {    
     return ExprParser::Parse(input, error);
 }
 
 Expr *Expr::From(const std::string &input, bool popUpError) {
+//Expr* Expr::From(const std::string &input, bool popUpError, int* paramCount,
+//                    std::unordered_map<std::string, hParam> *paramNames) {
+    // Create a map of parameter names with handles
+    std::unordered_map<std::string, hParam> vars = {};        
+    for(const Request &r : SK.request ) {
+        if (r.type != Request::Type::NAMED_PARAMETER) continue;
+        // TODO: need to check if group is less or equal to this group
+        vars[r.str] = r.h.param(64);
+    }
+    int paramCount;
+
     std::string error;
-    Expr *e = ExprParser::Parse(input, &error);
+    Expr *e = ExprParser::Parse(input, &error, &paramCount, &vars);
+//    Expr *e = ExprParser::Parse(input, &error, paramCount, &paramNames);
     if(!e) {
         dbp("Parse/lex error: %s", error.c_str());
         if(popUpError) {

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -760,7 +760,24 @@ ExprParser::Token ExprParser::Lex(std::string *error) {
 // New stuff
 //        } else if(params != NULL) {
         } else { // check all the named parameters
+            // Create a map of parameter names with handles
+            std::unordered_map<std::string, hParam> vars = {};        
+            for(const Request &r : SK.request ) {
+                if (r.type != Request::Type::NAMED_PARAMETER) continue;
+                // TODO: need to check if group is less or equal to this group
+                vars[r.str] = r.h.param(64);
+            }
+            
             bool found = false;
+            
+            if(vars.find(s) != vars.end()) {
+                t = Token::From(TokenType::OPERAND, Expr::Op::PARAM);
+                hParam hp = vars[s];
+                t.expr->parh = hp;
+                found = true;
+            }
+            
+/*
             for(const Request &r : SK.request ) {
                 if (r.type != Request::Type::NAMED_PARAMETER) continue;
                 if(r.str != s) continue;
@@ -769,6 +786,7 @@ ExprParser::Token ExprParser::Lex(std::string *error) {
                 t.expr->parh = hp;
                 found = true;
             }
+*/
             if(!found)
             {
               *error = "'" + s + "' is not a valid variable, function or constant";

--- a/src/expr.h
+++ b/src/expr.h
@@ -100,8 +100,10 @@ public:
                                        IdList<Param,hParam> *thenTry,
                                        bool foldConstants = false) const;
 
-    static Expr *Parse(const std::string &input, std::string *error);
-    static Expr *From(const std::string &input, bool popUpError);
+    static Expr* Parse(const std::string &input, std::string *error);
+    static Expr* From(const std::string &input, bool popUpError);
+//    static Expr* Expr::From(const std::string &input, bool popUpError, int* paramCount = 0,
+//                    std::unordered_map<std::string, hParam> *paramNames = NULL);
 };
 
 class ExprVector {

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1438,7 +1438,7 @@ void GraphicsWindow::EditControlDone(const std::string &s) {
     Expr *e = Expr::From(s, true);
     if(e) {
         SS.UndoRemember();
-        c->expression = s;
+        c->comment = s;
         
         switch(c->type) {
             case Constraint::Type::PROJ_PT_DISTANCE:

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1431,9 +1431,15 @@ void GraphicsWindow::EditControlDone(const std::string &s) {
         return;
     }
 
-    if(Expr *e = Expr::From(s, true)) {
+//    if(Expr *e = Expr::From(s, true)) {
+// the EvilSpirit version checked for nonzero used parameters
+//    int usedParams;
+//    Expr *e = Expr::From(s, true, &SK.param, &usedParams);
+    Expr *e = Expr::From(s, true);
+    if(e) {
         SS.UndoRemember();
-
+        c->expression = s;
+        
         switch(c->type) {
             case Constraint::Type::PROJ_PT_DISTANCE:
             case Constraint::Type::PT_LINE_DISTANCE:

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -31,6 +31,7 @@ static const EntReqMapping EntReqMap[] = {
 { Request::Type::ARC_OF_CIRCLE,   Entity::Type::ARC_OF_CIRCLE,  3,  false,  true,   false },
 { Request::Type::TTF_TEXT,        Entity::Type::TTF_TEXT,       4,  false,  true,   false },
 { Request::Type::IMAGE,           Entity::Type::IMAGE,          4,  false,  true,   false },
+{ Request::Type::NAMED_PARAMETER, (Entity::Type)0,              0,  false,  false,  false },
 };
 
 static void CopyEntityInfo(const EntReqMapping *te, int extraPoints,
@@ -115,6 +116,9 @@ void Request::Generate(EntityList *entity, ParamList *param)
                 aspectRatio = 1.0;
             }
             break;
+        }
+        case Type::NAMED_PARAMETER: {
+          AddParam(param, h.param(64));
         }
 
         default: // most requests don't do anything else
@@ -220,6 +224,7 @@ std::string Request::DescriptionString() const {
             case Type::ARC_OF_CIRCLE:   s = "arc-of-circle";  break;
             case Type::TTF_TEXT:        s = "ttf-text";       break;
             case Type::IMAGE:           s = "image";          break;
+            case Type::NAMED_PARAMETER: s = "parameter";      break;
         }
     }
     ssassert(s != NULL, "Unexpected request type");

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -710,7 +710,8 @@ public:
 
     bool        reference;  // a ref dimension, that generates no eqs
     std::string comment;    // since comments are represented as constraints
-
+    std::string expression;
+    
     bool Equals(const ConstraintBase &c) const {
         return type == c.type && group == c.group && workplane == c.workplane &&
             valA == c.valA && valP == c.valP && ptA == c.ptA && ptB == c.ptB &&

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -360,7 +360,8 @@ public:
         CIRCLE                 = 400,
         ARC_OF_CIRCLE          = 500,
         TTF_TEXT               = 600,
-        IMAGE                  = 700
+        IMAGE                  = 700,
+        NAMED_PARAMETER        = 800
     };
 
     Request::Type type;

--- a/src/sketch.h
+++ b/src/sketch.h
@@ -710,7 +710,7 @@ public:
 
     bool        reference;  // a ref dimension, that generates no eqs
     std::string comment;    // since comments are represented as constraints
-    std::string expression;
+//    std::string expression;
     
     bool Equals(const ConstraintBase &c) const {
         return type == c.type && group == c.group && workplane == c.workplane &&

--- a/src/textscreens.cpp
+++ b/src/textscreens.cpp
@@ -223,7 +223,19 @@ void TextWindow::ScreenSelectConstraint(int link, uint32_t v) {
     sel.constraint.v = v;
     SS.GW.selection.Add(&sel);
 }
-
+void TextWindow::AddNamedParameter(int link, uint32_t v) {
+    hGroup hg = { v };
+    SS.UndoRemember();
+    Request r = {};
+    r.group = hg;
+    r.type = Request::Type::NAMED_PARAMETER;
+    r.str = "Edit_Name";
+    SK.request.AddAndAssignId(&r);
+    r.Generate(&SK.entity, &SK.param);
+    hParam hp = r.h.param(64);
+    SK.GetParam(hp)->val = 123;
+    SS.MarkGroupDirty(r.group);
+}
 void TextWindow::ScreenChangeGroupOption(int link, uint32_t v) {
     SS.UndoRemember();
     Group *g = SK.GetGroup(SS.TW.shown.group);
@@ -355,6 +367,29 @@ void TextWindow::ScreenChangePitchOption(int link, uint32_t v) {
     }
     SS.GW.Invalidate();
 }
+void TextWindow::ScreenEditParamName(int link, uint32_t v) {
+    hRequest hr = { v };
+    Request *r = SK.request.FindByIdNoOops(hr);
+    SS.TW.ShowEditControl(3, r->str);
+    SS.TW.edit.meaning = Edit::PARAMETER_NAME;
+    SS.TW.edit.request = hr;
+}
+void TextWindow::ScreenChangeParamValue(int link, uint32_t v) {
+    Group *g = SK.GetGroup(SS.TW.shown.group);
+    hParam p = { v };
+    double value = SK.GetParam(p)->val;
+    SS.TW.ShowEditControl(3, ssprintf("%.8f", value));
+    SS.TW.edit.meaning = Edit::PARAMETER_VALUE;
+    SS.TW.edit.group.v = g->h.v;
+    SS.TW.edit.parameter = p;  
+}
+void TextWindow::ScreenDeleteParameter(int link, uint32_t v) {
+    hRequest hr = { v };
+    Request *r = SK.request.FindByIdNoOops(hr);
+    hParam p = r->h.param(64);
+    SK.param.RemoveById(p);
+    SK.request.RemoveById(hr);
+}
 void TextWindow::ScreenDeleteGroup(int link, uint32_t v) {
     SS.UndoRemember();
 
@@ -375,6 +410,7 @@ void TextWindow::ScreenDeleteGroup(int link, uint32_t v) {
     // group if it was removed.
     SS.GW.ClearSuper();
 }
+
 void TextWindow::ShowGroupInfo() {
     Group *g = SK.GetGroup(shown.group);
     const char *s = "???";
@@ -577,14 +613,42 @@ void TextWindow::ShowGroupInfo() {
         Printf(false, "'force NURBS surfaces to triangle mesh'.");
     }
 
+
 list_items:
+    Printf(false, "");
+    Printf(false, "%Ft parameters in group  %E [%Fl%Ll%D%fadd%E]",
+        g->h.v, &TextWindow::AddNamedParameter);
+    
+    int a = 0;
+    for(auto &r : SK.request) {
+        // filter on request type for parameters
+        if(r.group == shown.group && r.type == Request::Type::NAMED_PARAMETER) {
+            // get the name of our parameter request
+            std::string s = r.str;
+            // we need a handle to the parameter to get its value
+            hParam hp = r.h.param(64);
+            double value = SK.GetParam(hp)->val;
+            Printf(false,
+            "%Bp   %Fl%Ll%D%f%s%E %# %E [%Fl%Ll%f%Dchange%E] [%Fl%Ll%D%fdel%E] ",
+                   (a & 1) ? 'd' : 'a',
+                   r.h.v,
+                   &(TextWindow::ScreenEditParamName),
+                   s.c_str(),
+                   value,
+                   &(TextWindow::ScreenChangeParamValue), hp,
+                   r.h.v, &(TextWindow::ScreenDeleteParameter) );
+            a++;
+        }
+    }
+    if(a == 0) Printf(false, "%Ba   (none)");
+
     Printf(false, "");
     Printf(false, "%Ft requests in group");
 
-    int a = 0;
+    a = 0;
     for(auto &r : SK.request) {
 
-        if(r.group == shown.group) {
+        if(r.group == shown.group && r.type != Request::Type::NAMED_PARAMETER) {
             std::string s = r.DescriptionString();
             Printf(false, "%Bp   %Fl%Ll%D%f%h%s%E",
                    (a & 1) ? 'd' : 'a',
@@ -893,6 +957,27 @@ void TextWindow::EditControlDone(std::string s) {
                 double ev = e->Eval();
                 Group *g = SK.GetGroup(edit.group);
                 g->valB = ev * SS.MmPerUnit();
+                SS.MarkGroupDirty(g->h);
+            }
+            break;
+
+        case Edit::PARAMETER_NAME:
+            if(s.empty()) {
+                Error(_("Parameter name cannot be empty"));
+            } else {
+                SS.UndoRemember();
+                if(Request *r = SK.request.FindByIdNoOops(edit.request)) {
+                    r->str = s;
+                    SS.MarkGroupDirty(r->group);
+                }
+            }
+            break;
+
+        case Edit::PARAMETER_VALUE:  // by handle (passed in group handle...)
+            if(Expr *e = Expr::From(s, /*popUpError=*/true)) {
+                double ev = e->Eval();
+                Group *g = SK.GetGroup(edit.group);
+                SK.GetParam(edit.parameter)->val = ev;
                 SS.MarkGroupDirty(g->h);
             }
             break;

--- a/src/ui.h
+++ b/src/ui.h
@@ -350,13 +350,16 @@ public:
         // For tangent arc
         TANGENT_ARC_RADIUS    = 800,
         // For helix pitch
-        HELIX_PITCH           = 802
+        HELIX_PITCH           = 802,
+        PARAMETER_VALUE       = 810,
+        PARAMETER_NAME        = 812
     };
     struct {
         bool        showAgain;
         Edit        meaning;
         int         i;
         hGroup      group;
+        hParam      parameter;
         hRequest    request;
         hStyle      style;
     } edit;
@@ -426,7 +429,12 @@ public:
     static void ScreenSelectRequest(int link, uint32_t v);
     static void ScreenSelectEntity(int link, uint32_t v);
     static void ScreenSelectConstraint(int link, uint32_t v);
-
+    
+    static void AddNamedParameter(int link, uint32_t v);
+    static void ScreenEditParamName(int link, uint32_t v);
+    static void ScreenChangeParamValue(int link, uint32_t v);
+    static void ScreenDeleteParameter(int link, uint32_t v);
+    
     static void ScreenChangeGroupOption(int link, uint32_t v);
     static void ScreenColor(int link, uint32_t v);
     static void ScreenOpacity(int link, uint32_t v);


### PR DESCRIPTION
HELP WANTED - C++ Language Lawyer please.

This is my latest attempt to integrate named parameters. The first commits adds the text window stuff for creating requests for named parameters. These are unitless free parameters, though their value can be changed in the text window. They can be used in constraint expressions on the sketch.

I've partly implemented a way to handle units. It's a little stupid, and currently broken. I can fix that but...

My current roadblock is way down in Expr::From() the last function in expr.cpp where we create an expression from a string. I've temporarily added code in there to create a list of name/parameter-handle pairs. This is then passed into the ExprParser::Parse function, which assigns them to member variable of the parse so we don't have to keep passing optional parameters all around the parser functions.

The problem is that I need to use the new, commented-out function header to allow these two new variables to be optionally passed in. If they're left off it should behave as before. The idea is to create the parameter dictionary at an even higher level (group level) to enforce proper scope rules. I also need to know in GraphicsWindow::EditControlDone() the number of named parameters that were used in the expression (really just if that's non-zero). That will determine how the expression is stored and is critical to getting units handled correctly.

Anyway, when I used the commented out function header in Expr.cpp and also in Expr.h, I get build errors. More specifically when building the library, which I have little familiarity with.

A bit of help here and I can get the concept done so we can decide if it's good.

How do I get things to build with those two optional parameters in the last function in expr.cpp?