### PR TITLE
add missing else statement in Slvs_MarkDragged_check

### DIFF
--- a/src/slvs/lib.cpp
+++ b/src/slvs/lib.cpp
@@ -845,8 +845,9 @@ void Slvs_MarkDragged(Slvs_Entity ptA) {
             hParam p = hParam { ptA.param[i] };
             dragged.insert(p);
         }
+    } else {
+        SolveSpace::Platform::FatalError("Invalid entity for marking dragged");
     }
-    SolveSpace::Platform::FatalError("Invalid entity for marking dragged");
 }
 
 Slvs_SolveResult Slvs_SolveSketch(uint32_t shg, Slvs_hConstraint **bad = nullptr)


### PR DESCRIPTION
I notice in the Slvs_MarkDragged_check function, the FatalError function will be called at the end in any case. It is obvious incorrect, because it means once you call this method, the program will quit right now.I add the missing else statement, and only quit when parameter type is incorrect.