### PR TITLE
ci: use the Sequoia bottle tag for the macOS x86_64 build as well

### DIFF
--- a/.github/scripts/install-macos.sh
+++ b/.github/scripts/install-macos.sh
@@ -2,7 +2,7 @@
 
 if [ "$1" = "ci" ]; then
     armloc=$(brew fetch --bottle-tag=arm64_sequoia libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
-    x64loc=$(brew fetch --bottle-tag=sonoma libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
+    x64loc=$(brew fetch --bottle-tag=sequoia libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
     cp $armloc /tmp/libomp-arm64.tar.gz
     mkdir /tmp/libomp-arm64 || true
     tar -xzvf /tmp/libomp-arm64.tar.gz -C /tmp/libomp-arm64


### PR DESCRIPTION
Even though an OpenMP bottle is only available for Sonoma on x86_64, it just pulls that when a Sequoia bottle tag is specified, so this should make things more consistent, and hopefully allow it to also work for longer.