### PR TITLE
Qt: Force LC_NUMERIC locale so ReadFloatDecimal will work everywhere.

### DIFF
--- a/src/platform/guiqt.cpp
+++ b/src/platform/guiqt.cpp
@@ -520,6 +520,7 @@ public:
             }
         }
         SetLocale(localeStr);
+        setlocale(LC_NUMERIC, "C");
 
 #ifdef __linux
         QIcon icon("/usr/share/icons/hicolor/48x48/apps/solvespace.png");


### PR DESCRIPTION
Fixes issue #1646
