### PR TITLE
Qt: Request a specific GL version so GLES doesn't get used on Wayland.

### DIFF
--- a/src/platform/guiqt.cpp
+++ b/src/platform/guiqt.cpp
@@ -1044,6 +1044,16 @@ int main(int argc, char** argv) {
     // See https://bugreports.qt.io/browse/QTBUG-89812
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts, true);
 
+    // Specify the GL version so Qt doesn't use GLES on Wayland, which
+    // doesn't handle "#version 120" shaders.
+    {
+    QSurfaceFormat fmt;
+    fmt.setRenderableType(QSurfaceFormat::OpenGL);
+    fmt.setVersion(3, 2);
+    fmt.setProfile(QSurfaceFormat::CoreProfile);
+    QSurfaceFormat::setDefaultFormat(fmt);
+    }
+
     Platform::SSApplication app(argc, argv);
     Platform::Open3DConnexion();
     SS.Init();


### PR DESCRIPTION
Without this "QT_QPA_PLATFORM=xcb" is needed on Wayland or else the shaders may not compile.

Fixes issue #1650.