### PR TITLE
Fix: macOS points not draggable

### DIFF
--- a/src/platform/guimac.mm
+++ b/src/platform/guimac.mm
@@ -176,8 +176,9 @@ public:
         if(timer != NULL) {
             [timer invalidate];
         }
-        timer = [NSTimer scheduledTimerWithTimeInterval:(milliseconds / 1000.0)
+        timer = [NSTimer timerWithTimeInterval:(milliseconds / 1000.0)
             invocation:invocation repeats:NO];
+        [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
     }
 
     ~TimerImplCocoa() {


### PR DESCRIPTION
On macOS 26, interactive dragging could appear “stuck” because the one-shot NSTimer was registered only for the run loop’s default mode. During mouse drags AppKit runs the main run loop in an event-tracking mode, where default-mode timers don’t fire. Register the timer in NSRunLoopCommonModes so it continues firing during tracking and interactive updates keep running.