### PR TITLE
Fix: macOS test action not work

### DIFF
--- a/.github/scripts/install-macos.sh
+++ b/.github/scripts/install-macos.sh
@@ -1,12 +1,18 @@
 #!/bin/sh -xe
+set -o pipefail
 
 if [ "$1" = "ci" ]; then
-    armloc=$(brew fetch --bottle-tag=arm64_sequoia libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
-    x64loc=$(brew fetch --bottle-tag=sequoia libomp | grep -i downloaded | grep tar.gz | cut -f2 -d:)
-    cp $armloc /tmp/libomp-arm64.tar.gz
+    brew_cache=$(brew --cache)
+    brew fetch --bottle-tag=arm64_tahoe libomp >/dev/null
+    brew fetch --bottle-tag=sonoma libomp >/dev/null
+    armloc=$(find "$brew_cache"/downloads -maxdepth 1 -name "*--libomp--*arm64_tahoe.bottle.tar.gz" -print | tail -n1)
+    x64loc=$(find "$brew_cache"/downloads -maxdepth 1 -name "*--libomp--*sonoma.bottle.tar.gz" -print | tail -n1)
+    [ -n "$armloc" ] || { echo "Failed to locate arm64 libomp bottle in cache" >&2; exit 1; }
+    [ -n "$x64loc" ] || { echo "Failed to locate x86_64 libomp bottle in cache" >&2; exit 1; }
+    cp "$armloc" /tmp/libomp-arm64.tar.gz
     mkdir /tmp/libomp-arm64 || true
     tar -xzvf /tmp/libomp-arm64.tar.gz -C /tmp/libomp-arm64
-    cp $x64loc /tmp/libomp-x86_64.tar.gz
+    cp "$x64loc" /tmp/libomp-x86_64.tar.gz
     mkdir /tmp/libomp-x86_64 || true
     tar -xzvf /tmp/libomp-x86_64.tar.gz -C /tmp/libomp-x86_64
 else


### PR DESCRIPTION
When run with "ci“, the script now fetches the libomp bottles for arm64_tahoe and sonoma (on my research, [x86]tahoe doesn't exist), locates them in the Homebrew cache, copies them to /tmp, and extracts them.