### PR TITLE
Qt: Enable fontconfig use.

### DIFF
--- a/src/platform/guiqt.cpp
+++ b/src/platform/guiqt.cpp
@@ -29,6 +29,8 @@
 
 #ifdef WIN32
 #    include <windows.h>
+#else
+#    include <fontconfig/fontconfig.h>
 #endif
 
 namespace SolveSpace {
@@ -978,9 +980,9 @@ void Request3DConnexionEventsForWindow(WindowRef window) {}
 //-----------------------------------------------------------------------------
 
 std::vector<Platform::Path> GetFontFiles() {
-#if WIN32
     std::vector<Platform::Path> fonts;
 
+#ifdef WIN32
     std::wstring fontsDirW(MAX_PATH, '\0');
     fontsDirW.resize(GetWindowsDirectoryW(&fontsDirW[0], fontsDirW.length()));
     fontsDirW += L"\\fonts\\";
@@ -992,13 +994,8 @@ std::vector<Platform::Path> GetFontFiles() {
         fonts.push_back(fontsDir.Join(SolveSpace::Platform::Narrow(wfd.cFileName)));
         if (!FindNextFileW(h, &wfd)) break;
     }
-
-    return fonts;
-#endif
-#if UNIX
-    std::vector<Platform::Path> fonts;
-
-    // fontconfig is already initialized by GTK
+#else
+    // FcInit() should have already been called by QFontconfigDatabase.
     FcPattern* pat = FcPatternCreate();
     FcObjectSet* os = FcObjectSetBuild(FC_FILE, (char*)0);
     FcFontSet* fs = FcFontList(0, pat, os);
@@ -1012,12 +1009,9 @@ std::vector<Platform::Path> GetFontFiles() {
     FcFontSetDestroy(fs);
     FcObjectSetDestroy(os);
     FcPatternDestroy(pat);
-
-    return fonts;
-
 #endif
 
-    return std::vector<Platform::Path>();
+    return fonts;
 }
 
 void OpenInBrowser(const std::string& url) {


### PR DESCRIPTION
There are a couple annoying things I see after enabling the font detection.

First, the list in Properties is extremely long as each individual file is shown rather than each font family (as in a typical application).  There are over 560 files on my system.  A combo box widget would really be helpful.

The second issue is that there are now about 100 freetype warnings printed to the console like this:

```
freetype: CID-to-GID mapping for CID 0x0041 in file '/usr/share/fonts/google-noto-vf/NotoSansMeeteiMayek[wght].ttf' failed: no error; using CID as GID
Assuming cap height is the same as requested height (this is likely wrong).
```
