### PR TITLE
For faces created by lathe and revolve, use a point in the same group…

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -985,7 +985,7 @@ void Group::MakeLatheSurfacesSelectable(EntityList *el, hEntity in, Vector axis)
             en.style = ep->style;
             en.h = Remap(ep->h, REMAP_LINE_TO_FACE);
             en.type = Entity::Type::FACE_NORMAL_PT;
-            en.point[0] = ep->point[0];
+            en.point[0] = Remap(ep->point[0], REMAP_LATHE_START);
             el->Add(&en);
         }
     }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -76,9 +76,14 @@ void GraphicsWindow::StartDraggingByEntity(hEntity he) {
            || e->type == Entity::Type::FACE_N_ROT_TRANS) {        // needed for linked objects
         // Files save prior to v3.2 didn't specify point[0]
         // so check existence before using it.
-        if(SK.entity.FindByIdNoOops(e->point[0]))
+        Entity *pt = SK.entity.FindByIdNoOops(e->point[0]);
+        if(pt)
         {
-          AddPointToDraggedList(e->point[0]);
+          // for some reason Revolve top/bottom faces do bad things if they can't be dragged.
+          // but a two sided revolve group will behave OK.
+          if(pt->CanBeDragged()) {
+            AddPointToDraggedList(e->point[0]);
+          }
         }
     }
 }


### PR DESCRIPTION
…. We also need to check for draggability of face points before adding them to the drag list.

Hopefully this is the last of the face dragging/handle changes for now.