### PR TITLE
Windows 10/11: Fix the button click area in the property browser shifting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Bug fixes:
 	* Does not create an invisible zero length edge and jump the intersection point to (0, 0, 0) when splitting lines with coincident end points.
 * Fix IDF import with THOU units.
 * macOS: Fix some points not draggable on macOS 26 (Tahoe).
+* Windows 10/11: Fix the button click area in the property browser shifting because the contents were rendered stretched or compressed.
 
 3.1
 ---

--- a/src/platform/guiwin.cpp
+++ b/src/platform/guiwin.cpp
@@ -1350,8 +1350,25 @@ public:
     }
 
     void SetScrollbarVisible(bool visible) override {
-        scrollbarVisible = visible;
-        sscheck(ShowScrollBar(hWindow, SB_VERT, visible));
+        if(scrollbarVisible != visible) {
+            scrollbarVisible = visible;
+            sscheck(ShowScrollBar(hWindow, SB_VERT, visible));
+            // Force the window 1 pixel taller and then restore it's original size.
+            // This somehow fixes the problem where on Windows 10 and 11 toggling
+            // the scroll bar would cause the client area of the text window to
+            // be stretched or compressed horizontally. It looks bad and the
+            // buttons on the toolbar do not line up with the hit areas.
+            // See: https://github.com/solvespace/solvespace/issues/681
+            // This fix is the result of a long discussion with claude-sonnet-4.6
+            // https://github.com/solvespace/solvespace/agents/pull/1680
+            // https://github.com/solvespace/solvespace/pull/1680
+            RECT rc;
+            GetWindowRect(hWindow, &rc);
+            SetWindowPos(hWindow, HWND_TOP, rc.left, rc.top, rc.right - rc.left,
+                         rc.bottom - rc.top + 1, SWP_FRAMECHANGED);
+            SetWindowPos(hWindow, HWND_TOP, rc.left, rc.top, rc.right - rc.left,
+                         rc.bottom - rc.top,     SWP_FRAMECHANGED);
+        }
     }
 
     void ConfigureScrollbar(double min, double max, double pageSize) override {


### PR DESCRIPTION
...because the contents were rendered stretched or compressed.

Force the window 1 pixel taller and then restore it's original size. This somehow fixes the problem where on Windows 10 and 11 toggling the scroll bar would cause the client area of the text window to be stretched or compressed horizontally. It looks bad and the buttons on the toolbar do not line up with the hit areas.

This fix is the result of a long discussion with claude-sonnet-4.6
https://github.com/solvespace/solvespace/agents/pull/1680
https://github.com/solvespace/solvespace/pull/1680

Fixes: #681