### PR TITLE
CI: Add ping step for solvespace.com in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -168,6 +168,11 @@ jobs:
       with:
         name: solvespace_web
         path: build/bin/
+    - name: Ping solvespace.com
+      env:
+        WEB_SITE_PING_KEY: ${{ secrets.PULL_WEBVER_KEY }}
+      run: |
+        curl https://solvespace.com/pull-webver.pl?key=${WEB_SITE_PING_KEY}
 
   # deploy_snap_amd64:
   #   needs: [test_ubuntu, test_windows, test_macos]


### PR DESCRIPTION
Added a step to ping solvespace.com during the workflow to notify it that a new web build is available.

https://solvespace.com/pull-webver.pl?key=PULL_WEBVER_KEY

See: https://github.com/solvespace/solvespace-web/issues/46#issuecomment-4152277092