### PR TITLE
Web: fix right-click context menu

### DIFF
--- a/src/platform/guihtml.cpp
+++ b/src/platform/guihtml.cpp
@@ -230,6 +230,7 @@ public:
         htmlMenu(val::global("document").call<val>("createElement", val("ul")))
     {
         htmlMenu["classList"].call<void>("add", val("menu"));
+        htmlMenu.call<void>("setAttribute", val("oncontextmenu"), val("return false"));
     }
 
     MenuItemRef AddItem(const std::string &label, std::function<void()> onTrigger,


### PR DESCRIPTION
disable right-click on context menu `ul` element creation.
The element gets created on keydown, and then the browser sees a right click on that new element upon keyup.

Another way to go about this is something like this:

```
const observer = new MutationObserver((mutations) => {
  for (const mutation of mutations) {
    mutation.addedNodes.forEach(node => {
      if (node.nodeType === 1) { // Check if it's an element
        if (node.matches('ul.menu.popup')) {
          node.setAttribute('oncontextmenu', 'return false');
        }
        // Also check if the added node contains the target element
        const nested = node.querySelector('ul.menu.popup');
        if (nested) nested.setAttribute('oncontextmenu', 'return false');
      }
    });
  }
});

observer.observe(document.body, { childList: true, subtree: true });
```

but the approach I took here seemed much nicer.