### PR TITLE
QT: Add missing file extension on sketch save

### DIFF
--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -574,6 +574,15 @@ void SolveSpaceUI::AddToRecentList(const Platform::Path &filename) {
     GW.PopulateRecentFiles();
 }
 
+static Platform::Path EnsureSketchExtension(Platform::Path filename) {
+    std::string basename = filename.FileName();
+    if(basename.find('.') == std::string::npos) {
+        filename.raw += ".";
+        filename.raw += SolveSpaceUI::SKETCH_EXT;
+    }
+    return filename;
+}
+
 bool SolveSpaceUI::GetFilenameAndSave(bool saveAs) {
     Platform::SettingsRef settings = Platform::GetSettings();
     Platform::Path newSaveFile = saveFile;
@@ -594,6 +603,7 @@ bool SolveSpaceUI::GetFilenameAndSave(bool saveAs) {
             dbp("Calling FreezeChoices()...");
             dialog->FreezeChoices(settings, "Sketch");
             newSaveFile = dialog->GetFilename();
+            newSaveFile = EnsureSketchExtension(newSaveFile);
         } else {
             return false;
         }

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -574,13 +574,37 @@ void SolveSpaceUI::AddToRecentList(const Platform::Path &filename) {
     GW.PopulateRecentFiles();
 }
 
-static Platform::Path EnsureSketchExtension(Platform::Path filename) {
-    std::string basename = filename.FileName();
+bool EnsureSketchExtension(Platform::Path *filename, bool *shouldConfirmOverwrite) {
+    std::string basename = filename->FileName();
     if(basename.find('.') == std::string::npos) {
-        filename.raw += ".";
-        filename.raw += SolveSpaceUI::SKETCH_EXT;
+        filename->raw += ".";
+        filename->raw += SolveSpaceUI::SKETCH_EXT;
+        if(shouldConfirmOverwrite != NULL) {
+            *shouldConfirmOverwrite = FileExists(*filename);
+        }
+        return true;
     }
-    return filename;
+    if(shouldConfirmOverwrite != NULL) {
+        *shouldConfirmOverwrite = false;
+    }
+    return false;
+}
+
+static bool OkayToOverwriteFile(const Platform::Path &filename) {
+    Platform::MessageDialogRef dialog = CreateMessageDialog(SS.GW.window);
+
+    using Platform::MessageDialog;
+    dialog->SetType(MessageDialog::Type::QUESTION);
+    dialog->SetTitle(C_("title", "Overwrite File?"));
+    dialog->SetMessage(ssprintf(C_("dialog", "The file “%s” already exists."),
+                                filename.raw.c_str()));
+    dialog->SetDescription(C_("dialog", "Do you want to replace it?"));
+    dialog->AddButton(C_("button", "&Overwrite"), MessageDialog::Response::YES,
+                      /*isDefault=*/false);
+    dialog->AddButton(C_("button", "&Cancel"), MessageDialog::Response::NO,
+                      /*isDefault=*/true);
+
+    return dialog->RunModal() == MessageDialog::Response::YES;
 }
 
 bool SolveSpaceUI::GetFilenameAndSave(bool saveAs) {
@@ -603,7 +627,11 @@ bool SolveSpaceUI::GetFilenameAndSave(bool saveAs) {
             dbp("Calling FreezeChoices()...");
             dialog->FreezeChoices(settings, "Sketch");
             newSaveFile = dialog->GetFilename();
-            newSaveFile = EnsureSketchExtension(newSaveFile);
+            bool shouldConfirmOverwrite = false;
+            EnsureSketchExtension(&newSaveFile, &shouldConfirmOverwrite);
+            if(shouldConfirmOverwrite && !OkayToOverwriteFile(newSaveFile)) {
+                return false;
+            }
         } else {
             return false;
         }

--- a/src/solvespace.h
+++ b/src/solvespace.h
@@ -740,6 +740,7 @@ void ImportDxf(const Platform::Path &file);
 void ImportDwg(const Platform::Path &file);
 bool LinkIDF(const Platform::Path &filename, EntityList *le, SMesh *m, SShell *sh);
 bool LinkStl(const Platform::Path &filename, EntityList *le, SMesh *m, SShell *sh);
+bool EnsureSketchExtension(Platform::Path *filename, bool *shouldConfirmOverwrite = NULL);
 
 extern SolveSpaceUI SS;
 extern Sketch SK;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(testsuite_SOURCES
     core/expr/test.cpp
     core/locale/test.cpp
     core/path/test.cpp
+    core/save_filename/test.cpp
     constraint/points_coincident/test.cpp
     constraint/pt_pt_distance/test.cpp
     constraint/pt_plane_distance/test.cpp

--- a/test/core/save_filename/existing.slvs
+++ b/test/core/save_filename/existing.slvs
@@ -1,0 +1,1 @@
+existing

--- a/test/core/save_filename/test.cpp
+++ b/test/core/save_filename/test.cpp
@@ -1,0 +1,48 @@
+#include "solvespace.h"
+#include "harness.h"
+
+using Platform::Path;
+
+#if defined(WIN32)
+#define S "\\"
+#else
+#define S "/"
+#endif
+
+TEST_CASE(ensure_sketch_extension) {
+    Path path = Path::From("part");
+    bool shouldConfirmOverwrite = true;
+    CHECK_TRUE(EnsureSketchExtension(&path, &shouldConfirmOverwrite));
+    CHECK_EQ_STR(path.raw, "part.slvs");
+    CHECK_FALSE(shouldConfirmOverwrite);
+
+    path = Path::From("part.slvs");
+    shouldConfirmOverwrite = true;
+    CHECK_FALSE(EnsureSketchExtension(&path, &shouldConfirmOverwrite));
+    CHECK_EQ_STR(path.raw, "part.slvs");
+    CHECK_FALSE(shouldConfirmOverwrite);
+
+    path = Path::From("part.foo");
+    shouldConfirmOverwrite = true;
+    CHECK_FALSE(EnsureSketchExtension(&path, &shouldConfirmOverwrite));
+    CHECK_EQ_STR(path.raw, "part.foo");
+    CHECK_FALSE(shouldConfirmOverwrite);
+}
+
+TEST_CASE(ensure_sketch_extension_ignores_parent_dots) {
+    Path path = Path::From("dir.with.dots" S "part");
+    CHECK_TRUE(EnsureSketchExtension(&path));
+    CHECK_EQ_STR(path.raw, "dir.with.dots" S "part.slvs");
+}
+
+TEST_CASE(confirm_overwrite_after_appending_sketch_extension) {
+    Path path = helper->GetAssetPath(__FILE__, "existing");
+    bool shouldConfirmOverwrite = false;
+    CHECK_TRUE(EnsureSketchExtension(&path, &shouldConfirmOverwrite));
+    CHECK_TRUE(shouldConfirmOverwrite);
+
+    path = helper->GetAssetPath(__FILE__, "absent.slvs");
+    shouldConfirmOverwrite = true;
+    CHECK_FALSE(EnsureSketchExtension(&path, &shouldConfirmOverwrite));
+    CHECK_FALSE(shouldConfirmOverwrite);
+}


### PR DESCRIPTION
This fix should append .slvs to sketch files, regardless of the UI used, if no file extension was given.

If a different file extension exists, it will be retained and .slvs will not be added.

Resolves #1689

Tested in Ubuntu Noble for Qt and GTK interfaces. That is, it fixes the Qt problem and doesn't break the GTK interface.