### PR TITLE
fix(ci): unzip correct path in npm publish CI job

### DIFF
--- a/.github/workflows/wasmlib.yml
+++ b/.github/workflows/wasmlib.yml
@@ -55,7 +55,7 @@ jobs:
           git fetch --unshallow --tags
 
           ls artifacts
-          unzip artifacts/slvs-wasmlib/slvs-wasmlib.zip -d js
+          unzip artifacts/slvs-wasmlib.zip -d js
           ls js
 
           mkdir empty-build


### PR DESCRIPTION
one-liner to hopefully get ci on master green. 

right now the wasm build's publish prepare step fails because it tries to unzip the wrong path.

here it is running on my branch: https://github.com/dgramop/solvespace/actions/runs/27749066387/job/82095100713

of course it fails on my branch since I don't have creds. but it shows the unzip (where it fails) now succeeds