### PR TITLE
Added suffix handling for Qt SAVE file dialogs

### DIFF
--- a/src/platform/guiqt.cpp
+++ b/src/platform/guiqt.cpp
@@ -137,20 +137,27 @@ class FileDialogImplQt final : public FileDialog {
 public:
     QFileDialog fileDialogQ;
     QStringList filters;
+    QStringList defaultSuffixes;
     bool filtersMod;
+    bool isSaveDialog;
 
-    FileDialogImplQt(QWidget* parent, bool save) : filtersMod(false) {
+    FileDialogImplQt(QWidget* parent, bool save)
+        : filtersMod(false), isSaveDialog(save) {
         fileDialogQ.setParent(parent);
         fileDialogQ.setWindowFlags(Qt::Dialog); // Reset after setParent.
 
         // NOTE: The file extension is automatically set by the KDE native
-        // dialog but not with the Qt one.
+        // dialog and now with the Qt one.
 #if 0
         fileDialogQ.setOption(QFileDialog::DontUseNativeDialog);
 #endif
 
         if (save) {
             fileDialogQ.setAcceptMode(QFileDialog::AcceptSave);
+            QObject::connect(&fileDialogQ, &QFileDialog::filterSelected,
+                             [this](const QString &filter) {
+                                 updateDefaultSuffix(filter);
+                             });
         }
     }
 
@@ -187,13 +194,28 @@ public:
 
         //printf("AddFilter \"%s\"\n", fline.toLocal8Bit().data());
         filters.append(fline);
+        defaultSuffixes.append(extensions.empty() ? QString()
+                                                  : QString::fromStdString(extensions.front()));
         filtersMod = true;
+    }
+
+    void updateDefaultSuffix(const QString &filter) {
+        if(!isSaveDialog) return;
+
+        int filterIndex = filters.indexOf(filter);
+        if(filterIndex < 0 || filterIndex >= defaultSuffixes.size()) {
+            filterIndex = 0;
+        }
+        if(filterIndex < defaultSuffixes.size()) {
+            fileDialogQ.setDefaultSuffix(defaultSuffixes[filterIndex]);
+        }
     }
 
     void updateFilters() {
         if (filtersMod) {
             filtersMod = false;
             fileDialogQ.setNameFilters(filters);
+            updateDefaultSuffix(fileDialogQ.selectedNameFilter());
         }
     }
 
@@ -214,6 +236,7 @@ public:
         fileDialogQ.setDirectory(QDir(QString::fromStdString(val)));
         val = settings->ThawString("Dialog_" + key + "_Filter");
         fileDialogQ.selectNameFilter(QString::fromStdString(val));
+        updateDefaultSuffix(fileDialogQ.selectedNameFilter());
     }
 
     bool RunModal() override {

--- a/src/platform/guiqt.cpp
+++ b/src/platform/guiqt.cpp
@@ -145,15 +145,16 @@ public:
         : filtersMod(false), isSaveDialog(save) {
         fileDialogQ.setParent(parent);
         fileDialogQ.setWindowFlags(Qt::Dialog); // Reset after setParent.
-
-        // NOTE: The file extension is automatically set by the KDE native
-        // dialog and now with the Qt one.
 #if 0
+        // For testing Qt dialog.
         fileDialogQ.setOption(QFileDialog::DontUseNativeDialog);
 #endif
 
         if (save) {
             fileDialogQ.setAcceptMode(QFileDialog::AcceptSave);
+            // NOTE: SolveSpace requires a file extension in the filename.
+            // The file extension is automatically set by the KDE native
+            // dialog, while the Qt dialog requires a little more setup.
             QObject::connect(&fileDialogQ, &QFileDialog::filterSelected,
                              [this](const QString &filter) {
                                  updateDefaultSuffix(filter);


### PR DESCRIPTION
Resolves #1689

Not much else to say, the code is straightforward and matches how guigtk.cpp handles file extensions as closely as possible.

This also fix how file extensions are handled for other export file types, like .stl etc.

I have functionally tested this in Ubuntu 24.04.