### PR TITLE
Fix an OpenMP use-after-free on into->curve in AddExactIntersectionCurve()

### DIFF
--- a/src/srf/surfinter.cpp
+++ b/src/srf/surfinter.cpp
@@ -44,12 +44,17 @@ void SSurface::AddExactIntersectionCurve(SBezier *sb, SSurface *srfB,
                 }
             }
         }
+        if(existing) {
+            // Copy the pwl points while still in the critical section;
+            // existing points into into->curve, which reallocates when
+            // another thread adds a curve.
+            SCurvePt *v;
+            for(v = existing->pts.First(); v; v = existing->pts.NextAfter(v)) {
+                sc.pts.Add(v);
+            }
+        }
     }// end omp critical
     if(existing) {
-        SCurvePt *v;
-        for(v = existing->pts.First(); v; v = existing->pts.NextAfter(v)) {
-            sc.pts.Add(v);
-        }
         if(backwards) sc.pts.Reverse();
         split = sc;
         sc = {};


### PR DESCRIPTION
# Fix an OpenMP use-after-free on into->curve in AddExactIntersectionCurve()

**Branch:** `fix-surfinter-openmp-race` (one commit, `3b3a12b4`, off master)

## Summary

`SSurface::AddExactIntersectionCurve()` (src/srf/surfinter.cpp) searches
`into->curve` for an existing identical exact curve inside
`#pragma omp critical(into)`, but keeps the raw pointer `existing` and
dereferences it (iterating `existing->pts`) **after** leaving the critical
section. Meanwhile other threads in the surface-intersection loop call
`into->curve.AddAndAssignId()`, which can grow the underlying `std::vector`
and reallocate its storage — so the reader walks freed memory: a classic
use-after-free.

The bug is pre-existing on master and independent of any classification
logic; it just needs a model whose Boolean produces many *identical* exact
intersection curves (so the `existing` path is taken often) plus OpenMP
scheduling luck. Coincident/overlapping faces do exactly that.

Fix: copy the piecewise-linear points into the local curve while still
inside the critical section. The later `sc.pts.Reverse()` then operates on
the local copy only.

## How it was found and verified

All on Windows 11, MSVC 19.44 x64, `-G Ninja`, `ENABLE_OPENMP=ON`, using the
`NURBS_ThreePrisms.slvs` model from #1091 (its coplanar prism faces generate
many identical exact curves):

- **Reproduced**: `solvespace-cli export-mesh` on that model segfaulted in
  ~5–7 of 60 Debug runs; **0 of 60** with `OMP_NUM_THREADS=1`.
- **Pinpointed with ASan** (`-DENABLE_SANITIZERS=ON`, `/fsanitize=address`):
  heap-use-after-free — read at the `existing->pts` iteration
  (surfinter.cpp:51 area) of memory freed by `_Emplace_reallocate` reached
  from `AddAndAssignId` in another thread's `AddExactIntersectionCurve`
  (surfinter.cpp:111 area). Full report captured.
- **After the fix**: 0 crashes in 100 Debug runs, 60 ASan runs, and
  40 Release runs of the same model; repeated OpenMP runs produce
  byte-identical triangle sets. Full test suite passes in Debug and Release.

## Notes

- The pointer was already obtained under `critical(into)` and the writers in
  boolean.cpp use a different (unnamed) critical, but those run in a
  different phase; the racing writer is the *same* function on other
  threads, whose `AddAndAssignId` is outside any critical section's
  protection of the read.
- Related but not touched: `SSurface::cached` (ratpoly.cpp
  `ClosestPointTo`) is also shared mutable state across threads; it only
  degrades a Newton starting guess, so it's left alone here.
- The classification PR (#1619 / #1091 knife edge) adds a regression test
  whose model is the heaviest known trigger of this race — with that test in
  the suite but this fix absent, the full test suite segfaults in roughly
  half of Debug OpenMP runs. The classification branch is therefore stacked
  on this one; **this PR should merge first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
