### PR TITLE
Classify Boolean edges where a tangent fillet surface folds onto the shell. Fixes #1291.

### DIFF
--- a/src/export.cpp
+++ b/src/export.cpp
@@ -407,8 +407,7 @@ void SolveSpaceUI::ExportLinesAndMesh(SEdgeList *sel, SBezierList *sbl, SMesh *s
         // Generate the edges where a curved surface turns from front-facing
         // to back-facing.
         if(SS.GW.showEdges || SS.GW.showOutlines) {
-            root->MakeCertainEdgesInto(sel, EdgeKind::TURNING,
-                                       /*coplanarIsInter=*/false, NULL, NULL,
+            root->MakeCertainEdgesInto(sel, EdgeKind::TURNING, NULL, NULL,
                                        GW.showOutlines ? Style::OUTLINE : Style::SOLID_EDGE);
         }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -86,8 +86,7 @@ void SMesh::MakeEdgesInPlaneInto(SEdgeList *sel, Vector n, double d) {
     // Select the naked edges in our resulting open mesh.
     SKdNode *root = SKdNode::From(&m);
     root->SnapToMesh(&m);
-    root->MakeCertainEdgesInto(sel, EdgeKind::NAKED_OR_SELF_INTER,
-                               /*coplanarIsInter=*/false, NULL, NULL);
+    root->MakeCertainEdgesInto(sel, EdgeKind::NAKED_OR_SELF_INTER, NULL, NULL);
 
     m.Clear();
 }
@@ -830,12 +829,9 @@ void SKdNode::OcclusionTestLine(SEdge orig, SEdgeList *sel, int cnt) const {
 // for the edge from a to b), and increment info->count each time that we
 // find one. If a triangle is found, then report whether it is front- or
 // back-facing using info->frontFacing. And regardless of whether a mate is
-// found, report whether the edge intersects the mesh with info->intersectsMesh;
-// if coplanarIsInter then we count the edge as intersecting if it's coplanar
-// with a triangle in the mesh, otherwise not.
+// found, report whether the edge intersects the mesh with info->intersectsMesh.
 //-----------------------------------------------------------------------------
-void SKdNode::FindEdgeOn(Vector a, Vector b, int cnt, bool coplanarIsInter,
-                         EdgeOnInfo *info) const
+void SKdNode::FindEdgeOn(Vector a, Vector b, int cnt, EdgeOnInfo *info) const
 {
     if(gt && lt) {
         double ac = a.Element(which),
@@ -843,12 +839,12 @@ void SKdNode::FindEdgeOn(Vector a, Vector b, int cnt, bool coplanarIsInter,
         if(ac < c + KDTREE_EPS ||
            bc < c + KDTREE_EPS)
         {
-            lt->FindEdgeOn(a, b, cnt, coplanarIsInter, info);
+            lt->FindEdgeOn(a, b, cnt, info);
         }
         if(ac > c - KDTREE_EPS ||
            bc > c - KDTREE_EPS)
         {
-            gt->FindEdgeOn(a, b, cnt, coplanarIsInter, info);
+            gt->FindEdgeOn(a, b, cnt, info);
         }
         return;
     }
@@ -898,28 +894,27 @@ void SKdNode::FindEdgeOn(Vector a, Vector b, int cnt, bool coplanarIsInter,
                 // The edge crosses the plane of the triangle; now see if
                 // it crosses inside the triangle.
                 if(tr->ContainsPointProjd(b.Minus(a), a)) {
-                    if(coplanarIsInter) {
-                        info->intersectsMesh = true;
+                    Vector p = Vector::AtIntersectionOfPlaneAndLine(
+                                            n, d, a, b, NULL);
+                    Vector ta = tr->a,
+                           tb = tr->b,
+                           tc = tr->c;
+                    if((p.DistanceToLine(ta, tb.Minus(ta)) < LENGTH_EPS) ||
+                       (p.DistanceToLine(tb, tc.Minus(tb)) < LENGTH_EPS) ||
+                       (p.DistanceToLine(tc, ta.Minus(tc)) < LENGTH_EPS))
+                    {
+                        // Intersection lies on edge. This happens when
+                        // our edge is from a triangle coplanar with, or
+                        // tangent to, another triangle in the mesh; for
+                        // example where a surface of a Boolean result
+                        // grazes the interior of a face without cutting
+                        // it. That is a touch, not a crossing: an edge
+                        // that actually passes into the mesh here also
+                        // passes through the interior of the triangles
+                        // on the other side of that edge, and is
+                        // reported there.
                     } else {
-                        Vector p = Vector::AtIntersectionOfPlaneAndLine(
-                                                n, d, a, b, NULL);
-                        Vector ta = tr->a,
-                               tb = tr->b,
-                               tc = tr->c;
-                        if((p.DistanceToLine(ta, tb.Minus(ta)) < LENGTH_EPS) ||
-                           (p.DistanceToLine(tb, tc.Minus(tb)) < LENGTH_EPS) ||
-                           (p.DistanceToLine(tc, ta.Minus(tc)) < LENGTH_EPS))
-                        {
-                            // Intersection lies on edge. This happens when
-                            // our edge is from a triangle coplanar with
-                            // another triangle in the mesh. We don't test
-                            // the edge against triangles whose plane contains
-                            // that edge, but we do end up testing against
-                            // the coplanar triangle's neighbours, which we
-                            // will intersect on their edges.
-                        } else {
-                            info->intersectsMesh = true;
-                        }
+                        info->intersectsMesh = true;
                     }
                 }
             }
@@ -951,7 +946,7 @@ static bool CheckAndAddTrianglePair(std::set<std::pair<STriangle *, STriangle *>
 //    * emphasized edges (i.e., edges where a triangle from one face joins
 //      a triangle from a different face)
 //-----------------------------------------------------------------------------
-void SKdNode::MakeCertainEdgesInto(SEdgeList *sel, EdgeKind how, bool coplanarIsInter,
+void SKdNode::MakeCertainEdgesInto(SEdgeList *sel, EdgeKind how,
                                    bool *inter, bool *leaky, int auxA) const
 {
     if(inter) *inter = false;
@@ -969,7 +964,7 @@ void SKdNode::MakeCertainEdgesInto(SEdgeList *sel, EdgeKind how, bool coplanarIs
             Vector b = tr->vertices[(j + 1) % 3];
 
             SKdNode::EdgeOnInfo info = {};
-            FindEdgeOn(a, b, cnt, coplanarIsInter, &info);
+            FindEdgeOn(a, b, cnt, &info);
 
             switch(how) {
                 case EdgeKind::NAKED_OR_SELF_INTER:
@@ -977,7 +972,7 @@ void SKdNode::MakeCertainEdgesInto(SEdgeList *sel, EdgeKind how, bool coplanarIs
                     if(info.count != 1) {
                         // but there may be multiple parallel coincident edges
                         SKdNode::EdgeOnInfo parallelInfo = {};
-                        FindEdgeOn(b, a, -cnt, coplanarIsInter, &parallelInfo);
+                        FindEdgeOn(b, a, -cnt, &parallelInfo);
                         if (info.count != parallelInfo.count) {
                             sel->AddEdge(a, b, auxA);
                             if(leaky) *leaky = true;
@@ -1059,7 +1054,7 @@ void SKdNode::MakeOutlinesInto(SOutlineList *sol, EdgeKind edgeKind) const
             Vector b = tr->vertices[(j + 1) % 3];
 
             SKdNode::EdgeOnInfo info = {};
-            FindEdgeOn(a, b, cnt, /*coplanarIsInter=*/false, &info);
+            FindEdgeOn(a, b, cnt, &info);
             cnt++;
             if(info.count != 1) continue;
             if(CheckAndAddTrianglePair(&edgeTris, tr, info.tr))

--- a/src/polygon.h
+++ b/src/polygon.h
@@ -362,8 +362,8 @@ public:
     void ListTrianglesInto(std::vector<STriangle *> *tl) const;
     void ClearTags() const;
 
-    void FindEdgeOn(Vector a, Vector b, int cnt, bool coplanarIsInter, EdgeOnInfo *info) const;
-    void MakeCertainEdgesInto(SEdgeList *sel, EdgeKind how, bool coplanarIsInter,
+    void FindEdgeOn(Vector a, Vector b, int cnt, EdgeOnInfo *info) const;
+    void MakeCertainEdgesInto(SEdgeList *sel, EdgeKind how,
                               bool *inter, bool *leaky, int auxA = 0) const;
     void MakeOutlinesInto(SOutlineList *sel, EdgeKind tagKind) const;
 

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -905,7 +905,7 @@ void SolveSpaceUI::MenuAnalyze(Command id) {
             SKdNode *root = SKdNode::From(m);
             bool inters, leaks;
             root->MakeCertainEdgesInto(&(SS.nakedEdges),
-                EdgeKind::SELF_INTER, /*coplanarIsInter=*/false, &inters, &leaks);
+                EdgeKind::SELF_INTER, &inters, &leaks);
 
             SS.GW.Invalidate();
 
@@ -1070,7 +1070,7 @@ void SolveSpaceUI::ShowNakedEdges(bool reportOnlyWhenNotOkay) {
     SKdNode *root = SKdNode::From(m);
     bool inters, leaks;
     root->MakeCertainEdgesInto(&(SS.nakedEdges),
-        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+        EdgeKind::NAKED_OR_SELF_INTER, &inters, &leaks);
 
     if(reportOnlyWhenNotOkay && !inters && !leaks && SS.nakedEdges.l.IsEmpty()) {
         return;

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -559,8 +559,20 @@ SSurface SSurface::MakeCopyTrimAgainst(SShell *parent,
                 // We are subtracting the portion of our surface that
                 // lies in the shell, so the in-plane edge normal should
                 // point opposite to the surface normal.
+                Vector tnxd = tn.Cross(b.Minus(a));
+                double dot = tnxd.Dot(sn);
+                if(fabs(dot) < SShell::DOTP_TOL*tnxd.Magnitude()*sn.Magnitude()) {
+                    // The surfaces are tangent along this curve, so their
+                    // normals give no orientation for it. Add the edge in
+                    // both directions; the classification against the
+                    // shells keeps the correctly oriented one and
+                    // discards the other.
+                    inter.AddEdge(ta, tb, sc.h.v, 0);
+                    inter.AddEdge(tb, ta, sc.h.v, 1);
+                    continue;
+                }
                 bool bkwds = true;
-                if((tn.Cross(b.Minus(a))).Dot(sn) < 0) bkwds = !bkwds;
+                if(dot < 0) bkwds = !bkwds;
                 if((type == SSurface::CombineAs::DIFFERENCE && !opA) ||
                    (type == SSurface::CombineAs::INTERSECTION)) { // Invert all newly created edges for intersection
                     bkwds = !bkwds;

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -617,14 +617,21 @@ SSurface SSurface::MakeCopyTrimAgainst(SShell *parent,
         ret.EdgeNormalsWithinSurface(auv, buv, &pt, &enin, &enout, &surfn,
                                         se->auxA, into, sha, shb);
 
-        SShell::Class indir_shell, outdir_shell, indir_orig, outdir_orig;
+        // Initialize to a deterministic (if arbitrary) guess, so that if the
+        // classification fails we don't use values from uninitialized stack.
+        SShell::Class indir_shell  = SShell::Class::SURF_OUTSIDE,
+                      outdir_shell = SShell::Class::SURF_OUTSIDE,
+                      indir_orig, outdir_orig;
 
         indir_orig  = SShell::Class::SURF_INSIDE;
         outdir_orig = SShell::Class::SURF_OUTSIDE;
 
-        agnst->ClassifyEdge(&indir_shell, &outdir_shell,
-                            ret.PointAt(auv), ret.PointAt(buv), pt,
-                            enin, enout, surfn);
+        if(!agnst->ClassifyEdge(&indir_shell, &outdir_shell,
+                                ret.PointAt(auv), ret.PointAt(buv), pt,
+                                enin, enout, surfn))
+        {
+            dbp("MakeCopyTrimAgainst: failed to classify orig edge (I=%d)", I+dbg_index);
+        }
 
         if(KeepEdge(type, opA, indir_shell, outdir_shell,
                                indir_orig,  outdir_orig))
@@ -650,14 +657,21 @@ SSurface SSurface::MakeCopyTrimAgainst(SShell *parent,
         ret.EdgeNormalsWithinSurface(auv, buv, &pt, &enin, &enout, &surfn,
                                         se->auxA, into, sha, shb);
 
-        SShell::Class indir_shell, outdir_shell, indir_orig, outdir_orig;
+        // Initialize to a deterministic (if arbitrary) guess, so that if the
+        // classification fails we don't use values from uninitialized stack.
+        SShell::Class indir_shell  = SShell::Class::SURF_OUTSIDE,
+                      outdir_shell = SShell::Class::SURF_OUTSIDE,
+                      indir_orig, outdir_orig;
 
         SBspUv::Class c_this = (origBsp) ? origBsp->ClassifyEdge(auv, buv, &ret) : SBspUv::Class::OUTSIDE;
         TagByClassifiedEdge(c_this, &indir_orig, &outdir_orig);
 
-        agnst->ClassifyEdge(&indir_shell, &outdir_shell,
-                            ret.PointAt(auv), ret.PointAt(buv), pt,
-                            enin, enout, surfn);
+        if(!agnst->ClassifyEdge(&indir_shell, &outdir_shell,
+                                ret.PointAt(auv), ret.PointAt(buv), pt,
+                                enin, enout, surfn))
+        {
+            dbp("MakeCopyTrimAgainst: failed to classify inter edge (I=%d)", I+dbg_index);
+        }
 
         if(KeepEdge(type, opA, indir_shell, outdir_shell,
                                indir_orig,  outdir_orig))

--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -452,9 +452,15 @@ void SSurface::EdgeNormalsWithinSurface(Point2d auv, Point2d buv,
 
     *surfn = NormalAt(muv.x, muv.y);
 
-    // Compute the edge's inner normal in xyz space.
+    // Compute the edge's inner normal in xyz space. Use the configured
+    // chord tolerance as the probe distance, but never more than a
+    // fraction of this edge's own length: the classification must probe
+    // the surfaces close to the edge, and a coarse tolerance on a small
+    // model would otherwise evaluate them far away, or even extrapolate
+    // them outside their domain, and misclassify.
     Vector ab    = (PointAt(auv)).Minus(PointAt(buv)),
-           enxyz = (ab.Cross(*surfn)).WithMagnitude(SS.ChordTolMm());
+           enxyz = (ab.Cross(*surfn)).WithMagnitude(
+                        min(SS.ChordTolMm(), ab.Magnitude() / 10));
     // And based on that, compute the edge's inner normal in uv space. This
     // vector is perpendicular to the edge in xyz, but not necessarily in uv.
     Vector tu, tv, tx, ty;

--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -435,6 +435,7 @@ bool SShell::ClassifyEdge(Class *indir, Class *outdir,
     // First, check for edge-on-edge
     int edge_inters = 0;
     Vector inter_surf_n[2], inter_edge_n[2];
+    SSurface *inter_srf[2] = {};
     for(SSurface &srf : surface) {
         if(srf.LineEntirelyOutsideBbox(ea, eb, /*asSegment=*/true)) continue;
 
@@ -456,6 +457,7 @@ bool SShell::ClassifyEdge(Class *indir, Class *outdir,
                     // out.
                     inter_edge_n[edge_inters] =
                       (inter_surf_n[edge_inters]).Cross((se->b).Minus((se->a)));
+                    inter_srf[edge_inters] = &srf;
                 }
 
                 edge_inters++;
@@ -474,15 +476,83 @@ bool SShell::ClassifyEdge(Class *indir, Class *outdir,
             swap(dotp[0],         dotp[1]);
             swap(inter_surf_n[0], inter_surf_n[1]);
             swap(inter_edge_n[0], inter_edge_n[1]);
+            swap(inter_srf[0],    inter_srf[1]);
         }
 
         Class coinc = (surf_n.Dot(inter_surf_n[0])) > 0 ? Class::SURF_COINC_SAME : Class::SURF_COINC_OPP;
 
         if(fabs(dotp[0]) < DOTP_TOL && fabs(dotp[1]) < DOTP_TOL) {
-            // This is actually an edge on face case, just that the face
-            // is split into two pieces joining at our edge.
-            *indir  = coinc;
-            *outdir = coinc;
+            // Both faces meeting at the shell's edge lie in our surface's
+            // tangent plane at p. Usually the shell's surface is just
+            // split into two pieces joining at our edge, and both sides
+            // of our edge are coincident with the shell. But a face may
+            // instead be *tangent* to our surface at the shell's edge,
+            // curving away from it past that edge (e.g. a fillet cylinder
+            // meeting the flat cap it's tangent to, issue #1291); the
+            // side of our edge towards such a face is not coincident with
+            // the shell. The normals at p can't distinguish these, so
+            // probe each face's actual geometry a little way in from the
+            // shell's edge.
+            Vector f[2];    // points into face i, perpendicular to edge
+            double dev[2];  // face i's deviation from our tangent plane
+            bool   flat[2]; // does face i lie in our tangent plane?
+            Vector nu = surf_n.WithMagnitude(1);
+            for(int i = 0; i < 2; i++) {
+                // Probe at a small fraction of the face's own size, so
+                // that the deviation of a curved face is well above
+                // numerical noise no matter the model's scale.
+                SSurface *srf = inter_srf[i];
+                Vector c00 = srf->ctrl[0][0],
+                       cm0 = srf->ctrl[srf->degm][0],
+                       c0n = srf->ctrl[0][srf->degn],
+                       cmn = srf->ctrl[srf->degm][srf->degn];
+                double size = max(max((cm0.Minus(c00)).Magnitude(),
+                                      (c0n.Minus(c00)).Magnitude()),
+                                  (cmn.Minus(c00)).Magnitude());
+                f[i] = (inter_edge_n[i].ScaledBy(-1))
+                            .WithMagnitude(max(size / 20, LENGTH_EPS * 100));
+                Point2d fuv;
+                srf->ClosestPointTo(p.Plus(f[i]), &fuv, /*mustConverge=*/false);
+                dev[i] = ((srf->PointAt(fuv)).Minus(p)).Dot(nu);
+                flat[i] = fabs(dev[i]) < max(LENGTH_EPS, 1e-3 * f[i].Magnitude());
+            }
+            Class *dir[2] = { indir, outdir };
+            Vector  en[2] = { edge_n_in, edge_n_out };
+            for(int s = 0; s < 2; s++) {
+                // Of the faces extending into this side of our edge, find
+                // the one lying nearest our tangent plane.
+                int best = -1;
+                for(int i = 0; i < 2; i++) {
+                    if(f[i].Dot(en[s]) <= 0) continue;
+                    if(best < 0 || fabs(dev[i]) < fabs(dev[best])) best = i;
+                }
+                if(best >= 0 && flat[best]) {
+                    // This side of our edge lies on that face.
+                    *dir[s] = (surf_n.Dot(inter_surf_n[best]) > 0) ?
+                                Class::SURF_COINC_SAME : Class::SURF_COINC_OPP;
+                } else if(best >= 0) {
+                    // The nearest face on this side curves away from our
+                    // tangent plane, so this side of our edge is not on
+                    // the shell; it's on the shell's material side of
+                    // that face iff the face curves away opposite the
+                    // face's outward normal.
+                    *dir[s] = (dev[best] * surf_n.Dot(inter_surf_n[best]) > 0) ?
+                                Class::SURF_INSIDE : Class::SURF_OUTSIDE;
+                } else {
+                    // Both faces fold back to the other side of our edge,
+                    // meeting our surface tangentially at the shell's
+                    // edge. They enclose a zero-angle wedge, of material
+                    // if the farther face lies on the material side of
+                    // the nearer one (then this side of our edge is
+                    // beyond that material, outside the shell), and of
+                    // void cut into material otherwise.
+                    int nr = (fabs(dev[0]) < fabs(dev[1])) ? 0 : 1;
+                    bool material = (dev[1-nr] - dev[nr]) *
+                                        surf_n.Dot(inter_surf_n[nr]) < 0;
+                    *dir[s] = material ? Class::SURF_OUTSIDE
+                                       : Class::SURF_INSIDE;
+                }
+            }
         } else if(fabs(dotp[0]) < DOTP_TOL && dotp[1] > DOTP_TOL) {
             if(edge_n_out.Dot(inter_edge_n[0]) > 0) {
                 *indir  = coinc;

--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -522,6 +522,72 @@ bool SShell::ClassifyEdge(Class *indir, Class *outdir,
         return true;
     }
 
+    if(edge_inters >= 4 && edge_inters % 2 == 0) {
+        // More than two surfaces of our shell meet edge-on-edge along the
+        // given edge: regions of the shell join along a knife edge there
+        // (e.g. two prisms sharing a single edge, issue #1091). The faces
+        // along the knife edge divide the directions perpendicular to the
+        // edge at p into sectors that are alternately inside and outside
+        // the shell, so classify each side of our edge against the face
+        // that lies angularly closest to it: that face bounds the sector
+        // containing it, and its normal points out of that sector iff the
+        // sector is outside the shell.
+        Vector edge_d = (eb.Minus(ea)).WithMagnitude(1);
+        Vector en[2] = { edge_n_in, edge_n_out };
+        Vector ep[2];
+        double bestdot[2] = { VERY_NEGATIVE, VERY_NEGATIVE };
+        Vector bestn[2];
+        for(int i = 0; i < 2; i++) {
+            ep[i] = (en[i].Minus(edge_d.ScaledBy(en[i].Dot(edge_d))))
+                        .WithMagnitude(1);
+        }
+
+        for(SSurface &srf : surface) {
+            if(srf.LineEntirelyOutsideBbox(ea, eb, /*asSegment=*/true)) continue;
+
+            SEdgeList *sel = &(srf.edges);
+            SEdge *se;
+            for(se = sel->l.First(); se; se = sel->l.NextAfter(se)) {
+                if((ea.Equals(se->a) && eb.Equals(se->b)) ||
+                   (eb.Equals(se->a) && ea.Equals(se->b)) ||
+                    p.OnLineSegment(se->a, se->b))
+                {
+                    Point2d pm;
+                    srf.ClosestPointTo(p, &pm, /*mustConverge=*/false);
+                    Vector n = srf.NormalAt(pm);
+                    // A vector tangent to the intersecting surface at p,
+                    // pointing into that face, perpendicular to our edge.
+                    Vector f = ((se->b).Minus(se->a)).Cross(n);
+                    f = f.Minus(edge_d.ScaledBy(f.Dot(edge_d)));
+                    if(f.Magnitude() < LENGTH_EPS) continue;
+                    f = f.WithMagnitude(1);
+                    for(int i = 0; i < 2; i++) {
+                        double dot = ep[i].Dot(f);
+                        if(dot > bestdot[i]) {
+                            bestdot[i] = dot;
+                            bestn[i]   = n;
+                        }
+                    }
+                }
+            }
+        }
+
+        Class *dir[2] = { indir, outdir };
+        for(int i = 0; i < 2; i++) {
+            double dotn = en[i].DirectionCosineWith(bestn[i]);
+            if(bestdot[i] > 0 && fabs(dotn) < DOTP_TOL) {
+                // This side of our edge lies along the nearest face, so
+                // our surface is locally coincident with it there.
+                *dir[i] = (surf_n.Dot(bestn[i]) > 0) ? Class::SURF_COINC_SAME
+                                                     : Class::SURF_COINC_OPP;
+            } else {
+                *dir[i] = (dotn > 0) ? Class::SURF_OUTSIDE
+                                     : Class::SURF_INSIDE;
+            }
+        }
+        return true;
+    }
+
     if(edge_inters != 0) dbp("bad, edge_inters=%d", edge_inters);
 
     // Next, check for edge-on-surface. The ray-casting for edge-inside-shell

--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -506,9 +506,18 @@ bool SShell::ClassifyEdge(Class *indir, Class *outdir,
             *indir  = Class::SURF_OUTSIDE;
             *outdir = Class::SURF_INSIDE;
         } else {
-            // Edge is tangent to the shell at shell's edge, so can't be
-            // a boundary of the surface.
-            return false;
+            // Our edge is tangent to the shell at the shell's edge: the
+            // two faces meeting at the shell's edge lie on the same side
+            // of our surface, so the regions on both sides of our edge
+            // get the same class. That's outside the shell if the shell's
+            // edge is convex, and inside if it's concave (reflex).
+            // inter_edge_n[i] points away from face i's material, so the
+            // shell's edge is convex iff face 1's material direction lies
+            // behind face 0's plane.
+            Class c = (inter_edge_n[1].Dot(inter_surf_n[0]) > 0) ?
+                            Class::SURF_OUTSIDE : Class::SURF_INSIDE;
+            *indir  = c;
+            *outdir = c;
         }
         return true;
     }

--- a/src/srf/surfinter.cpp
+++ b/src/srf/surfinter.cpp
@@ -199,12 +199,15 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
     {
         // The intersection between a plane and a surface of extrusion
         SSurface *splane, *sext;
+        SShell *shext;
         if(degm == 1 && degn == 1) {
             splane = this;
             sext = b;
+            shext = agnstB;
         } else {
             splane = b;
             sext = this;
+            shext = agnstA;
         }
 
         Vector n = splane->NormalAt(0, 0).WithMagnitude(1), along;
@@ -228,12 +231,48 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
             // extrusion, and dp component doesn't matter so zero
             p0 = n.ScaledBy(d).Plus(alu.ScaledBy(pm.Dot(alu)));
 
+            // The extruded curve might be tangent to the plane, e.g. where
+            // a fillet-like surface blends into the flat face it's tangent
+            // to (issue #1291). The numerical line-surface intersection
+            // below can't converge on such a grazing intersection; but the
+            // tangency occurs where the extruded curve ends on the plane,
+            // so the line of intersection is the trim curve that the
+            // surface shares with its neighbour there, and that curve lies
+            // entirely in the plane. Add any such exact curves directly,
+            // like the exact-curve case in the general branch below.
+            List<SBezier> exacts = {};
+            for(SCurve &sc : shext->curve) {
+                if(sc.source == SCurve::Source::INTERSECTION) continue;
+                if(!sc.isExact) continue;
+                if((sc.surfA != sext->h) && (sc.surfB != sext->h)) continue;
+                if(splane->ContainsPlaneCurve(&sc)) {
+                    SBezier bezier = sc.exact;
+                    AddExactIntersectionCurve(&bezier, b, agnstA, agnstB, into);
+                    exacts.Add(&bezier);
+                }
+            }
+
             List<SInter> inters = {};
             sext->AllPointsIntersecting(p0, p0.Plus(dp), &inters,
                 /*asSegment=*/false, /*trimmed=*/false, /*inclTangent=*/true);
 
             SInter *si;
             for(si = inters.First(); si; si = inters.NextAfter(si)) {
+                // If this line was already added exactly above, don't add a
+                // numerical (last-digits different) duplicate of it; the
+                // duplicates would break the trim polygon assembly.
+                bool duplicate = false;
+                SBezier *eb;
+                for(eb = exacts.First(); eb; eb = exacts.NextAfter(eb)) {
+                    double t;
+                    eb->ClosestPointTo(si->p, &t, /*mustConverge=*/false);
+                    if(((eb->PointAt(t)).Minus(si->p)).Magnitude() < LENGTH_EPS) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if(duplicate) continue;
+
                 Vector al = along.ScaledBy(0.5);
                 SBezier bezier;
                 bezier = SBezier::From((si->p).Minus(al), (si->p).Plus(al));
@@ -241,6 +280,7 @@ void SSurface::IntersectAgainst(SSurface *b, SShell *agnstA, SShell *agnstB,
             }
 
             inters.Clear();
+            exacts.Clear();
         } else {
             // Direction of extrusion is not parallel to plane; so
             // intersection is projection of extruded curve into our plane.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(testsuite_SOURCES
     request/line_segment/test.cpp
     request/ttf_text/test.cpp
     request/workplane/test.cpp
+    group/boolean_knife_edge/test.cpp
     group/boolean_tangent_edge/test.cpp
     group/link/test.cpp
     group/translate_asy/test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ set(testsuite_SOURCES
     group/boolean_knife_edge/test.cpp
     group/boolean_tangent_edge/test.cpp
     group/boolean_tangent_fillet/test.cpp
+    group/boolean_tangent_spline/test.cpp
     group/link/test.cpp
     group/translate_asy/test.cpp
     group/translate_nd/test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(testsuite_SOURCES
     analysis/contour_area/test.cpp
     core/expr/test.cpp
     core/locale/test.cpp
+    core/mesh/test.cpp
     core/path/test.cpp
     constraint/points_coincident/test.cpp
     constraint/pt_pt_distance/test.cpp
@@ -63,6 +64,7 @@ set(testsuite_SOURCES
     request/line_segment/test.cpp
     request/ttf_text/test.cpp
     request/workplane/test.cpp
+    group/boolean_grazing_edge/test.cpp
     group/boolean_knife_edge/test.cpp
     group/boolean_tangent_edge/test.cpp
     group/boolean_tangent_fillet/test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(testsuite_SOURCES
     request/line_segment/test.cpp
     request/ttf_text/test.cpp
     request/workplane/test.cpp
+    group/boolean_tangent_edge/test.cpp
     group/link/test.cpp
     group/translate_asy/test.cpp
     group/translate_nd/test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(testsuite_SOURCES
     request/workplane/test.cpp
     group/boolean_knife_edge/test.cpp
     group/boolean_tangent_edge/test.cpp
+    group/boolean_tangent_fillet/test.cpp
     group/link/test.cpp
     group/translate_asy/test.cpp
     group/translate_nd/test.cpp

--- a/test/core/mesh/test.cpp
+++ b/test/core/mesh/test.cpp
@@ -1,0 +1,50 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// A triangle whose edge lies in another triangle's interior — for example
+// where a surface of a Boolean result grazes the interior of a face without
+// cutting it — touches the mesh, but does not intersect it.
+TEST_CASE(grazing_edge_is_not_self_intersecting) {
+    SMesh m = {};
+    STriMeta meta = {};
+    // A square floor in the xy plane, and a tent rising from it whose ridge
+    // base lies across the floor's interior.
+    m.AddTriangle(meta, Vector::From(0, 0, 0), Vector::From(10, 0, 0),
+                        Vector::From(10, 10, 0));
+    m.AddTriangle(meta, Vector::From(0, 0, 0), Vector::From(10, 10, 0),
+                        Vector::From(0, 10, 0));
+    m.AddTriangle(meta, Vector::From(2, 5, 0), Vector::From(8, 5, 0),
+                        Vector::From(5, 5, 3));
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(&m)->MakeCertainEdgesInto(&el,
+        EdgeKind::SELF_INTER, &inters, &leaks);
+    CHECK_FALSE(inters);
+    el.Clear();
+    m.Clear();
+}
+
+// An edge that passes through another triangle's interior is a real
+// self-intersection, and must still be reported.
+TEST_CASE(crossing_edge_is_self_intersecting) {
+    SMesh m = {};
+    STriMeta meta = {};
+    m.AddTriangle(meta, Vector::From(0, 0, 0), Vector::From(10, 0, 0),
+                        Vector::From(10, 10, 0));
+    m.AddTriangle(meta, Vector::From(0, 0, 0), Vector::From(10, 10, 0),
+                        Vector::From(0, 10, 0));
+    // A triangle poking through the floor's interior.
+    m.AddTriangle(meta, Vector::From(3, 3, 1), Vector::From(7, 3, 1),
+                        Vector::From(5, 3, -1));
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(&m)->MakeCertainEdgesInto(&el,
+        EdgeKind::SELF_INTER, &inters, &leaks);
+    CHECK_TRUE(inters);
+    CHECK_FALSE(el.l.IsEmpty());
+    el.Clear();
+    m.Clear();
+}

--- a/test/group/boolean_grazing_edge/normal.slvs
+++ b/test/group/boolean_grazing_edge/normal.slvs
@@ -1,0 +1,2129 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=sketch-square
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=extrude-cube
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7001
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 00070000 1002
+    29 00070001 1002
+    30 00070002 1002
+    31 00070000 1001
+    32 00070001 1001
+    33 00070002 1001
+    34 00070000 1004
+    35 00070001 1003
+    36 00070002 1003
+    37 80020000 1002
+    38 80020000 1001
+    39 80020001 1002
+    40 80020002 1002
+    41 80020001 1001
+    42 80020002 1001
+    43 80020002 1003
+    44 00000000 1001
+    45 00000000 1002
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=sketch-fillet
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6001
+Group.skipFirst=0
+Group.predef.origin.v=80030018
+Group.predef.entityB.v=8003000d
+Group.predef.entityC.v=80030016
+Group.predef.swapUV=0
+Group.predef.negateU=1
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=cut
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.meshCombine=1
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00080000 1002
+    2 00080001 1002
+    3 00080002 1002
+    4 00080000 1001
+    5 00080001 1001
+    6 00080002 1001
+    7 00080000 1004
+    8 00080001 1003
+    9 00080002 1003
+    10 00090000 1002
+    11 00090001 1002
+    12 00090002 1002
+    13 00090000 1001
+    14 00090001 1001
+    15 00090002 1001
+    16 00090000 1004
+    17 00090001 1003
+    18 00090002 1003
+    19 000a0000 1002
+    20 000a0001 1002
+    21 000a0002 1002
+    22 000a0003 1002
+    23 000a0004 1002
+    24 000a0000 1001
+    25 000a0001 1001
+    26 000a0002 1001
+    27 000a0003 1001
+    28 000a0004 1001
+    29 000a0001 1003
+    30 000a0002 1003
+    31 000a0003 1003
+    32 000a0004 1003
+    33 80040000 1002
+    34 80040000 1001
+    35 80040001 1002
+    36 80040002 1002
+    37 80040001 1001
+    38 80040002 1001
+    39 80040002 1003
+    40 00000000 1001
+    41 00000000 1002
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00040011
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00040013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00040014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00050010
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00050011
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00050013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00050014
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060010
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00060013
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060014
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00070010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070013
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00070014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00080010
+Param.val=13.75569688166065063228
+AddParam
+
+Param.h.v.=00080011
+AddParam
+
+Param.h.v.=00080013
+Param.val=51.92366793841181049629
+AddParam
+
+Param.h.v.=00080014
+AddParam
+
+Param.h.v.=00090010
+Param.val=51.92366793841181049629
+AddParam
+
+Param.h.v.=00090011
+AddParam
+
+Param.h.v.=00090013
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=00090014
+Param.val=48.78837126472273411082
+AddParam
+
+Param.h.v.=000a0010
+Param.val=13.75569688166065063228
+AddParam
+
+Param.h.v.=000a0011
+AddParam
+
+Param.h.v.=000a0013
+Param.val=48.78060959786832029295
+AddParam
+
+Param.h.v.=000a0014
+AddParam
+
+Param.h.v.=000a0016
+Param.val=38.90683606737869837389
+AddParam
+
+Param.h.v.=000a0017
+Param.val=41.29451542357136872852
+AddParam
+
+Param.h.v.=000a0019
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=000a001a
+Param.val=48.78837126472273411082
+AddParam
+
+Param.h.v.=4000000d
+Param.val=0.22926161469434416795
+AddParam
+
+Param.h.v.=4000000f
+Param.val=0.81313952107871223518
+AddParam
+
+Param.h.v.=40000016
+Param.val=0.81301015996447201228
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=-15.00000000000000000000
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000005
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000006
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000a
+Request.type=300
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00050001
+Entity.point[1].v=00050002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00060001
+Entity.point[1].v=00060002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.point[1].v=00080002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0000
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=000a0001
+Entity.point[1].v=000a0002
+Entity.point[2].v=000a0003
+Entity.point[3].v=000a0004
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0003
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=8.90683606737869837389
+Entity.actPoint.y=11.29451542357136872852
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0004
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000b
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000f
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030014
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030019
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030018
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003001d
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001d
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=80030021
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=8003001d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030027
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80030028
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030028
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030029
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002a
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002b
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=8003002a
+Entity.point[1].v=80030028
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002c
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002d
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80030028
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.actPoint.x=21.92366793841181049629
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vx=0.98657388986266281172
+Entity.actNormal.vy=-0.16331552235245294646
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000f
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050015
+Entity.point[2].v=80050016
+Entity.point[3].v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=8.90683606737869837389
+Entity.actPoint.y=11.29451542357136872852
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=8005001a
+Entity.point[2].v=8005001b
+Entity.point[3].v=8005001c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=8.90683606737869837389
+Entity.actPoint.y=11.29451542357136872852
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001a
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001b
+Entity.point[1].v=80050016
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050020
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001c
+Entity.point[1].v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050026
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050027
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050026
+Entity.point[1].v=80050024
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050029
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000001
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040001
+Constraint.ptB.v=00050002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000002
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050001
+Constraint.ptB.v=00060002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000003
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00060001
+Constraint.ptB.v=00070002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000004
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00040002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000006
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000007
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000008
+Constraint.type=61
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000009
+Constraint.type=62
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000a
+Constraint.type=50
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00070000
+Constraint.entityB.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000b
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=60.00000000000000000000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00070002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=10.00000000000000000000
+AddConstraint
+
+Constraint.h.v=0000000c
+Constraint.type=50
+Constraint.group.v=00000003
+Constraint.entityA.v=80030024
+Constraint.entityB.v=8003001f
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000d
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000d
+Constraint.ptA.v=00080001
+Constraint.entityA.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000e
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080002
+Constraint.ptB.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000f
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000f
+Constraint.ptA.v=00090002
+Constraint.entityA.v=80030004
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000010
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080001
+Constraint.ptB.v=000a0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090002
+Constraint.ptB.v=000a0004
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000012
+Constraint.type=41
+Constraint.group.v=00000005
+Constraint.ptA.v=80050019
+Constraint.entityA.v=00010000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000013
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=Corner
+Constraint.disp.offset.x=0.20241264915207013431
+Constraint.disp.offset.y=-3.59163429853392557334
+Constraint.disp.offset.z=-2.21417101842298524872
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000a0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=P1
+Constraint.disp.offset.x=1.63427326092519353828
+Constraint.disp.offset.y=1.80363269244023460836
+Constraint.disp.offset.z=-3.40170696078009004992
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000a0003
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=P2
+Constraint.disp.offset.x=0.00123499079765074238
+Constraint.disp.offset.y=-4.38799135888326219401
+Constraint.disp.offset.z=0.22945940412293114319
+AddConstraint
+
+Constraint.h.v=00000016
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=40000016
+Constraint.ptA.v=000a0002
+Constraint.entityA.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000017
+Constraint.type=121
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00080000
+Constraint.entityB.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000018
+Constraint.type=1000
+Constraint.group.v=00000005
+Constraint.ptA.v=8005000b
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=X
+Constraint.disp.offset.x=1.08410703351691650731
+Constraint.disp.offset.y=-1.27213983342871506110
+Constraint.disp.offset.z=-1.16687781431738568649
+AddConstraint
+
+Surface 00000001 00646464 8003002c 1 1
+SCtrl 0 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 0 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000009 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000004 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000005 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000a 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000016 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000017 0 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddSurface
+Surface 00000002 00646464 8003002d 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000003 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000001 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 0000000b 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000002 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030010 1 1
+SCtrl 0 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000b 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000008 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000a 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -16.24430311833935292043 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000c 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 0000001b 0 -16.24430311833933160415 -30.00000000000000000000 0.00000000000000000000  21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+TrimBy 0000001f 0 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000  21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000001c 0 -16.24430311833935292043 -30.00000000000000000000 30.00000000000000000000  -16.24430311833935292043 -30.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000004 00646464 80030019 1 1
+SCtrl 0 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000005 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000002 0 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000007 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000008 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000005 00646464 80030022 1 1
+SCtrl 0 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000004 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000003 0 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000006 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000007 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000006 00646464 80030007 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000009 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000001 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 0000000c 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000006 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000007 00646464 80050029 1 1
+SCtrl 0 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 29.99999999999999644729 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -16.24430311833934936772 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 29.99999999999999644729 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 00000008 00646464 80050028 1 1
+SCtrl 0 0 29.99999999999999644729 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 29.99999999999999644729 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -16.24430311833934936772 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000010 0 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000  29.99999999999999644729 18.78837126472273411082 0.00000000000000000000
+TrimBy 00000011 0 29.99999999999999644729 18.78837126472273411082 0.00000000000000000000  21.92366793841180694358 -30.00000000000000000000 0.00000000000000000000
+TrimBy 0000000d 0 21.92366793841180694358 -30.00000000000000000000 0.00000000000000000000  -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000009 00646464 00000000 3 1
+SCtrl 0 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 8.90683606737869837389 11.29451542357136872852 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 8.90683606737869837389 11.29451542357136872852 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 0 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 18.78060959786832029295 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 3 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 3 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000012 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+TrimBy 00000010 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000  -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+TrimBy 00000014 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+TrimBy 0000000e 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000  -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+AddSurface
+Surface 0000000a 00646464 80050010 1 1
+SCtrl 0 0 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000f 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000011 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000  30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+TrimBy 00000013 0 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000  21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+TrimBy 00000014 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddSurface
+Surface 0000000b 00646464 80050007 1 1
+SCtrl 0 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000002 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000002 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000002 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000001 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000001 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000005 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000004 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000003 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000001 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000000a 1 1 00000001 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000002 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000006 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000008 0000000b
+CCtrl 0 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000e 1 1 0000000b 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000f 1 1 00000007 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000010 1 3 00000008 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 8.90683606737869837389 11.29451542357136872852 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+CurvePt 0 -5.06641172126718863922 -28.21098985320366736573 0.00000000000000000000
+CurvePt 0 2.79127811802641412342 -23.43064046754898654967 0.00000000000000000000
+CurvePt 0 12.10225423467521466137 -8.41601030807039407478 0.00000000000000000000
+CurvePt 0 18.80102745440157008261 8.00371782162407541250 0.00000000000000000000
+CurvePt 0 23.39346367254211855879 14.54043967004861137582 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 00000011 1 1 00000008 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000012 1 3 00000007 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 8.90683606737869837389 11.29451542357136872852 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 0 -5.06641172126718863922 -28.21098985320366736573 30.00000000000000000000
+CurvePt 0 2.79127811802641412342 -23.43064046754898654967 30.00000000000000000000
+CurvePt 0 12.10225423467521466137 -8.41601030807039407478 30.00000000000000000000
+CurvePt 0 18.80102745440157008261 8.00371782162407541250 30.00000000000000000000
+CurvePt 0 23.39346367254211855879 14.54043967004861137582 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 00000013 1 1 0000000a 0000000b
+CCtrl 0 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000014 1 1 00000009 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 00000015 1 1 00000007 0000000b
+CCtrl 0 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000016 1 3 00000001 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 8.90683606737869837389 11.29451542357136872852 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 0 -5.06641172126718863922 -28.21098985320366736573 30.00000000000000000000
+CurvePt 0 2.79127811802641412342 -23.43064046754898654967 30.00000000000000000000
+CurvePt 0 12.10225423467521466137 -8.41601030807039407478 30.00000000000000000000
+CurvePt 0 18.80102745440157008261 8.00371782162407541250 30.00000000000000000000
+CurvePt 0 23.39346367254211855879 14.54043967004861137582 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 00000017 1 1 00000001 0000000a
+CCtrl 0 21.92366793841181404900 -29.99999999999999644729 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 29.99999999999999644729 18.78837126472270924182 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 00000018 1 1 00000001 0000000b
+CCtrl 0 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 21.92366793841181404900 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000019 1 1 00000003 00000007
+CCtrl 0 29.99999999999998223643 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833935292043 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 29.99999999999998223643 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833935292043 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000001a 1 1 00000006 00000007
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -29.99999999999999289457 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -29.99999999999999289457 30.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 00000003 00000008
+CCtrl 0 -16.24430311833933515686 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833933515686 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001c 1 1 00000003 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001d 1 1 00000006 00000008
+CCtrl 0 30.00000000000000000000 -29.99999999999999289457 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -29.99999999999999289457 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 0000001e 1 1 00000006 00000009
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 0000001f 1 1 00000003 0000000a
+CCtrl 0 21.92366793841180694358 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 21.92366793841180694358 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 21.92366793841181049629 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000020 1 1 00000006 0000000a
+CCtrl 0 29.99999999999998578915 18.78837126472279805967 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 29.99999999999998578915 18.78837126472279805967 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve

--- a/test/group/boolean_grazing_edge/test.cpp
+++ b/test/group/boolean_grazing_edge/test.cpp
@@ -1,0 +1,32 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// A cube minus a fillet-shaped tool that lies entirely inside the cube,
+// except that the edge between the tool's two side surfaces lies exactly in
+// a face of the cube, since its profile's corner is constrained onto the
+// cube's edge. The tool grazes that face without cutting it, so the
+// resulting surfaces touch the face's interior along the grazing edge; that
+// tangential touch must not be reported as a self-intersection (issue #1291;
+// the model is ruevs' relocated cube_cut).
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The cube is 60³ = 216000 mm³; the tool cuts away a groove bounded by
+    // the spline surface, roughly 20000 mm³.
+    CHECK_EQ_EPS(m->CalculateVolume() / 196108.6117657832, 1.0);
+}

--- a/test/group/boolean_knife_edge/normal.slvs
+++ b/test/group/boolean_knife_edge/normal.slvs
@@ -1,0 +1,2229 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=sketch-in-plane
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=extrude
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 00070000 1002
+    29 00070001 1002
+    30 00070002 1002
+    31 00070000 1001
+    32 00070001 1001
+    33 00070002 1001
+    34 00070000 1004
+    35 00070001 1003
+    36 00070002 1003
+    37 00080000 1002
+    38 00080001 1002
+    39 00080002 1002
+    40 00080000 1001
+    41 00080001 1001
+    42 00080002 1001
+    43 00080000 1004
+    44 00080001 1003
+    45 00080002 1003
+    46 00090000 1002
+    47 00090001 1002
+    48 00090002 1002
+    49 00090000 1001
+    50 00090001 1001
+    51 00090002 1001
+    52 00090000 1004
+    53 00090001 1003
+    54 00090002 1003
+    55 000a0000 1002
+    56 000a0001 1002
+    57 000a0002 1002
+    58 000a0000 1001
+    59 000a0001 1001
+    60 000a0002 1001
+    61 000a0000 1004
+    62 000a0001 1003
+    63 000a0002 1003
+    64 000b0000 1002
+    65 000b0001 1002
+    66 000b0002 1002
+    67 000b0000 1001
+    68 000b0001 1001
+    69 000b0002 1001
+    70 000b0000 1004
+    71 000b0001 1003
+    72 000b0002 1003
+    73 80020000 1002
+    74 80020000 1001
+    75 80020001 1002
+    76 80020002 1002
+    77 80020001 1001
+    78 80020002 1001
+    79 80020002 1003
+    80 00000000 1001
+    81 00000000 1002
+    82 000f0000 1002
+    83 000f0001 1002
+    84 000f0002 1002
+    85 000f0000 1001
+    86 000f0001 1001
+    87 000f0002 1001
+    88 000f0000 1004
+    89 000f0001 1003
+    90 000f0002 1003
+    91 00100000 1002
+    92 00100001 1002
+    93 00100002 1002
+    94 00100000 1001
+    95 00100001 1001
+    96 00100002 1001
+    97 00100000 1004
+    98 00100001 1003
+    99 00100002 1003
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=sketch-in-plane
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6001
+Group.skipFirst=0
+Group.predef.origin.v=80030042
+Group.predef.entityB.v=8003001c
+Group.predef.entityC.v=80030037
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=1
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=extrude
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 000c0000 1002
+    2 000c0001 1002
+    3 000c0002 1002
+    4 000c0000 1001
+    5 000c0001 1001
+    6 000c0002 1001
+    7 000c0000 1004
+    8 000c0001 1003
+    9 000c0002 1003
+    10 000d0000 1002
+    11 000d0001 1002
+    12 000d0002 1002
+    13 000d0000 1001
+    14 000d0001 1001
+    15 000d0002 1001
+    16 000d0000 1004
+    17 000d0001 1003
+    18 000d0002 1003
+    19 000e0000 1002
+    20 000e0001 1002
+    21 000e0002 1002
+    22 000e0003 1002
+    23 000e0020 1002
+    24 000e0000 1001
+    25 000e0001 1001
+    26 000e0002 1001
+    27 000e0003 1001
+    28 000e0020 1001
+    29 000e0001 1003
+    30 000e0002 1003
+    31 000e0003 1003
+    32 80040000 1002
+    33 80040000 1001
+    34 80040001 1002
+    35 80040002 1002
+    36 80040001 1001
+    37 80040002 1001
+    38 80040002 1003
+    39 00000000 1001
+    40 00000000 1002
+    41 000e0000 1004
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+AddParam
+
+Param.h.v.=00040011
+Param.val=-1.61260523905064823147
+AddParam
+
+Param.h.v.=00040013
+AddParam
+
+Param.h.v.=00040014
+AddParam
+
+Param.h.v.=00070010
+AddParam
+
+Param.h.v.=00070011
+AddParam
+
+Param.h.v.=00070013
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=00070014
+AddParam
+
+Param.h.v.=000a0010
+AddParam
+
+Param.h.v.=000a0011
+AddParam
+
+Param.h.v.=000a0013
+AddParam
+
+Param.h.v.=000a0014
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=000b0010
+Param.val=1.54983460368207648372
+AddParam
+
+Param.h.v.=000b0011
+AddParam
+
+Param.h.v.=000b0013
+AddParam
+
+Param.h.v.=000b0014
+AddParam
+
+Param.h.v.=000c0010
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=000c0011
+AddParam
+
+Param.h.v.=000c0013
+AddParam
+
+Param.h.v.=000c0014
+AddParam
+
+Param.h.v.=000d0010
+AddParam
+
+Param.h.v.=000d0011
+AddParam
+
+Param.h.v.=000d0013
+AddParam
+
+Param.h.v.=000d0014
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=000e0010
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=000e0011
+AddParam
+
+Param.h.v.=000e0013
+AddParam
+
+Param.h.v.=000e0014
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=000f0010
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=000f0011
+AddParam
+
+Param.h.v.=000f0013
+AddParam
+
+Param.h.v.=000f0014
+Param.val=-1.61260523905064823147
+AddParam
+
+Param.h.v.=00100010
+Param.val=1.54983460368207648372
+AddParam
+
+Param.h.v.=00100011
+AddParam
+
+Param.h.v.=00100013
+AddParam
+
+Param.h.v.=00100014
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=0.24917011440269723477
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000a
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000b
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000c
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000d
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000e
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000f
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000010
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000a0001
+Entity.point[1].v=000a0002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000b0001
+Entity.point[1].v=000b0002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=1.54983460368207648372
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000c0001
+Entity.point[1].v=000c0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000d0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000d0001
+Entity.point[1].v=000d0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000d0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000d0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000e0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000e0001
+Entity.point[1].v=000e0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000e0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000e0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000f0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000f0001
+Entity.point[1].v=000f0002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000f0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000f0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00100000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00100001
+Entity.point[1].v=00100002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00100001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=1.54983460368207648372
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00100002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003001d
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001d
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=80030021
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=8003001d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030037
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030038
+Entity.point[1].v=80030039
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030038
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030039
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003003b
+Entity.point[1].v=8003003c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003d
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8003003b
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003003b
+Entity.point[1].v=80030038
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003003c
+Entity.point[1].v=80030039
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030040
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030041
+Entity.point[1].v=80030042
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030041
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.54983460368207648372
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030042
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030043
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030044
+Entity.point[1].v=80030045
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030044
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.54983460368207648372
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030045
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030046
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030044
+Entity.actPoint.x=1.54983460368207648372
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030047
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030044
+Entity.point[1].v=80030041
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030048
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030045
+Entity.point[1].v=80030042
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003004b
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003004c
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003004c
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003004d
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003004e
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003004e
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003004f
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=8003004e
+Entity.point[1].v=8003004c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030050
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003004e
+Entity.actPoint.z=1.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030051
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003004c
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030052
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030053
+Entity.point[1].v=80030054
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030053
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030054
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030055
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030056
+Entity.point[1].v=80030057
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030056
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030057
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-1.61260523905064823147
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030058
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030056
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actNormal.vx=0.84985908367046281153
+Entity.actNormal.vy=0.52700999791541092154
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030059
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030056
+Entity.point[1].v=80030053
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003005a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030057
+Entity.point[1].v=80030054
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003005b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003005c
+Entity.point[1].v=8003005d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003005c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.54983460368207648372
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003005d
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003005e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003005f
+Entity.point[1].v=80030060
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003005f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.54983460368207648372
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030060
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030061
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8003005f
+Entity.actPoint.x=1.54983460368207648372
+Entity.actNormal.vx=-0.54216771927521723029
+Entity.actNormal.vy=-0.84027029233212158221
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030062
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003005f
+Entity.point[1].v=8003005c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030063
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030060
+Entity.point[1].v=8003005d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000f
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=8005001a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001a
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050022
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050023
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050025
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=0.49834022880539446954
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050026
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050025
+Entity.point[1].v=80050023
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050027
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050025
+Entity.actPoint.z=0.49834022880539446954
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050023
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050029
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actNormal.vx=-0.70710678118654746172
+Entity.actNormal.vy=0.70710678118654746172
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000004
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00040002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000005
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00040000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000008
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00070000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000b
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000a0001
+Constraint.ptB.v=000b0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000f
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=000a0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000010
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=000b0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=000a0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000012
+Constraint.type=50
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00070000
+Constraint.entityB.v=000a0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000013
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=8003001e
+Constraint.ptB.v=000c0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=80040002
+Constraint.ptB.v=000c0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=80040002
+Constraint.ptB.v=000d0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000016
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=80030039
+Constraint.ptB.v=000d0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000017
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000c0001
+Constraint.ptB.v=000e0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000018
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000d0002
+Constraint.ptB.v=000e0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000019
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070002
+Constraint.ptB.v=000f0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001a
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040001
+Constraint.ptB.v=000f0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001b
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000b0001
+Constraint.ptB.v=00100001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001c
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000a0002
+Constraint.ptB.v=00100002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001d
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=80020002
+Constraint.ptB.v=000b0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001e
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=1.00000000000000000000
+Constraint.ptA.v=000a0001
+Constraint.ptB.v=000a0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=0.92176438157236606497
+Constraint.disp.offset.y=-0.00000000000000000988
+AddConstraint
+
+Constraint.h.v=0000001f
+Constraint.type=30
+Constraint.group.v=00000003
+Constraint.valA=1.00000000000000000000
+Constraint.ptA.v=80030045
+Constraint.ptB.v=80030042
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=0.30989527145288076060
+Constraint.disp.offset.y=0.31869450617176736662
+AddConstraint
+
+Surface 00000001 00646464 80030050 1 1
+SCtrl 0 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -1.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000004 0 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000  -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 0000000e 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000
+TrimBy 00000001 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+AddSurface
+Surface 00000002 00646464 80030051 1 1
+SCtrl 0 0 1.60992452418024134531 1.06008992049816486158 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -1.06008992049816486158 1.06008992049816486158 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 1.60992452418024134531 -1.67269515954881309305 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -1.06008992049816486158 -1.67269515954881309305 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000008 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000
+TrimBy 0000000f 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 0000001b 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000  -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000011 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  1.54983460368207648372 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000003 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030058 1 1
+SCtrl 0 0 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000012 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 00000008 0 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000  -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 0000000a 0 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000  0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000
+TrimBy 00000004 1 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000
+AddSurface
+Surface 00000004 00646464 80030022 1 1
+SCtrl 0 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000005 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539441402  0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 00000012 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000  -1.00000000000000000000 0.00000000000000000000 0.49834022880539441402
+TrimBy 00000001 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000  -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 0000001d 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539441402  0.00000000000000000000 0.00000000000000000000 0.49834022880539441402
+AddSurface
+Surface 00000005 00646464 80030007 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000f 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000
+TrimBy 0000000a 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000  0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000
+TrimBy 0000000e 1 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 00000005 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000006 00646464 80030050 1 1
+SCtrl 0 0 0.00000000000000000000 0.99999999999999977796 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 1.54983460368207648372 0.99999999999999977796 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000002 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 0.99999999999999977796 1.00000000000000000000
+TrimBy 0000000b 0 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 00000006 0 0.00000000000000000000 0.99999999999999977796 1.00000000000000000000  1.54983460368207648372 0.00000000000000000000 1.00000000000000000000
+AddSurface
+Surface 00000008 00646464 8003003d 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000007 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539441402  0.00000000000000000000 1.00000000000000000000 1.00000000000000000000
+TrimBy 00000009 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.49834022880539441402
+TrimBy 00000002 1 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 0000001c 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539441402  0.00000000000000000000 1.00000000000000000000 0.49834022880539441402
+AddSurface
+Surface 00000009 00646464 80030061 1 1
+SCtrl 0 0 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000003 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000  1.54983460368207648372 0.00000000000000000000 0.00000000000000000000
+TrimBy 0000000c 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000  1.54983460368207648372 0.00000000000000000000 1.00000000000000000000
+TrimBy 00000006 1 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000  0.00000000000000000000 1.00000000000000000000 1.00000000000000000000
+TrimBy 00000007 0 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000  0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 0000000a 00646464 80030046 1 1
+SCtrl 0 0 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000009 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+TrimBy 00000011 0 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 0000000c 0 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000  1.54983460368207648372 0.00000000000000000000 0.00000000000000000000
+TrimBy 0000000b 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000  1.54983460368207648372 0.00000000000000000000 1.00000000000000000000
+AddSurface
+Surface 0000000b 00646464 80050027 1 1
+SCtrl 0 0 -1.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 1 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+TrimBy 00000016 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954  0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+TrimBy 00000017 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954  0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+TrimBy 00000014 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954  -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddSurface
+Surface 0000000d 00646464 80050029 1 1
+SCtrl 0 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 0 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000016 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954  -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+TrimBy 0000001b 0 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+TrimBy 00000015 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000  0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+TrimBy 00000013 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954  -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 0000000e 00646464 80050010 1 1
+SCtrl 0 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 0000000f 00646464 80050007 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+SCtrl 1 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000001 00000004
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000006 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000002 00000009
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000001 00000003
+CCtrl 0 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000004 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000006 00000009
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000
+CurvePt 1 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000008 00000009
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000002 00000003
+CCtrl 0 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000009 1 1 0000000a 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000a 1 1 00000005 00000003
+CCtrl 0 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000006 0000000a
+CCtrl 0 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000009 0000000a
+CCtrl 0 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.54983460368207648372 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000002 00000004
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000e 1 1 00000001 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -1.61260523905064823147 1.00000000000000000000
+AddCurve
+Curve 0000000f 1 1 00000002 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 -1.61260523905064823147 0.00000000000000000000
+AddCurve
+Curve 00000010 1 1 00000002 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000011 1 1 00000002 0000000a
+CCtrl 0 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.54983460368207648372 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000012 1 1 00000003 00000004
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000013 1 1 0000000f 0000000d
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000014 1 1 0000000b 0000000f
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000015 1 1 0000000d 0000000e
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000016 1 1 0000000b 0000000d
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000017 1 1 0000000b 0000000e
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000018 1 1 00000002 0000000f
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000019 1 1 00000002 0000000e
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001a 1 1 0000000e 0000000f
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 00000002 0000000d
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001c 1 1 00000008 0000000b
+CCtrl 0 -0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 0000001d 1 1 00000004 0000000b
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 0000001e 1 1 00000003 0000000d
+CCtrl 0 -1.00000000000000000000 0.00000000000000005551 0.49834022880539446954 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000005551 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001f 1 1 00000004 00000002
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000020 1 1 00000003 0000000f
+CCtrl 0 -0.99999999999999988898 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.99999999999999988898 0.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000021 1 1 00000004 0000000d
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000022 1 1 00000009 0000000d
+CCtrl 0 -0.00000000000000011102 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000011102 1.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000023 1 1 0000000a 0000000e
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve
+Curve 00000024 1 1 00000005 0000000f
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000025 1 1 00000008 00000002
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000026 1 1 00000004 0000000e
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000027 1 1 00000002 0000000e
+CCtrl 0 0.00000000000000000000 0.99999999999999977796 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000028 1 1 00000009 0000000e
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000029 1 1 00000002 0000000f
+CCtrl 0 0.00000000000000000000 -0.00000000000000000000 -0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000002a 1 1 00000008 0000000d
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.49834022880539446954
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000002b 1 1 00000008 0000000f
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539441402 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.49834022880539446954
+AddCurve

--- a/test/group/boolean_knife_edge/test.cpp
+++ b/test/group/boolean_knife_edge/test.cpp
@@ -19,7 +19,7 @@ TEST_CASE(normal_watertight_volume) {
     SEdgeList el = {};
     bool inters, leaks;
     SKdNode::From(m)->MakeCertainEdgesInto(&el,
-        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+        EdgeKind::NAKED_OR_SELF_INTER, &inters, &leaks);
     CHECK_FALSE(inters);
     CHECK_FALSE(leaks);
     CHECK_TRUE(el.l.IsEmpty());

--- a/test/group/boolean_knife_edge/test.cpp
+++ b/test/group/boolean_knife_edge/test.cpp
@@ -1,0 +1,32 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// Two triangular prisms extruded together, sharing only a single vertical
+// edge, plus a third prism whose edge lies along that shared line: regions
+// of the shell join along a knife edge there, so the third prism's edge
+// falls on four coincident edges of the shell (the edge_inters == 4 case in
+// SShell::ClassifyEdge(), issue #1091). Before that case was handled, the
+// Boolean failed to assemble the trim polygon and left naked edges.
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The expected volume from the sketch: the two big prisms are
+    // (0.5*1.6126052390506482 + 0.5*1.5498346036820765)*1.0 and the small
+    // one is 0.5*1*1*0.49834022880539446.
+    CHECK_EQ_EPS(m->CalculateVolume() / 1.8303900357690596, 1.0);
+}

--- a/test/group/boolean_tangent_edge/normal.slvs
+++ b/test/group/boolean_tangent_edge/normal.slvs
@@ -1,0 +1,2006 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=sketch-in-plane
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=extrude
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 00070000 1002
+    29 00070001 1002
+    30 00070002 1002
+    31 00070000 1001
+    32 00070001 1001
+    33 00070002 1001
+    34 00070000 1004
+    35 00070001 1003
+    36 00070002 1003
+    37 00080000 1002
+    38 00080001 1002
+    39 00080002 1002
+    40 00080000 1001
+    41 00080001 1001
+    42 00080002 1001
+    43 00080000 1004
+    44 00080001 1003
+    45 00080002 1003
+    46 00090000 1002
+    47 00090001 1002
+    48 00090002 1002
+    49 00090000 1001
+    50 00090001 1001
+    51 00090002 1001
+    52 00090000 1004
+    53 00090001 1003
+    54 00090002 1003
+    55 80020000 1002
+    56 80020000 1001
+    57 80020001 1002
+    58 80020002 1002
+    59 80020001 1001
+    60 80020002 1001
+    61 80020002 1003
+    62 00000000 1001
+    63 00000000 1002
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=sketch-in-plane
+Group.activeWorkplane.v=80040000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=extrude
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.meshCombine=1
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 000a0000 1002
+    2 000a0001 1002
+    3 000a0002 1002
+    4 000a0000 1001
+    5 000a0001 1001
+    6 000a0002 1001
+    7 000a0000 1004
+    8 000a0001 1003
+    9 000a0002 1003
+    10 000b0000 1002
+    11 000b0001 1002
+    12 000b0002 1002
+    13 000b0000 1001
+    14 000b0001 1001
+    15 000b0002 1001
+    16 000b0000 1004
+    17 000b0001 1003
+    18 000b0002 1003
+    19 000c0000 1002
+    20 000c0001 1002
+    21 000c0002 1002
+    22 000c0000 1001
+    23 000c0001 1001
+    24 000c0002 1001
+    25 000c0000 1004
+    26 000c0001 1003
+    27 000c0002 1003
+    28 80040000 1002
+    29 80040000 1001
+    30 80040001 1002
+    31 80040002 1002
+    32 80040001 1001
+    33 80040002 1001
+    34 80040002 1003
+    35 00000000 1001
+    36 00000000 1002
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+AddParam
+
+Param.h.v.=00040011
+AddParam
+
+Param.h.v.=00040013
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00040014
+AddParam
+
+Param.h.v.=00050010
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00050011
+AddParam
+
+Param.h.v.=00050013
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00050014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00060010
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00060011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00060013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00060014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070014
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00080010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00080011
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00080013
+AddParam
+
+Param.h.v.=00080014
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00090010
+AddParam
+
+Param.h.v.=00090011
+Param.val=80.00000000000000000000
+AddParam
+
+Param.h.v.=00090013
+AddParam
+
+Param.h.v.=00090014
+AddParam
+
+Param.h.v.=000a0010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=000a0011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=000a0013
+Param.val=10.00000000000000000000
+AddParam
+
+Param.h.v.=000a0014
+Param.val=50.00000000000000000000
+AddParam
+
+Param.h.v.=000b0010
+Param.val=10.00000000000000000000
+AddParam
+
+Param.h.v.=000b0011
+Param.val=50.00000000000000000000
+AddParam
+
+Param.h.v.=000b0013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=000b0014
+Param.val=50.00000000000000000000
+AddParam
+
+Param.h.v.=000c0010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=000c0011
+Param.val=50.00000000000000000000
+AddParam
+
+Param.h.v.=000c0013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=000c0014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=40.00000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=40.00000000000000000000
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000005
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000006
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000a
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000b
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000c
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00050001
+Entity.point[1].v=00050002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00060001
+Entity.point[1].v=00060002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.point[1].v=00080002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000a0001
+Entity.point[1].v=000a0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000b0001
+Entity.point[1].v=000b0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=000c0001
+Entity.point[1].v=000c0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000b
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.actPoint.x=80.00000000000000000000
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000f
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030014
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030019
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.actPoint.x=80.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030018
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003001d
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001d
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=80030021
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=8003001d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030025
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030026
+Entity.point[1].v=80030027
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030026
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030027
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030028
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030029
+Entity.point[1].v=8003002a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030029
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=80.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002b
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030029
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=80.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030029
+Entity.point[1].v=80030026
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.point[1].v=80030027
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003002f
+Entity.point[1].v=80030030
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030030
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030031
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030032
+Entity.point[1].v=80030033
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030032
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=80.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030033
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030034
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030032
+Entity.actPoint.y=80.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030035
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030032
+Entity.point[1].v=8003002f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030036
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030033
+Entity.point[1].v=80030030
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030039
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003003a
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003a
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003b
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003003c
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003c
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003d
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=8003003c
+Entity.point[1].v=8003003a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003e
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003003c
+Entity.actPoint.z=80.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003003f
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003003a
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vx=-0.70710678118654757274
+Entity.actNormal.vy=-0.70710678118654757274
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.actPoint.x=10.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000f
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050017
+Entity.point[1].v=80050018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050017
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=50.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050017
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050018
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005001f
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001f
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050020
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050021
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050021
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=80.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050022
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050021
+Entity.point[1].v=8005001f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050021
+Entity.actPoint.z=80.00000000000000000000
+Entity.actNormal.vz=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8005001f
+Entity.actNormal.vz=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Surface 00000001 00646464 8003003f 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 80.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000012 0 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000  30.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+TrimBy 00000004 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000009 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  80.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000003 0 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000  80.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+TrimBy 0000000d 0 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000  30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+TrimBy 00000006 0 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000  0.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+TrimBy 0000001d 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000  10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+TrimBy 00000021 0 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000  30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000002 00646464 8003003e 1 1
+SCtrl 0 0 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 80.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000f 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000  80.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+TrimBy 0000000c 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000  0.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+TrimBy 00000005 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000  0.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+TrimBy 0000000b 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000  80.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+TrimBy 00000001 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000  30.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+TrimBy 00000010 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000  30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+TrimBy 00000023 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000  10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+TrimBy 0000001e 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000  30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030007 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000009 1 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000005 0 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000  80.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+TrimBy 00000002 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000  80.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000008 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 00000004 00646464 80030010 1 1
+SCtrl 0 0 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000003 1 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000  80.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 0000000b 0 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000  80.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+TrimBy 0000000e 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000  80.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+TrimBy 00000002 0 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000  80.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 00000005 00646464 80030019 1 1
+SCtrl 0 0 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000d 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000  80.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+TrimBy 0000000f 0 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000  30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+TrimBy 0000000e 0 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000  80.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+TrimBy 00000011 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000  30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000006 00646464 80030022 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000010 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000  30.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+TrimBy 0000000a 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000  30.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+TrimBy 00000012 1 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000  30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+TrimBy 00000026 0 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000  30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 00000007 00646464 8003002b 1 1
+SCtrl 0 0 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000006 1 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000  30.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+TrimBy 00000001 0 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000  0.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+TrimBy 00000007 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000  0.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+TrimBy 0000000a 0 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000  30.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 00000008 00646464 80030034 1 1
+SCtrl 0 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000004 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+TrimBy 0000000c 0 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000  0.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+TrimBy 00000008 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000007 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000  0.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 00000009 00646464 80050023 1 1
+SCtrl 0 0 10.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 0000000a 00646464 80050024 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 10.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 0000000b 00646464 80050007 1 1
+SCtrl 0 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000017 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000  10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+TrimBy 00000019 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000  30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+TrimBy 00000013 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000  10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+TrimBy 00000018 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000  30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 0000000c 00646464 80050010 1 1
+SCtrl 0 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000014 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000  30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+TrimBy 00000016 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000  10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+TrimBy 00000015 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000  30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+TrimBy 00000013 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000  10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddSurface
+Surface 0000000d 00646464 80050019 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000002 00000007
+CCtrl 0 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+CurvePt 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000003 00000004
+CCtrl 0 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000001 00000004
+CCtrl 0 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000001 00000008
+CCtrl 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000002 00000003
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+CurvePt 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000001 00000007
+CCtrl 0 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000007 00000008
+CCtrl 0 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000008 00000003
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000001 00000003
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 80.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000a 1 1 00000006 00000007
+CCtrl 0 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000002 00000004
+CCtrl 0 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 80.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+CurvePt 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000002 00000008
+CCtrl 0 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000001 00000005
+CCtrl 0 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000e 1 1 00000004 00000005
+CCtrl 0 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 80.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000000f 1 1 00000002 00000005
+CCtrl 0 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 80.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000010 1 1 00000002 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 80.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000011 1 1 00000005 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000012 1 1 00000001 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 80.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000013 1 1 0000000b 0000000c
+CCtrl 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000014 1 1 00000009 0000000c
+CCtrl 0 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000015 1 1 0000000c 0000000d
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000016 1 1 0000000a 0000000c
+CCtrl 0 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000017 1 1 00000009 0000000b
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000018 1 1 0000000d 0000000b
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000019 1 1 0000000a 0000000b
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001a 1 1 00000009 0000000d
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 0000000a 0000000d
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001c 1 1 00000006 00000009
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000001d 1 1 00000001 0000000b
+CCtrl 0 29.99999999999999644729 29.99999999999999644729 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 9.99999999999999289457 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001e 1 1 00000002 0000000b
+CCtrl 0 9.99999999999999289457 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 29.99999999999999644729 29.99999999999999644729 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 0000001f 1 1 00000005 0000000b
+CCtrl 0 29.99999999999999644729 30.00000000000000355271 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 29.99999999999999644729 30.00000000000000355271 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000020 1 1 00000006 0000000a
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000021 1 1 00000001 0000000c
+CCtrl 0 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000022 1 1 00000005 0000000d
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000023 1 1 00000002 0000000c
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+CurvePt 1 10.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000024 1 1 00000006 0000000b
+CCtrl 0 30.00000000000000355271 29.99999999999999644729 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000355271 29.99999999999999644729 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000025 1 1 00000001 0000000d
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000026 1 1 00000006 0000000c
+CCtrl 0 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddCurve
+Curve 00000027 1 1 00000002 0000000d
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 80.00000000000000000000
+CurvePt 1 30.00000000000000000000 50.00000000000000000000 80.00000000000000000000
+AddCurve

--- a/test/group/boolean_tangent_edge/test.cpp
+++ b/test/group/boolean_tangent_edge/test.cpp
@@ -1,0 +1,34 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// An L-section extrusion minus a triangular prism. One face plane of the
+// prism passes tangentially through the L-section's concave vertical edge,
+// and the prism shares an edge with it there, so edges of each shell lie on
+// edges of the other: the tangent edge-on-edge cases in
+// SShell::ClassifyEdge(). The prism's edge classifies against the L-shell's
+// concave edge as inside, and the L-shell's edge against the prism's convex
+// edge as outside. Before those cases were handled, this model's Boolean
+// failed or succeeded depending on uninitialized memory (issue #1619).
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The expected volume from the sketch: the L-section is
+    // 80*30 + 30*80 - 30*30 = 3900 mm² minus the 200 mm² notch, extruded
+    // 80 mm, giving 296000 mm³.
+    CHECK_EQ_EPS(m->CalculateVolume() / 296000.0, 1.0);
+}

--- a/test/group/boolean_tangent_edge/test.cpp
+++ b/test/group/boolean_tangent_edge/test.cpp
@@ -21,7 +21,7 @@ TEST_CASE(normal_watertight_volume) {
     SEdgeList el = {};
     bool inters, leaks;
     SKdNode::From(m)->MakeCertainEdgesInto(&el,
-        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+        EdgeKind::NAKED_OR_SELF_INTER, &inters, &leaks);
     CHECK_FALSE(inters);
     CHECK_FALSE(leaks);
     CHECK_TRUE(el.l.IsEmpty());

--- a/test/group/boolean_tangent_fillet/normal.slvs
+++ b/test/group/boolean_tangent_fillet/normal.slvs
@@ -1,0 +1,1820 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=sketch-in-plane
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=extrude
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 80020000 1002
+    29 80020000 1001
+    30 80020001 1002
+    31 80020002 1002
+    32 80020001 1001
+    33 80020002 1001
+    34 80020002 1003
+    35 00000000 1001
+    36 00000000 1002
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=sketch-in-plane
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=extrude
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.meshCombine=1
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00070000 1002
+    2 00070001 1002
+    3 00070002 1002
+    4 00070000 1001
+    5 00070001 1001
+    6 00070002 1001
+    7 00070000 1004
+    8 00070001 1003
+    9 00070002 1003
+    10 00080000 1002
+    11 00080001 1002
+    12 00080002 1002
+    13 00080000 1001
+    14 00080001 1001
+    15 00080002 1001
+    16 00080000 1004
+    17 00080001 1003
+    18 00080002 1003
+    19 00090000 1002
+    20 00090001 1002
+    21 00090002 1002
+    22 00090003 1002
+    23 00090020 1002
+    24 00090000 1001
+    25 00090001 1001
+    26 00090002 1001
+    27 00090003 1001
+    28 00090020 1001
+    29 00090001 1003
+    30 00090002 1003
+    31 00090003 1003
+    32 80040000 1002
+    33 80040000 1001
+    34 80040001 1002
+    35 80040002 1002
+    36 80040001 1001
+    37 80040002 1001
+    38 80040002 1003
+    39 00000000 1001
+    40 00000000 1002
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+AddParam
+
+Param.h.v.=00040011
+Param.val=-2.00000000000000000000
+AddParam
+
+Param.h.v.=00040013
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00040014
+AddParam
+
+Param.h.v.=00050010
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00050011
+AddParam
+
+Param.h.v.=00050013
+AddParam
+
+Param.h.v.=00050014
+AddParam
+
+Param.h.v.=00060010
+AddParam
+
+Param.h.v.=00060011
+AddParam
+
+Param.h.v.=00060013
+AddParam
+
+Param.h.v.=00060014
+Param.val=-2.00000000000000000000
+AddParam
+
+Param.h.v.=00070010
+AddParam
+
+Param.h.v.=00070011
+AddParam
+
+Param.h.v.=00070013
+Param.val=-0.00000000000000000000
+AddParam
+
+Param.h.v.=00070014
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00080010
+AddParam
+
+Param.h.v.=00080011
+AddParam
+
+Param.h.v.=00080013
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00080014
+Param.val=-0.00000000000000000000
+AddParam
+
+Param.h.v.=00090010
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00090011
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00090013
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00090014
+Param.val=-0.00000000000000000000
+AddParam
+
+Param.h.v.=00090016
+Param.val=-0.00000000000000000000
+AddParam
+
+Param.h.v.=00090017
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=4000000b
+Param.val=0.25000000000000000000
+AddParam
+
+Param.h.v.=4000000d
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=-0.25000000000000000000
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000005
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000006
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=500
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00050001
+Entity.point[1].v=00050002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00060001
+Entity.point[1].v=00060002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.point[1].v=00080002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.point[2].v=00090003
+Entity.normal.v=00090020
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090003
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090020
+Entity.type=3001
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.workplane.v=80040000
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actNormal.vx=0.89442719099991585541
+Entity.actNormal.vy=-0.44721359549995792770
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000b
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000c
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030010
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000f
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030014
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030014
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=-2.00000000000000000000
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030019
+Entity.type=5001
+Entity.construction=0
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030018
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003001f
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.actPoint.z=-1.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003001f
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=5001
+Entity.construction=0
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actNormal.vy=0.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=5001
+Entity.construction=0
+Entity.actNormal.vx=-0.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000f
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050015
+Entity.point[2].v=80050016
+Entity.normal.v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=8005001a
+Entity.point[2].v=8005001b
+Entity.normal.v=8005001c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.y=-0.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.y=-0.50000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001c
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001a
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001b
+Entity.point[1].v=80050016
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050022
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050023
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050025
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050026
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050025
+Entity.point[1].v=80050023
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050027
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050025
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actNormal.vz=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050023
+Entity.actNormal.vz=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000001
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040002
+Constraint.ptB.v=00050001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000002
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=80020002
+Constraint.ptB.v=00050002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000003
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000004
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=80020002
+Constraint.ptB.v=00060001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000005
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040001
+Constraint.ptB.v=00060002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000006
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000007
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=1.00000000000000000000
+Constraint.ptA.v=00050001
+Constraint.ptB.v=00050002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=1.10885523616734715802
+Constraint.disp.offset.y=0.28873383007360320374
+AddConstraint
+
+Constraint.h.v=00000008
+Constraint.type=51
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=2.00000000000000000000
+Constraint.entityA.v=00060000
+Constraint.entityB.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=-0.76687050448578786277
+Constraint.disp.offset.y=-0.87120662754508071401
+AddConstraint
+
+Constraint.h.v=00000009
+Constraint.type=50
+Constraint.group.v=00000003
+Constraint.entityA.v=8003001a
+Constraint.entityB.v=8003000a
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000a
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=80040002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000b
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000b
+Constraint.ptA.v=00070002
+Constraint.entityA.v=80030013
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000c
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=80040002
+Constraint.ptB.v=00080001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000d
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000d
+Constraint.ptA.v=00080002
+Constraint.entityA.v=8003000a
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000010
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080002
+Constraint.ptB.v=00090002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00070002
+Constraint.ptB.v=00090003
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000012
+Constraint.type=123
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00090000
+Constraint.entityB.v=00070000
+Constraint.other=1
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000013
+Constraint.type=123
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00090000
+Constraint.entityB.v=00080000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=51
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valA=0.50000000000000000000
+Constraint.entityA.v=00080000
+Constraint.entityB.v=8003000a
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=0.01233300898148663102
+Constraint.disp.offset.y=-0.08227322904526794545
+Constraint.disp.offset.z=0.01139786412109675129
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=50
+Constraint.group.v=00000005
+Constraint.entityA.v=8005000a
+Constraint.entityB.v=80050011
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Surface 00000001 00646464 80030023 1 1
+SCtrl 0 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 1.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000002 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000  1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+TrimBy 00000001 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000  0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000
+TrimBy 00000004 0 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+AddSurface
+Surface 00000002 00646464 80030024 1 1
+SCtrl 0 0 1.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000006 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000  1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000007 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000  0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000
+TrimBy 00000009 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000
+TrimBy 00000018 0 0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000  0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030007 1 1
+SCtrl 0 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000002 1 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000  0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000
+TrimBy 00000009 0 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000  1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000003 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+TrimBy 00000008 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000  0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000004 00646464 80030010 1 1
+SCtrl 0 0 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000005 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000  0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+TrimBy 00000006 0 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000003 0 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000  1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000004 1 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000  1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+TrimBy 00000013 0 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000  0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddSurface
+Surface 00000005 00646464 80030019 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000007 0 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000  0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000
+TrimBy 00000008 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000  0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000
+TrimBy 00000001 1 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+TrimBy 00000005 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000  0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddSurface
+Surface 00000006 00646464 80050027 1 1
+SCtrl 0 0 -0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.50000000000000000000 -0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 1 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000  -0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+TrimBy 00000011 1 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000  -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000
+TrimBy 0000000d 1 -0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000  0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddSurface
+Surface 00000007 00646464 80050028 1 1
+SCtrl 0 0 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.50000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 00000008 00646464 80050007 1 1
+SCtrl 0 0 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 00000009 00646464 00000000 2 1
+SCtrl 0 0 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000005551 0.00000000000000003062 -0.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 0.00000000000000005551 0.00000000000000003062 0.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 0.00000000000000000000 -0.49999999999999994449 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000011 0 0.00000000000000000000 -0.49999999999999994449 -0.50000000000000000000  0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000
+TrimBy 00000012 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000
+TrimBy 0000000b 0 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000  0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000010 1 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000  0.00000000000000000000 -0.49999999999999994449 -0.50000000000000000000
+AddSurface
+Surface 0000000a 00646464 80050010 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.50000000000000000000 -0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.50000000000000000000 -0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000001 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000001 00000003
+CCtrl 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000003 00000004
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000001 00000004
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000004 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -1.00000000000000000000
+CurvePt 1 -0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000002 00000004
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000002 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000005 00000003
+CCtrl 0 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -2.00000000000000000000 -1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000002 00000003
+CCtrl 0 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -2.00000000000000000000 0.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000a 1 1 00000006 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000009 0000000a
+CCtrl 0 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000007 0000000a
+CCtrl 0 0.50000000000000000000 -0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.50000000000000000000 -0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000006 0000000a
+CCtrl 0 0.50000000000000000000 -0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.50000000000000000000 -0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 0000000e 1 1 00000007 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000f 1 1 0000000a 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000010 1 1 00000008 00000009
+CCtrl 0 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000011 1 2 00000006 00000009
+CCtrl 0 0.00000000000000000000 -0.49999999999999994449 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000005551 0.00000000000000003062 -0.50000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -0.49999999999999994449 -0.50000000000000000000
+CurvePt 0 0.00202254569356066088 -0.45507278105114756794 -0.49999999999999994449
+CurvePt 0 0.00834731579171281782 -0.40901847379392758386 -0.50000000000000000000
+CurvePt 0 0.01930052090648426075 -0.36242089257731524565 -0.50000000000000000000
+CurvePt 0 0.03510584946878485962 -0.31595264521906357702 -0.50000000000000000000
+CurvePt 0 0.05585799658512363014 -0.27035270347199824581 -0.49999999999999994449
+CurvePt 0 0.08150224439067435545 -0.22639512330742866952 -0.49999999999999994449
+CurvePt 0 0.11182340621257842728 -0.18485093680038469643 -0.50000000000000000000
+CurvePt 0 0.14644660940672626914 -0.14644660940672621363 -0.50000000000000000000
+CurvePt 0 0.18485093680038475195 -0.11182340621257838564 -0.50000000000000000000
+CurvePt 0 0.22639512330742872503 -0.08150224439067429993 -0.49999999999999994449
+CurvePt 0 0.27035270347199830132 -0.05585799658512359545 -0.49999999999999994449
+CurvePt 0 0.31595264521906363253 -0.03510584946878483187 -0.50000000000000000000
+CurvePt 0 0.36242089257731530116 -0.01930052090648423646 -0.50000000000000000000
+CurvePt 0 0.40901847379392763937 -0.00834731579171280394 -0.50000000000000000000
+CurvePt 0 0.45507278105114762345 -0.00202254569356065308 -0.49999999999999994449
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000012 1 2 00000007 00000009
+CCtrl 0 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000005551 0.00000000000000003062 0.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000
+CurvePt 0 0.00202254569356066088 -0.45507278105114756794 0.00000000000000000000
+CurvePt 0 0.00834731579171281782 -0.40901847379392758386 0.00000000000000000000
+CurvePt 0 0.01930052090648426075 -0.36242089257731524565 0.00000000000000000000
+CurvePt 0 0.03510584946878485962 -0.31595264521906357702 0.00000000000000000000
+CurvePt 0 0.05585799658512363014 -0.27035270347199824581 0.00000000000000000000
+CurvePt 0 0.08150224439067435545 -0.22639512330742866952 0.00000000000000000000
+CurvePt 0 0.11182340621257842728 -0.18485093680038469643 0.00000000000000000000
+CurvePt 0 0.14644660940672626914 -0.14644660940672621363 0.00000000000000000000
+CurvePt 0 0.18485093680038475195 -0.11182340621257838564 0.00000000000000000000
+CurvePt 0 0.22639512330742872503 -0.08150224439067429993 0.00000000000000000000
+CurvePt 0 0.27035270347199830132 -0.05585799658512359545 0.00000000000000000000
+CurvePt 0 0.31595264521906363253 -0.03510584946878483187 0.00000000000000000000
+CurvePt 0 0.36242089257731530116 -0.01930052090648423646 0.00000000000000000000
+CurvePt 0 0.40901847379392763937 -0.00834731579171280394 0.00000000000000000000
+CurvePt 0 0.45507278105114762345 -0.00202254569356065308 0.00000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000013 1 1 00000004 00000006
+CCtrl 0 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.50000000000000000000 -0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000014 1 1 00000005 00000006
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000015 1 1 00000002 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000016 1 1 00000004 00000007
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.50000000000000000000 -0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000017 1 1 00000005 00000007
+CCtrl 0 0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000018 1 2 00000002 00000009
+CCtrl 0 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000005551 0.00000000000000003062 0.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 -0.49999999999999994449 0.00000000000000000000
+CurvePt 0 0.00202254569356066088 -0.45507278105114756794 0.00000000000000000000
+CurvePt 0 0.00834731579171281782 -0.40901847379392758386 0.00000000000000000000
+CurvePt 0 0.01930052090648426075 -0.36242089257731524565 0.00000000000000000000
+CurvePt 0 0.03510584946878485962 -0.31595264521906357702 0.00000000000000000000
+CurvePt 0 0.05585799658512363014 -0.27035270347199824581 0.00000000000000000000
+CurvePt 0 0.08150224439067435545 -0.22639512330742866952 0.00000000000000000000
+CurvePt 0 0.11182340621257842728 -0.18485093680038469643 0.00000000000000000000
+CurvePt 0 0.14644660940672626914 -0.14644660940672621363 0.00000000000000000000
+CurvePt 0 0.18485093680038475195 -0.11182340621257838564 0.00000000000000000000
+CurvePt 0 0.22639512330742872503 -0.08150224439067429993 0.00000000000000000000
+CurvePt 0 0.27035270347199830132 -0.05585799658512359545 0.00000000000000000000
+CurvePt 0 0.31595264521906363253 -0.03510584946878483187 0.00000000000000000000
+CurvePt 0 0.36242089257731530116 -0.01930052090648423646 0.00000000000000000000
+CurvePt 0 0.40901847379392763937 -0.00834731579171280394 0.00000000000000000000
+CurvePt 0 0.45507278105114762345 -0.00202254569356065308 0.00000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000019 1 1 00000004 00000008
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001a 1 1 00000002 0000000a
+CCtrl 0 0.50000000000000000000 -0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.50000000000000000000 -0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 00000005 00000009
+CCtrl 0 0.00000000000000000636 -0.49999999747846401998 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000636 -0.49999999747846401998 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 -0.50000000000000000000
+CurvePt 1 -0.00000000000000000000 -0.50000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001c 1 1 00000004 00000009
+CCtrl 0 0.49999999291850866223 -0.00000000000000005551 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.49999999291850866223 -0.00000000000000005551 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001d 1 1 00000005 0000000a
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve

--- a/test/group/boolean_tangent_fillet/test.cpp
+++ b/test/group/boolean_tangent_fillet/test.cpp
@@ -1,0 +1,37 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// A triangular prism minus a fillet-shaped tool: a quarter-cylinder sliver
+// that rounds off the prism's right-angle corner. The tool's cylinder is
+// tangent to both faces of the prism that form the corner, and its flat cap
+// faces are coplanar with them, so along each tangent line a flat and a
+// curved surface of the tool meet edge-on-edge, both lying in the tangent
+// plane of the prism's face: the case in SShell::ClassifyEdge() where the
+// first-order data (the normals at the edge) cannot classify the edge, and
+// the faces' actual geometry away from the edge decides. The intersection
+// curves along the tangent lines also get no orientation from the surface
+// normals, which are parallel there (issue #1291; the model is ruevs'
+// PrismFilletMinimalTestCase).
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The prism is 1/2 * 1 * 2 * 1 = 1 mm³; the fillet cuts away a sliver
+    // just under (1 - π/4) * 0.5² * 0.5 ≈ 0.0268 mm³ of it (just under,
+    // since the mesh approximates the cylinder with inscribed facets).
+    CHECK_EQ_EPS(m->CalculateVolume() / 0.9730161212, 1.0);
+}

--- a/test/group/boolean_tangent_fillet/test.cpp
+++ b/test/group/boolean_tangent_fillet/test.cpp
@@ -24,7 +24,7 @@ TEST_CASE(normal_watertight_volume) {
     SEdgeList el = {};
     bool inters, leaks;
     SKdNode::From(m)->MakeCertainEdgesInto(&el,
-        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+        EdgeKind::NAKED_OR_SELF_INTER, &inters, &leaks);
     CHECK_FALSE(inters);
     CHECK_FALSE(leaks);
     CHECK_TRUE(el.l.IsEmpty());

--- a/test/group/boolean_tangent_spline/normal.slvs
+++ b/test/group/boolean_tangent_spline/normal.slvs
@@ -1,0 +1,2125 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=sketch-square
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=extrude-cube
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7001
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 00070000 1002
+    29 00070001 1002
+    30 00070002 1002
+    31 00070000 1001
+    32 00070001 1001
+    33 00070002 1001
+    34 00070000 1004
+    35 00070001 1003
+    36 00070002 1003
+    37 80020000 1002
+    38 80020000 1001
+    39 80020001 1002
+    40 80020002 1002
+    41 80020001 1001
+    42 80020002 1001
+    43 80020002 1003
+    44 00000000 1001
+    45 00000000 1002
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=sketch-fillet
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6001
+Group.skipFirst=0
+Group.predef.origin.v=80030018
+Group.predef.entityB.v=8003000d
+Group.predef.entityC.v=80030016
+Group.predef.swapUV=0
+Group.predef.negateU=1
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=cut
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.meshCombine=1
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00080000 1002
+    2 00080001 1002
+    3 00080002 1002
+    4 00080000 1001
+    5 00080001 1001
+    6 00080002 1001
+    7 00080000 1004
+    8 00080001 1003
+    9 00080002 1003
+    10 00090000 1002
+    11 00090001 1002
+    12 00090002 1002
+    13 00090000 1001
+    14 00090001 1001
+    15 00090002 1001
+    16 00090000 1004
+    17 00090001 1003
+    18 00090002 1003
+    19 000a0000 1002
+    20 000a0001 1002
+    21 000a0002 1002
+    22 000a0003 1002
+    23 000a0004 1002
+    24 000a0000 1001
+    25 000a0001 1001
+    26 000a0002 1001
+    27 000a0003 1001
+    28 000a0004 1001
+    29 000a0001 1003
+    30 000a0002 1003
+    31 000a0003 1003
+    32 000a0004 1003
+    33 80040000 1002
+    34 80040000 1001
+    35 80040001 1002
+    36 80040002 1002
+    37 80040001 1001
+    38 80040002 1001
+    39 80040002 1003
+    40 00000000 1001
+    41 00000000 1002
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00040011
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00040013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00040014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00050010
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00050011
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00050013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00050014
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060010
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00060013
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060014
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00070010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070013
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00070014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00080010
+Param.val=13.75569688166065063228
+AddParam
+
+Param.h.v.=00080011
+Param.val=0.00000000000000000000
+AddParam
+
+Param.h.v.=00080013
+Param.val=70.95998125794230304564
+AddParam
+
+Param.h.v.=00080014
+Param.val=0.00000000000000000000
+AddParam
+
+Param.h.v.=00090010
+Param.val=70.95998125794230304564
+AddParam
+
+Param.h.v.=00090011
+Param.val=0.00000000000000000000
+AddParam
+
+Param.h.v.=00090013
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=00090014
+Param.val=48.78837126472273411082
+AddParam
+
+Param.h.v.=000a0010
+Param.val=13.75569688166065063228
+AddParam
+
+Param.h.v.=000a0011
+Param.val=0.00000000000000000000
+AddParam
+
+Param.h.v.=000a0013
+Param.val=48.78060959786832029295
+AddParam
+
+Param.h.v.=000a0014
+AddParam
+
+Param.h.v.=000a0016
+Param.val=58.08097978168794384146
+AddParam
+
+Param.h.v.=000a0017
+Param.val=17.74284065818248024016
+AddParam
+
+Param.h.v.=000a0019
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=000a001a
+Param.val=48.78837126472273411082
+AddParam
+
+Param.h.v.=4000000d
+Param.val=0.22926161469434416795
+AddParam
+
+Param.h.v.=4000000f
+Param.val=0.81313952107871223518
+AddParam
+
+Param.h.v.=40000016
+Param.val=0.81301015996447201228
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=-15.00000000000000000000
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000005
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000006
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000a
+Request.type=300
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00050001
+Entity.point[1].v=00050002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00060001
+Entity.point[1].v=00060002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.point[1].v=00080002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0000
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=000a0001
+Entity.point[1].v=000a0002
+Entity.point[2].v=000a0003
+Entity.point[3].v=000a0004
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0003
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=28.08097978168794384146
+Entity.actPoint.y=-12.25715934181751975984
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0004
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000b
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030010
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000f
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030014
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030019
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030018
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003001d
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001d
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=80030021
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=8003001d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030027
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80030028
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030028
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030029
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002a
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002b
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=8003002a
+Entity.point[1].v=80030028
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002c
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002d
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80030028
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=5001
+Entity.construction=0
+Entity.actPoint.x=40.95998125794230304564
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vx=0.97568423032715678733
+Entity.actNormal.vy=0.21918093596593588024
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000f
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050015
+Entity.point[2].v=80050016
+Entity.point[3].v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=28.08097978168794384146
+Entity.actPoint.y=-12.25715934181751975984
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=8005001a
+Entity.point[2].v=8005001b
+Entity.point[3].v=8005001c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=28.08097978168794384146
+Entity.actPoint.y=-12.25715934181751975984
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001a
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001b
+Entity.point[1].v=80050016
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050020
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001c
+Entity.point[1].v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050026
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050027
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050026
+Entity.point[1].v=80050024
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050029
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000001
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040001
+Constraint.ptB.v=00050002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000002
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050001
+Constraint.ptB.v=00060002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000003
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00060001
+Constraint.ptB.v=00070002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000004
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00040002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000006
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000007
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000008
+Constraint.type=61
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000009
+Constraint.type=62
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000a
+Constraint.type=50
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00070000
+Constraint.entityB.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000b
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=60.00000000000000000000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00070002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=10.00000000000000000000
+AddConstraint
+
+Constraint.h.v=0000000c
+Constraint.type=50
+Constraint.group.v=00000003
+Constraint.entityA.v=80030024
+Constraint.entityB.v=8003001f
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000d
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000d
+Constraint.ptA.v=00080001
+Constraint.entityA.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000e
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080002
+Constraint.ptB.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000f
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000f
+Constraint.ptA.v=00090002
+Constraint.entityA.v=80030004
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000010
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080001
+Constraint.ptB.v=000a0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090002
+Constraint.ptB.v=000a0004
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000012
+Constraint.type=41
+Constraint.group.v=00000005
+Constraint.ptA.v=80050019
+Constraint.entityA.v=00010000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000013
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=Corner
+Constraint.disp.offset.x=0.20241264915207013431
+Constraint.disp.offset.y=-3.59163429853392557334
+Constraint.disp.offset.z=-2.21417101842298524872
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000a0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=P1
+Constraint.disp.offset.x=1.63427326092519353828
+Constraint.disp.offset.y=1.80363269244023460836
+Constraint.disp.offset.z=-3.40170696078009004992
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000a0003
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=P2
+Constraint.disp.offset.x=0.00123499079765074238
+Constraint.disp.offset.y=-4.38799135888326219401
+Constraint.disp.offset.z=0.22945940412293114319
+AddConstraint
+
+Constraint.h.v=00000016
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=40000016
+Constraint.ptA.v=000a0002
+Constraint.entityA.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000017
+Constraint.type=121
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00080000
+Constraint.entityB.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Surface 00000001 00646464 8003002c 1 1
+SCtrl 0 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000b 0 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000009 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+TrimBy 00000006 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000001 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000016 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000
+AddSurface
+Surface 00000002 00646464 8003002d 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000005 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000002 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000003 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030010 1 1
+SCtrl 0 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000c 0 30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000002 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000008 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000b 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -16.24430311833935292043 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000001d 0 -16.24430311833935292043 -30.00000000000000000000 0.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000004 00646464 80030019 1 1
+SCtrl 0 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000001 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000003 0 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000004 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000008 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000005 00646464 80030022 1 1
+SCtrl 0 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000006 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000a 0 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000007 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000004 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000006 00646464 80030007 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000009 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000005 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 0000000c 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000001421085 0.00000000000000000000
+TrimBy 00000007 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000018 0 30.00000000000000000000 -29.99999999999999289457 0.00000000000000000000  30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+TrimBy 0000001a 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddSurface
+Surface 00000007 00646464 80050029 1 1
+SCtrl 0 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -16.24430311833934936772 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 40.95998125794230304564 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 00000008 00646464 80050028 1 1
+SCtrl 0 0 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -16.24430311833934581500 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 40.95998125794230304564 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -16.24430311833934581500 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000015 0 -16.24430311833934581500 -30.00000000000000000000 0.00000000000000000000  30.00000000000000355271 18.78837126472273411082 0.00000000000000000000
+TrimBy 00000012 0 30.00000000000000355271 -30.00000000000000355271 0.00000000000000000000  -16.24430311833934581500 -30.00000000000000000000 0.00000000000000000000
+TrimBy 00000018 1 30.00000000000000355271 18.78837126472273411082 0.00000000000000000000  30.00000000000000000000 -29.99999999999999644729 0.00000000000000000000
+AddSurface
+Surface 00000009 00646464 00000000 3 1
+SCtrl 0 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 28.08097978168794384146 -12.25715934181751975984 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 28.08097978168794384146 -12.25715934181751975984 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 0 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 18.78060959786832029295 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 3 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 3 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000014 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+TrimBy 00000015 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000  -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+TrimBy 00000010 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000  -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000f 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddSurface
+Surface 0000000a 00646464 80050010 1 1
+SCtrl 0 0 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 0000000b 00646464 80050007 1 1
+SCtrl 0 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000001 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000002 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000002 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000004 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000002 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000001 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000005 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000003 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000001 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000000a 1 1 00000002 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000001 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000006 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000001065814 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 0000000a 0000000b
+CCtrl 0 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000e 1 1 00000008 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+CurvePt 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000f 1 1 00000009 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 00000010 1 1 0000000b 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000011 1 1 00000007 0000000b
+CCtrl 0 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000012 1 1 00000008 0000000b
+CCtrl 0 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 40.95998125794230304564 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000013 1 1 00000007 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 40.95998125794230304564 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000014 1 3 00000007 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 28.08097978168794384146 -12.25715934181751975984 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 0 -9.97411314835406059842 -29.79316010720631524578 30.00000000000000000000
+CurvePt 0 -4.27997223298497431188 -29.17697651350282228577 30.00000000000000000000
+CurvePt 0 0.86498953875454942519 -28.15795334590586662671 30.00000000000000000000
+CurvePt 0 5.48764207785115232241 -26.74259473143179732801 30.00000000000000000000
+CurvePt 0 9.61485529529147520122 -24.93740479709694923827 30.00000000000000000000
+CurvePt 0 13.27349910206216065944 -22.74888766991767852232 30.00000000000000000000
+CurvePt 0 16.49044340914984729807 -20.18354747691032002876 30.00000000000000000000
+CurvePt 0 19.29255812754118082353 -17.24788834509122636973 30.00000000000000000000
+CurvePt 0 21.70671316822279806047 -13.94841440147674305194 30.00000000000000000000
+CurvePt 0 23.75977844218134293897 -10.29162977308320492398 30.00000000000000000000
+CurvePt 0 25.47862386040345938909 -6.28403858692696282162 30.00000000000000000000
+CurvePt 0 26.89011933387578068277 -1.93214497002436136341 30.00000000000000000000
+CurvePt 0 28.02113477358495430281 2.75754695060825216757 30.00000000000000000000
+CurvePt 0 28.89854009051762062654 7.77853304795453581733 30.00000000000000000000
+CurvePt 0 29.54920519566042358406 13.12430919499814585549 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 00000015 1 3 00000008 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 28.08097978168794384146 -12.25715934181751975984 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 0.00000000000000000000
+CurvePt 0 -9.97411314835406059842 -29.79316010720631524578 0.00000000000000000000
+CurvePt 0 -4.27997223298497431188 -29.17697651350282228577 0.00000000000000000000
+CurvePt 0 0.86498953875454942519 -28.15795334590586662671 0.00000000000000000000
+CurvePt 0 5.48764207785115232241 -26.74259473143179732801 0.00000000000000000000
+CurvePt 0 9.61485529529147520122 -24.93740479709694923827 0.00000000000000000000
+CurvePt 0 13.27349910206216065944 -22.74888766991767852232 0.00000000000000000000
+CurvePt 0 16.49044340914984729807 -20.18354747691032002876 0.00000000000000000000
+CurvePt 0 19.29255812754118082353 -17.24788834509122636973 0.00000000000000000000
+CurvePt 0 21.70671316822279806047 -13.94841440147674305194 0.00000000000000000000
+CurvePt 0 23.75977844218134293897 -10.29162977308320492398 0.00000000000000000000
+CurvePt 0 25.47862386040345938909 -6.28403858692696282162 0.00000000000000000000
+CurvePt 0 26.89011933387578068277 -1.93214497002436136341 0.00000000000000000000
+CurvePt 0 28.02113477358495430281 2.75754695060825216757 0.00000000000000000000
+CurvePt 0 28.89854009051762062654 7.77853304795453581733 0.00000000000000000000
+CurvePt 0 29.54920519566042358406 13.12430919499814585549 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 00000016 1 3 00000001 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 28.08097978168794384146 -12.25715934181751975984 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 0 -9.97411314835406059842 -29.79316010720631524578 30.00000000000000000000
+CurvePt 0 -4.27997223298497431188 -29.17697651350282228577 30.00000000000000000000
+CurvePt 0 0.86498953875454942519 -28.15795334590586662671 30.00000000000000000000
+CurvePt 0 5.48764207785115232241 -26.74259473143179732801 30.00000000000000000000
+CurvePt 0 9.61485529529147520122 -24.93740479709694923827 30.00000000000000000000
+CurvePt 0 13.27349910206216065944 -22.74888766991767852232 30.00000000000000000000
+CurvePt 0 16.49044340914984729807 -20.18354747691032002876 30.00000000000000000000
+CurvePt 0 19.29255812754118082353 -17.24788834509122636973 30.00000000000000000000
+CurvePt 0 21.70671316822279806047 -13.94841440147674305194 30.00000000000000000000
+CurvePt 0 23.75977844218134293897 -10.29162977308320492398 30.00000000000000000000
+CurvePt 0 25.47862386040345938909 -6.28403858692696282162 30.00000000000000000000
+CurvePt 0 26.89011933387578068277 -1.93214497002436136341 30.00000000000000000000
+CurvePt 0 28.02113477358495430281 2.75754695060825216757 30.00000000000000000000
+CurvePt 0 28.89854009051762062654 7.77853304795453581733 30.00000000000000000000
+CurvePt 0 29.54920519566042358406 13.12430919499814585549 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 00000017 1 1 00000006 00000007
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -29.99999999999999289457 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -29.99999999999999289457 30.00000000000000000000
+AddCurve
+Curve 00000018 1 1 00000006 00000008
+CCtrl 0 30.00000000000000000000 -29.99999999999999289457 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -29.99999999999999289457 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 00000019 1 1 00000003 00000007
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000001a 1 1 00000006 00000009
+CCtrl 0 29.99999999983266008030 18.78837126201548102244 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 29.99999999983266008030 18.78837126201548102244 0.00000000000000177636 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 00000006 0000000a
+CCtrl 0 30.00000000000008526513 18.78837126472273411082 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000008526513 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 0000001c 1 1 00000006 0000000b
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 29.99999999999999289457 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -0.00000000000000666134 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 29.99999999999999289457
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -0.00000000000000666134
+AddCurve
+Curve 0000001d 1 1 00000003 00000008
+CCtrl 0 -16.24430311833934581500 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934581500 -30.00000000000000000000 0.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000001e 1 1 00000001 0000000b
+CCtrl 0 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve

--- a/test/group/boolean_tangent_spline/test.cpp
+++ b/test/group/boolean_tangent_spline/test.cpp
@@ -1,0 +1,36 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// A cube minus a fillet-shaped tool whose curved surface is the extrusion
+// of a cubic spline, tangent to a face of the cube where the spline ends on
+// it. Since the spline is not an arc, the extruded surface is not a
+// cylinder, so the intersection curve along the tangent line cannot come
+// from a closed-form line-surface intersection; and the numerical
+// intersection cannot converge on a grazing intersection. The line is
+// instead recovered from the tool's trim curve at the tangency, which lies
+// entirely within the cube face's plane (issue #1291; the model is
+// phkahler's relocated cube_cut).
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The cube is 60³ = 216000 mm³; the tool cuts away a sliver bounded by
+    // the spline surface, roughly 11360 mm³ (slightly more than the true
+    // value, since the mesh approximates the spline surface with inscribed
+    // facets).
+    CHECK_EQ_EPS(m->CalculateVolume() / 204638.6271882122, 1.0);
+}

--- a/test/group/boolean_tangent_spline/test.cpp
+++ b/test/group/boolean_tangent_spline/test.cpp
@@ -22,7 +22,7 @@ TEST_CASE(normal_watertight_volume) {
     SEdgeList el = {};
     bool inters, leaks;
     SKdNode::From(m)->MakeCertainEdgesInto(&el,
-        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+        EdgeKind::NAKED_OR_SELF_INTER, &inters, &leaks);
     CHECK_FALSE(inters);
     CHECK_FALSE(leaks);
     CHECK_TRUE(el.l.IsEmpty());

--- a/test/group/translate_asy/test.cpp
+++ b/test/group/translate_asy/test.cpp
@@ -23,7 +23,7 @@ TEST_CASE(normal_inters) {
     SEdgeList el = {};
     bool inters, leaks;
     SKdNode::From(m)->MakeCertainEdgesInto(&el,
-        EdgeKind::SELF_INTER, /*coplanarIsInter=*/false, &inters, &leaks);
+        EdgeKind::SELF_INTER, &inters, &leaks);
     el.Clear();
 
     // The assembly is supposed to interfere.


### PR DESCRIPTION
Fixes the remaining Boolean failures from #1291: the models from the issue comments where a fillet surface of the tool is tangent to the faces it rounds off — `PrismFilletMinimalTestCase.slvs`, `PrismFilletMinimalTestCase_OnlyOneFailingEdge.slvs`, `PrismChamferMinimalTestCase.slvs` (@ruevs), `BoolBreakTangent.slvs` (@drwho495), `1291_cube_cut.slvs` — @phkahler's relocated original model with a true spline-face tangency — and @ruevs' further relocation of that model, which turned out to hit a false positive in the naked-edge checker rather than a Boolean defect (the fifth item below). (The `cube_cut.slvs` from the opening post is already fixed by #1729; as @phkahler pointed out, it was not saved in the failing position — the relocated versions needed two more fixes, the fourth and fifth defects below.)

**Stacked on #1729** — the first three commits here are that PR's commits (rebased onto current master, which already has the `AddExactIntersectionCurve()` race fix). Only the last eight commits are new; I'll rebase this branch the moment #1729 merges so the diff shrinks to just them. Reviewing commit-by-commit works today.

### What was still failing, and why

These models hit five independent defects:

1. **`SShell::ClassifyEdge()` misclassified tangent folds** (`src/srf/raycast.cpp`). Along the tangency line, the tool's flat cap and its fillet cylinder meet edge-on-edge, and *both* lie in the tangent plane of the surface being trimmed — both direction cosines are ~0. The old code assumed this meant "a flat face split in two pieces" and returned `SURF_COINC_SAME`/`OPP` for both sides of the edge. That's only right when both faces really are flat; here one of them curves away, so one side of the edge is genuinely inside or outside the shell. First-order data (normals at the edge) fundamentally cannot distinguish these — exactly @phkahler's "coincidence + curvature" hypothesis in the issue.

   The fix probes each shell face's actual surface a small distance in from the edge (scaled by the face's own control-net size), giving each face's deviation from the tangent plane. Each side of the edge is then classified by the nearest face extending to that side:
   - it stays in the tangent plane → **coincident**, using *that* face's normal (the old code used face 0's normal for both sides — wrong when a checkerboard-coincident split puts oppositely-oriented faces on the two sides);
   - it curves away from the tangent plane → **inside** or **outside**, by which way it curves relative to our outward normal;
   - no face extends to that side, i.e. both faces fold back onto the other side (a zero-angle wedge) → **outside** if the wedge between them is material, **inside** if it's a void slot, decided by which of the two faces is nearer the tangent plane.

   For the ordinary flat split face the new code reproduces the old answers exactly.

2. **Tangent intersection curves got an arbitrary edge direction** (`src/srf/boolean.cpp`, `MakeCopyTrimAgainst`). New intersection edges are oriented by the triple product `(tn × d) · sn`, which is ~0 when the two surfaces are tangent along the curve — the sign was numerical noise. Since `KeepEdge()` keeps only correctly-oriented edges, even correctly *classified* tangent edges were then discarded, leaving holes. Degenerate cases now add the edge in both directions; classification keeps the right one and `CullExtraneousEdges()` drops the leftover parallel duplicate.

3. **The edge-classification probe distance wasn't local** (`src/srf/boolean.cpp`, `EdgeNormalsWithinSurface`). The probe point is offset from the edge midpoint by `SS.ChordTolMm()` — 1 mm by default, which on these ~0.5 mm-radius models is far outside the edge's neighborhood. Evaluating the fillet's arc patch that far past its end curves back (rational quadratics do), misclassifying a perfectly transversal edge — but only at export/regenerate chord tolerances, which is why `OnlyOneFailingEdge` failed on export while looking fine on screen. The probe is now clamped to a tenth of the edge's length.

4. **Tangent plane–extrusion intersection lines were never generated** (`src/srf/surfinter.cpp`, `IntersectAgainst`). This is what @phkahler's relocated `1291_cube_cut.slvs` still hit after the three fixes above, and it sits *upstream* of them: fixes 1–2 classify and orient tangent intersection edges correctly, but only once the intersection curve exists. The plane-vs-parallel-extrusion branch finds the intersection lines by casting a probe line within the plane against the surface numerically, and `PointIntersectingLine()` cannot converge on a grazing (tangent) intersection — the plane-line step degenerates exactly at the solution. A cylinder never gets there (closed-form intersection with an explicit tangency case), which is why the arc-profile fillets above worked while the relocated model's *cubic-spline* profile failed: its tangent line silently didn't exist, and the cube face's trim polygon was left open.

   Such a tangency happens where the extruded profile ends on the plane, so the missing line is exactly the trim curve the extruded surface shares with its neighbour there — and that curve lies entirely in the plane. The fix adds those trim curves as exact intersection curves (the same way the general branch already handles exact curves lying in a plane, from d72eba80) and skips numerical probe hits that duplicate a curve added exactly. Downstream, fixes 1–2 then keep exactly the right directed edge with no further changes.

   **Known limitation:** a tangency in the *interior* of the extruded profile (a plane grazing the middle of a spline, where no trim curve exists) would still be missed; that needs a root finder that is robust at grazing intersections. Fillet-style tangencies are at profile endpoints by construction, and no known model hits the interior case.

5. **The self-intersection checker flagged exact edge-on-face grazes** (`src/mesh.cpp`, `SKdNode::FindEdgeOn`). This is what @ruevs' second relocated `1291_cube_cut` hit, and it is not a Boolean defect at all. That drag moved the profile's free corner *inside* the cube, so the tool touches the cube's side face only along the sweep line through the other corner — which is constrained onto the cube's edge, so the line lies *exactly* in the face. The face is correctly left uncut: the grazing line dangles into the face's interior at the tool's cap, so no valid trim polygon exists to split it with, and the Boolean output is right — its volume matches the mesh-Boolean (`forceToMesh=1`) ground truth to ~1e-10 at every position along the whole drag path. But the strict mode of `FindEdgeOn` (used by Analyze → Show Naked Edges and by every mesh export) reported a self-intersection whenever a face-triangulation edge happened to cross a tool triangle's plane exactly *on* that triangle's grazing edge. Whether any of the face's triangulation diagonals cross within the grazing edge's span is per-position, per-machine floating-point luck — which is why the model fails on one machine and passes on another, independent of chord tolerance and of everything upstream.

   The relaxed mode of the checker already forgave intersections landing on a triangle's edge; the fix extends that forgiveness to both modes and removes the now-meaningless `coplanarIsInter` flag. No real intersection can be lost: an edge that actually passes into the mesh at a triangle's edge also passes through the interior of the triangles on the far side of that edge, and is reported there; and a coplanar overlap always puts a crossing point strictly inside some triangle. Grazes of this kind are inherent to correct Boolean output whenever a tool face ends exactly on a shell face, so the tangency models in this PR were all exposed to this false positive.

### Regression tests

- `test/group/boolean_tangent_fillet/` — @ruevs' `PrismFilletMinimalTestCase.slvs` verbatim, checking the display mesh is watertight (no naked or self-intersecting edges) and the volume matches. Fails with naked edges without fixes 1–3, passes after. Volume rather than image checks, as before.
- `test/group/boolean_tangent_spline/` — @phkahler's relocated `1291_cube_cut.slvs` verbatim, same watertight + volume checks. Fails with naked edges without fix 4, passes after.
- `test/group/boolean_grazing_edge/` — @ruevs' second relocated model (canonically re-saved), same watertight + volume checks. Fails "self-intersecting" without fix 5 on machines where the triangulation lands unluckily.
- `test/core/mesh/` — a deterministic unit pair for fix 5, independent of triangulation luck: a triangle edge lying in another triangle's interior (a graze) must not be reported as a self-intersection, while an edge passing *through* another triangle's interior still must be.

### Verification

- All eight models from the issue thread (`cube_cut`, both relocated `1291_cube_cut`s, `PrismFillet`, `OnlyOneFailingEdge`, `PrismChamfer`, `BoolBreakTangent`, plus the working `BoolWorks` control) export watertight, with volumes matching the mesh-Boolean ground truth of the same models (`forceToMesh=1`) — the relocated models to the last digit.
- For fix 5, the relocated corner was additionally swept along its whole drag path (201 positions) and the dragged control point over a surrounding grid: the Boolean volume matches the mesh ground truth everywhere, and the naked-edge/self-intersection check now passes at every position (before the fix it failed at a machine-dependent band of positions).
- Full test suite passes in Debug and Release (264 cases / 928 checks), including the #1619/#1091 regression tests from #1729.
- Repeated runs with OpenMP produce identical triangle sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
