### PR TITLE
Fix Gtk-CRITICAL assertion in file chooser when opening files

### DIFF
--- a/src/platform/guigtk.cpp
+++ b/src/platform/guigtk.cpp
@@ -1407,7 +1407,9 @@ public:
     }
 
     void SetCurrentName(std::string name) override {
-        gtkChooser->set_current_name(name);
+        if(gtkChooser->get_action() != Gtk::FILE_CHOOSER_ACTION_OPEN) {
+            gtkChooser->set_current_name(name);
+        }
     }
 
     Platform::Path GetFilename() override {
@@ -1419,7 +1421,9 @@ public:
     }
 
     void SuggestFilename(Platform::Path path) override {
-        gtkChooser->set_current_name(path.FileStem()+"."+GetExtension());
+        if(gtkChooser->get_action() != Gtk::FILE_CHOOSER_ACTION_OPEN) {
+            gtkChooser->set_current_name(path.FileStem()+"."+GetExtension());
+        }
     }
 
     void AddFilter(std::string name, std::vector<std::string> extensions) override {


### PR DESCRIPTION
Guard SetCurrentName() and SuggestFilename() calls against being invoked on open file dialogs, where GTK's gtk_file_chooser_widget_set_current_name asserts that the action is GTK_FILE_CHOOSER_ACTION_SAVE or GTK_FILE_CHOOSER_ACTION_CREATE_FOLDER.

Follow the same guard pattern already used in FilterChanged() and CheckForUntitledFile() in the same file.