### PR TITLE
CI: Update bottle tag for libomp in install-macos.sh

### DIFF
--- a/.github/scripts/install-macos.sh
+++ b/.github/scripts/install-macos.sh
@@ -4,7 +4,7 @@ set -o pipefail
 if [ "$1" = "ci" ]; then
     brew_cache=$(brew --cache)
     brew fetch --bottle-tag=arm64_tahoe libomp >/dev/null
-    brew fetch --bottle-tag=sonoma libomp >/dev/null
+    arch -x86_64 brew fetch --bottle-tag=sonoma libomp >/dev/null
     armloc=$(find "$brew_cache"/downloads -maxdepth 1 -name "*--libomp--*arm64_tahoe.bottle.tar.gz" -print | tail -n1)
     x64loc=$(find "$brew_cache"/downloads -maxdepth 1 -name "*--libomp--*sonoma.bottle.tar.gz" -print | tail -n1)
     [ -n "$armloc" ] || { echo "Failed to locate arm64 libomp bottle in cache" >&2; exit 1; }


### PR DESCRIPTION
Because the CI fails to fetch the `libomp bottle for Sonoma, even though the site claims it is supported: https://formulae.brew.sh/formula/libomp