### PR TITLE
Web: Enable OpenMP for Emscripten

### DIFF
--- a/.github/scripts/build-web.sh
+++ b/.github/scripts/build-web.sh
@@ -22,6 +22,6 @@ emcmake cmake .. \
   -DENABLE_CLI="OFF" \
   -DENABLE_TESTS="OFF" \
   -DENABLE_COVERAGE="OFF" \
-  -DENABLE_OPENMP="OFF" \
+  -DENABLE_OPENMP="ON" \
   -DENABLE_LTO="ON"
 cmake --build . --config "${BUILD_TYPE}" -j$(nproc) --target solvespace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,32 @@ if(ENABLE_OPENMP)
         target_include_directories(slvs_openmp SYSTEM INTERFACE
             ${OpenMP_CXX_INCLUDE_DIRS})
         message(STATUS "found OpenMP, compiling with flags: " ${OpenMP_CXX_FLAGS} )
+		# Explicitly pair OpenMP with Emscripten's pthread engine
+		if(EMSCRIPTEN)
+			# In Emscripten, compiling with OpenMP pulls in the WebAssembly multi-threaded runtime (libc-mt-debug.a)
+			# because OpenMP relies on Web Workers to parallelize loops. However, Emscripten's built-in OpenMP
+			# implementation does not automatically propagate the underlying -pthread linker flags to every
+			# compilation unit.
+			#
+			# When ThinLTO evaluates the final output, any file that didn't explicitly receive the threading context
+			# falls back to single-threaded stubs (library_pthread_stub.o), causing wasm-ld duplicate symbol errors e.g.:
+			#
+			# [2/2] Linking CXX executable bin\solvespace.html
+			# FAILED: bin/solvespace.html
+			# wasm-ld: error: duplicate symbol: emscripten_futex_wait
+			# >>> defined in ./emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/libc-mt-debug.a(emscripten_futex_wait.o)
+			# >>> defined in .\emsdk\upstream\emscripten\cache\sysroot\lib\wasm32-emscripten\thinlto\libc-debug.a(library_pthread_stub.o)
+			#
+			# Therefore force -pthread for all compilation units.
+			add_compile_options(-pthread)
+			add_link_options(-pthread)
+			# Avoid the following error in the browser:
+			#	Tried to spawn a new thread, but the thread pool is exhausted.
+			#	This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop.
+			#	If you want to increase the pool size, use setting `-sPTHREAD_POOL_SIZE=...`.
+			#	If you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-sPTHREAD_POOL_SIZE_STRICT=2`.
+			add_link_options(-sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency)
+		endif()
     endif()
 endif()
 

--- a/cmake/Platform/Emscripten.cmake
+++ b/cmake/Platform/Emscripten.cmake
@@ -2,12 +2,30 @@
 # It teaches CMake about the Emscripten compiler, so that CMake can generate
 # makefiles from CMakeLists.txt that invoke emcc.
 
+# To use this toolchain file with CMake, invoke CMake with the following command
+# line parameters:
+# cmake -DCMAKE_TOOLCHAIN_FILE=<EmscriptenRoot>/cmake/Modules/Platform/Emscripten.cmake
+#       -DCMAKE_BUILD_TYPE=<Debug|RelWithDebInfo|Release|MinSizeRel>
+#       -G "Unix Makefiles" (Linux and macOS)
+#       -G "MinGW Makefiles" (Windows)
+#       <path/to/CMakeLists.txt> # Note, pass in here ONLY the path to the file, not the filename 'CMakeLists.txt' itself.
+
+# After that, build the generated Makefile with the command 'make'. On Windows,
+# you may download and use 'mingw32-make' instead.
+
 # The following variable describes the target OS we are building to.
 set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
 
 set(CMAKE_CROSSCOMPILING TRUE)
-set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+
+# Certain cmake versions are not compatible with dynnamic linking due to
+# https://gitlab.kitware.com/cmake/cmake/-/work_items/27240
+if (("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "4.2.0" AND "${CMAKE_VERSION}" VERSION_LESS "4.2.6") OR
+    ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "4.3.0" AND "${CMAKE_VERSION}" VERSION_LESS "4.3.3"))
+  message(WARNING "This version of cmake (${CMAKE_VERSION}) does not support emscripten shared libraries.  Use cmake < 4.2.0 or cmake > 4.3.3 if you need shared library support")
+  set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+endif()
 
 # Advertise Emscripten as a 32-bit platform (as opposed to
 # CMAKE_SYSTEM_PROCESSOR=x86_64 for 64-bit platform), since some projects (e.g.
@@ -23,22 +41,10 @@ set(CMAKE_SYSTEM_PROCESSOR ${EMSCRIPTEN_SYSTEM_PROCESSOR})
 # This feature is activated if a shared library project has the property
 # SOVERSION defined.
 set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Wl,-soname,")
+set(CMAKE_DL_LIBS "")
 
-# In CMake, CMAKE_HOST_WIN32 is set when we are cross-compiling from Win32 to
-# Emscripten:
-# http://www.cmake.org/cmake/help/v2.8.12/cmake.html#variable:CMAKE_HOST_WIN32
-# The variable WIN32 is set only when the target arch that will run the code
-# will be WIN32, so unset WIN32 when cross-compiling.
-set(WIN32)
-
-# The same logic as above applies for APPLE and CMAKE_HOST_APPLE, so unset
-# APPLE.
-set(APPLE)
-
-# And for UNIX and CMAKE_HOST_UNIX. However, Emscripten is often able to mimic
-# being a Linux/Unix system, in which case a lot of existing CMakeLists.txt
-# files can be configured for Emscripten while assuming UNIX build, so this is
-# left enabled.
+# Emscripten has good enough Linux/Unix emualtion that it makes sense to set
+# UNIX by defaut.
 set(UNIX 1)
 
 # Do a no-op access on the CMAKE_TOOLCHAIN_FILE variable so that CMake will not
@@ -46,29 +52,37 @@ set(UNIX 1)
 if (CMAKE_TOOLCHAIN_FILE)
 endif()
 
-if (CMAKE_HOST_WIN32)
-  set(EMCC_SUFFIX ".bat")
-else()
-  set(EMCC_SUFFIX "")
-endif()
-
-# Locate where the Emscripten compiler resides in
+# Locate where the Emscripten compiler resides in relative to this toolchain file.
 if (NOT DEFINED EMSCRIPTEN_ROOT_PATH)
-  # Check relative to this toolchain file
   get_filename_component(GUESS_EMSCRIPTEN_ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
-  # If not found by above search, locate using the EMSCRIPTEN environment variable
-  find_program(EMSCRIPTEN_EMRANLIB_PATH emranlib${EMCC_SUFFIX} HINTS "${GUESS_EMSCRIPTEN_ROOT_PATH}" ENV "EMSCRIPTEN")
-  if(NOT EMSCRIPTEN_EMRANLIB_PATH)
-    # Abort if not found
-    message(FATAL_ERROR "Could not locate the Emscripten compiler toolchain directory! Either set the EMSCRIPTEN environment variable, or pass -DEMSCRIPTEN_ROOT_PATH=xxx to CMake to explicitly specify the location of the compiler!")
+  if (EXISTS "${GUESS_EMSCRIPTEN_ROOT_PATH}/emranlib.py")
+    set(EMSCRIPTEN_ROOT_PATH "${GUESS_EMSCRIPTEN_ROOT_PATH}")
+  else()
+    # If not found by above search, locate using the EMSCRIPTEN environment variable.
+    set(EMSCRIPTEN_ROOT_PATH "$ENV{EMSCRIPTEN}")
+    # Abort if not found.
+    if ("${EMSCRIPTEN_ROOT_PATH}" STREQUAL "")
+      message(FATAL_ERROR "Could not locate the Emscripten compiler toolchain directory! Either set the EMSCRIPTEN environment variable, or pass -DEMSCRIPTEN_ROOT_PATH=xxx to CMake to explicitly specify the location of the compiler!")
+    endif()
   endif()
-  get_filename_component(EMSCRIPTEN_ROOT_PATH "${EMSCRIPTEN_EMRANLIB_PATH}" DIRECTORY)
 endif()
 
 # Normalize, convert Windows backslashes to forward slashes or CMake will crash.
 get_filename_component(EMSCRIPTEN_ROOT_PATH "${EMSCRIPTEN_ROOT_PATH}" ABSOLUTE)
 
 list(APPEND CMAKE_MODULE_PATH "${EMSCRIPTEN_ROOT_PATH}/cmake/Modules")
+
+if (CMAKE_HOST_WIN32)
+  # We use windows executables these days rather than `.bat` files, but we
+  # still support a fallback of using `.bat` files.
+  if (EXISTS "${EMSCRIPTEN_ROOT_PATH}/emcc.exe")
+    set(EMCC_SUFFIX ".exe")
+  else()
+    set(EMCC_SUFFIX ".bat")
+  endif()
+else()
+  set(EMCC_SUFFIX "")
+endif()
 
 # Specify the compilers to use for C and C++
 set(CMAKE_C_COMPILER "${EMSCRIPTEN_ROOT_PATH}/emcc${EMCC_SUFFIX}")
@@ -80,7 +94,7 @@ set(CMAKE_C_COMPILER_AR "${CMAKE_AR}")
 set(CMAKE_CXX_COMPILER_AR "${CMAKE_AR}")
 set(CMAKE_C_COMPILER_RANLIB "${CMAKE_RANLIB}")
 set(CMAKE_CXX_COMPILER_RANLIB "${CMAKE_RANLIB}")
-set(CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS "${EMSCRIPTEN_ROOT_PATH}/emscan-deps")
+set(CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS "${EMSCRIPTEN_ROOT_PATH}/emscan-deps${EMCC_SUFFIX}")
 
 # Capture the Emscripten version to EMSCRIPTEN_VERSION variable.
 if (NOT EMSCRIPTEN_VERSION)
@@ -108,10 +122,13 @@ endif()
 file(TO_CMAKE_PATH "${_emcache_output}" _emcache_output)
 set(EMSCRIPTEN_SYSROOT "${_emcache_output}/sysroot")
 
-# Allow skipping of CMake compiler autodetection, since this is quite slow with
-# Emscripten. Pass -DEMSCRIPTEN_FORCE_COMPILERS=ON to enable
-option(EMSCRIPTEN_FORCE_COMPILERS "Force C/C++ compiler" OFF)
+# Allow skipping of CMake compiler autodetection.  On by default since this is
+# quite slow with Emscripten and also leads to issues with
+# CMAKE_C_IMPLICIT_LINK_LIBRARIES.
+# See https://github.com/emscripten-core/emscripten/issues/23944
+option(EMSCRIPTEN_FORCE_COMPILERS "Force C/C++ compiler" ON)
 if (EMSCRIPTEN_FORCE_COMPILERS)
+
   # Detect version of the 'emcc' executable. Note that for CMake, we tell it the
   # version of the Clang compiler and not the version of Emscripten, because
   # CMake understands Clang better.
@@ -150,6 +167,7 @@ if (EMSCRIPTEN_FORCE_COMPILERS)
   set(CMAKE_CXX_COMPILER_ID Clang)
   set(CMAKE_CXX_COMPILER_FRONTEND_VARIANT GNU)
   set(CMAKE_CXX_STANDARD_COMPUTED_DEFAULT 98)
+  set(CMAKE_CXX_STANDARD_LIBRARY libc++)
 
   set(CMAKE_C_PLATFORM_ID "emscripten")
   set(CMAKE_CXX_PLATFORM_ID "emscripten")
@@ -161,46 +179,45 @@ if (EMSCRIPTEN_FORCE_COMPILERS)
     set(CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES "${EMSCRIPTEN_SYSROOT}/include;${EMSCRIPTEN_SYSROOT}/include/c++/v1")
   endif()
 
+  set(CXX_COMPILE_FEATURES_BASE "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates;cxx_std_17")
+  set(CXX11_COMPILE_FEATURES_BASE "cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates")
+  set(CXX14_COMPILE_FEATURES_BASE "cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates")
+
   if ("${CMAKE_VERSION}" VERSION_LESS "3.8")
     set(CMAKE_C_COMPILE_FEATURES "c_function_prototypes;c_restrict;c_variadic_macros;c_static_assert")
     set(CMAKE_C90_COMPILE_FEATURES "c_function_prototypes")
     set(CMAKE_C99_COMPILE_FEATURES "c_restrict;c_variadic_macros")
     set(CMAKE_C11_COMPILE_FEATURES "c_static_assert")
 
-    set(CMAKE_CXX_COMPILE_FEATURES "cxx_template_template_parameters;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates")
+    set(CMAKE_CXX_COMPILE_FEATURES "cxx_template_template_parameters;${CXX11_COMPILE_FEATURES_BASE};${CXX14_COMPILE_FEATURES_BASE}")
     set(CMAKE_CXX98_COMPILE_FEATURES "cxx_template_template_parameters")
-    set(CMAKE_CXX11_COMPILE_FEATURES "cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates")
-    set(CMAKE_CXX14_COMPILE_FEATURES "cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates")
+    set(CMAKE_CXX11_COMPILE_FEATURES "${CXX11_COMPILE_FEATURES_BASE}")
+    set(CMAKE_CXX14_COMPILE_FEATURES "${CXX14_COMPILE_FEATURES_BASE}")
   else() # 3.8+
+    set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macros;c_std_11;c_static_assert")
+    set(CMAKE_CXX_COMPILE_FEATURES "${CXX_COMPILE_FEATURES_BASE}")
     set(CMAKE_C90_COMPILE_FEATURES "c_std_90;c_function_prototypes")
     set(CMAKE_C99_COMPILE_FEATURES "c_std_99;c_restrict;c_variadic_macros")
     set(CMAKE_C11_COMPILE_FEATURES "c_std_11;c_static_assert")
 
     set(CMAKE_CXX98_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters")
-    set(CMAKE_CXX11_COMPILE_FEATURES "cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates")
-    set(CMAKE_CXX14_COMPILE_FEATURES "cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates")
+    set(CMAKE_CXX11_COMPILE_FEATURES "cxx_std_11;${CXX11_COMPILE_FEATURES_BASE}")
+    set(CMAKE_CXX14_COMPILE_FEATURES "cxx_std_14;${CXX14_COMPILE_FEATURES_BASE}")
     set(CMAKE_CXX17_COMPILE_FEATURES "cxx_std_17")
-    if ("${CMAKE_VERSION}" VERSION_LESS "3.12") # [3.8, 3.12)
-      set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macros;c_std_11;c_static_assert")
-      set(CMAKE_CXX_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates;cxx_std_17")
-    else() # 3.12+
+    if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.12") # 3.12+
       set(CMAKE_CXX20_COMPILE_FEATURES "cxx_std_20")
-      if ("${CMAKE_VERSION}" VERSION_LESS "3.20") # [3.12, 3.20)
-        set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macros;c_std_11;c_static_assert")
-        set(CMAKE_CXX_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates;cxx_std_17;cxx_std_20")
-      else() # 3.20+
+      set(CMAKE_CXX_COMPILE_FEATURES "${CMAKE_CXX_COMPILE_FEATURES};cxx_std_20")
+      if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.20") # 3.20+
         set(CMAKE_CXX23_COMPILE_FEATURES "cxx_std_23")
-        if ("${CMAKE_VERSION}" VERSION_LESS "3.25")
-          set(CMAKE_CXX_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates;cxx_std_17;cxx_std_20;cxx_std_23")
-        else() # 3.25+
-          set(CMAKE_CXX_COMPILE_FEATURES "cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates;cxx_std_17;cxx_std_20;cxx_std_23;cxx_std_26")
+        set(CMAKE_CXX_COMPILE_FEATURES "${CMAKE_CXX_COMPILE_FEATURES};cxx_std_23")
+        if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25") # 3.25+
+          set(CMAKE_CXX26_COMPILE_FEATURES "cxx_std_26")
+          set(CMAKE_CXX_COMPILE_FEATURES "${CMAKE_CXX_COMPILE_FEATURES};cxx_std_26")
         endif()
-        if ("${CMAKE_VERSION}" VERSION_LESS "3.21") # 3.20
-          set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macros;c_std_11;c_static_assert")
-        else() # 3.21+
+        if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.21")
           set(CMAKE_C17_COMPILE_FEATURES "c_std_17")
           set(CMAKE_C23_COMPILE_FEATURES "c_std_23")
-          set(CMAKE_C_COMPILE_FEATURES "c_std_90;c_function_prototypes;c_std_99;c_restrict;c_variadic_macros;c_std_11;c_static_assert;c_std_17;c_std_23")
+          set(CMAKE_C_COMPILE_FEATURES "${CMAKE_C_COMPILE_FEATURES};c_std_17;c_std_23")
         endif()
       endif()
     endif()
@@ -210,7 +227,7 @@ endif()
 list(APPEND CMAKE_FIND_ROOT_PATH "${EMSCRIPTEN_SYSROOT}")
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH /)
 
-if (${CMAKE_C_FLAGS} MATCHES "MEMORY64")
+if (${CMAKE_C_FLAGS} MATCHES "MEMORY64|-m64|--target=wasm64")
   set(CMAKE_LIBRARY_ARCHITECTURE "wasm64-emscripten")
   set(CMAKE_SIZEOF_VOID_P 8)
   set(CMAKE_C_SIZEOF_DATA_PTR 8)
@@ -265,12 +282,15 @@ endif()
 
 set(CMAKE_EXECUTABLE_SUFFIX ".js")
 
-set(CMAKE_C_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
-set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
-set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
-set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
-set(CMAKE_C_USE_RESPONSE_FILE_FOR_INCLUDES 1)
-set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES 1)
+if (CMAKE_HOST_WIN32)
+  # See https://github.com/emscripten-core/emscripten/issues/2386
+  set(CMAKE_C_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
+  set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_LIBRARIES 1)
+  set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+  set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+  set(CMAKE_C_USE_RESPONSE_FILE_FOR_INCLUDES 1)
+  set(CMAKE_CXX_USE_RESPONSE_FILE_FOR_INCLUDES 1)
+endif()
 
 set(CMAKE_C_RESPONSE_FILE_LINK_FLAG "@")
 set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
@@ -283,7 +303,7 @@ set(CMAKE_LINK_LIBRARY_USING_WHOLE_ARCHIVE_SUPPORTED True)
 # detect when building using Emscripten.
 set(EMSCRIPTEN 1 CACHE INTERNAL "If true, we are targeting Emscripten output.")
 
-# Hardwire support for cmake-2.8/Modules/CMakeBackwardsCompatibilityC.cmake
+# Hardwire support for CMake/Modules/CMakeBackwardCompatibilityC.cmake
 # without having CMake to try complex things to autodetect these:
 set(CMAKE_SKIP_COMPATIBILITY_TESTS 1)
 set(CMAKE_SIZEOF_CHAR 1)
@@ -302,7 +322,6 @@ set(CMAKE_HAVE_SYS_PRCTL_H 1)
 set(CMAKE_WORDS_BIGENDIAN 0)
 set(CMAKE_C_BYTE_ORDER "LITTLE_ENDIAN")
 set(CMAKE_CXX_BYTE_ORDER "LITTLE_ENDIAN")
-set(CMAKE_DL_LIBS)
 
 function(em_validate_asmjs_after_build target)
   message(WARNING "em_validate_asmjs_after_build no longer exists")
@@ -362,3 +381,45 @@ endif()
 # complain about unused CMake variable.
 if (CMAKE_CROSSCOMPILING_EMULATOR)
 endif()
+
+# C++23 stl modules (Ref: https://cmake.org/cmake/help/latest/manual/cmake-cxxmodules.7.html#import-std-support)
+# Opt-in via CMAKE_CXX_MODULE_STD (Ref: https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_MODULE_STD.html)
+if(CMAKE_CXX_MODULE_STD AND CMAKE_CXX_COMPILER_LOADED AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.30 AND NOT CMAKE_CXX_STDLIB_MODULES_JSON)
+  # include guard and auxiliary for _cmake_cxx_import_std
+  set(CMAKE_CXX_STDLIB_MODULES_JSON "${EMSCRIPTEN_SYSROOT}/lib/${CMAKE_LIBRARY_ARCHITECTURE}/${CMAKE_CXX_STANDARD_LIBRARY}.modules.json")
+
+  # Ref: https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_COMPILER_IMPORT_STD.html
+  unset(CMAKE_CXX_COMPILER_IMPORT_STD)
+  foreach(COMPILE_FEATURE IN LISTS CMAKE_CXX_COMPILE_FEATURES)
+    if(COMPILE_FEATURE MATCHES [[cxx_std_([0-9]+)]] AND CMAKE_MATCH_1 GREATER_EQUAL 23 AND CMAKE_MATCH_1 LESS 98)
+      list(APPEND CMAKE_CXX_COMPILER_IMPORT_STD ${CMAKE_MATCH_1})
+    endif()
+  endforeach()
+
+  include(Compiler/Clang-CXX-CXXImportStd)
+  if(COMMAND _cmake_cxx_find_modules_json)
+    # CMake >= 4.3
+    _cmake_cxx_find_modules_json()
+    if(CMAKE_CXX_COMPILER_IMPORT_STD_ERROR_MESSAGE)
+      message(WARNING "${CMAKE_CXX_COMPILER_IMPORT_STD_ERROR_MESSAGE}")
+      unset(CMAKE_CXX_COMPILER_IMPORT_STD)
+    endif()
+  elseif(COMMAND _cmake_cxx_import_std)
+    # CMake 3.30 ... 4.3
+    foreach(STD_VERSION IN LISTS CMAKE_CXX_COMPILER_IMPORT_STD)
+      _cmake_cxx_import_std(${STD_VERSION} eval_code)
+      cmake_language(EVAL CODE "${eval_code}")
+      if(CMAKE_CXX${STD_VERSION}_COMPILER_IMPORT_STD_NOT_FOUND_MESSAGE)
+        message(WARNING "${CMAKE_CXX${STD_VERSION}_COMPILER_IMPORT_STD_NOT_FOUND_MESSAGE}")
+        list(REMOVE_ITEM CMAKE_CXX_COMPILER_IMPORT_STD ${STD_VERSION})
+      endif()
+    endforeach()
+  endif()
+endif()
+
+set_property(SOURCE
+  "${EMSCRIPTEN_SYSROOT}/share/libc++/v1/std.cppm"
+  "${EMSCRIPTEN_SYSROOT}/share/libc++/v1/std.compat.cppm"
+  PROPERTY
+    COMPILE_FLAGS -Wno-reserved-module-identifier
+)


### PR DESCRIPTION
`cmake/Platform/Emscripten.cmake` is taken from Emsdk 6.0.4 (fe5be6afdff43ad58860d821fcc8572a23f92d19)

Unlike #1734 this works:
<img width="896" height="707" alt="image" src="https://github.com/user-attachments/assets/6aec4527-b1e6-4a56-9cf6-c60f6a655abb" />

The OpenMP version is definitely faster.
