### PR TITLE
Fix #1743 cross vertex split and fix #1291 tangent crossing

### DIFF
--- a/src/srf/boolean.cpp
+++ b/src/srf/boolean.cpp
@@ -203,6 +203,115 @@ SCurve SCurve::MakeCopySplitAgainst(SShell *agnstA, SShell *agnstB,
     return ret;
 }
 
+//-----------------------------------------------------------------------------
+// Insert p as a vertex of the piecewise linear curve sc, if it lies within one
+// of sc's segments (and on sc's exact curve, where we have one) and isn't
+// already one of its points. Returns true if we changed the curve.
+//-----------------------------------------------------------------------------
+static bool InsertVertexIntoCurve(SCurve *sc, Vector p) {
+    for(const SCurvePt &scpt : sc->pts) {
+        if(scpt.p.Equals(p)) return false;
+    }
+
+    int i;
+    for(i = 1; i < sc->pts.n; i++) {
+        Vector a = sc->pts[i-1].p,
+               d = (sc->pts[i].p).Minus(a);
+        double m = d.MagSquared();
+        if(m < LENGTH_EPS*LENGTH_EPS) continue;
+        double t = (p.Minus(a)).Dot(d)/m;
+        if((t <= 0.0) || (t >= 1.0)) continue;
+        if((p.Minus(a.Plus(d.ScaledBy(t)))).Magnitude() > LENGTH_EPS) continue;
+        break;
+    }
+    if(i >= sc->pts.n) return false;
+
+    // The pwl chord of a curved segment is not the curve, so make sure that
+    // the point really lies on the curve and not just near the chord.
+    if(sc->isExact) {
+        double t;
+        sc->exact.ClosestPointTo(p, &t, /*mustConverge=*/false);
+        if((p.Minus(sc->exact.PointAt(t))).Magnitude() > LENGTH_EPS) return false;
+    }
+
+    SCurvePt scpt = {};
+    scpt.p      = p;
+    scpt.vertex = true;
+
+    List<SCurvePt> pts = {};
+    pts.ReserveMore(sc->pts.n + 1);
+    for(int j = 0; j < sc->pts.n; j++) {
+        if(j == i) pts.Add(&scpt);
+        pts.Add(&(sc->pts[j]));
+    }
+    sc->pts.Clear();
+    sc->pts = pts;
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+// A curve of one shell may cross a curve of the other shell at a point that is
+// a vertex of neither input shell, and that lies on no surface which either
+// curve crosses transversally; that happens where the two shells touch without
+// passing through each other, for example where an edge of one runs within a
+// coincident face of the other. MakeCopySplitAgainst() splits curves against
+// surfaces, so at such a point it splits only whichever of the two curves does
+// meet a transversal surface there, and leaves the other one whole. The
+// unsplit curve then contributes a single trim edge whose two halves classify
+// differently, which cannot be represented: the edge is kept or discarded
+// whole, and the trim polygon fails to assemble, so the face is lost.
+//
+// So propagate the splits that we just made. Any vertex that splitting created
+// within a curve from one operand, and that lies within a curve from the other
+// operand, becomes a vertex of that curve too.
+//-----------------------------------------------------------------------------
+void SShell::SplitCurvesAtCrossings() {
+    List<Vector> vert[2] = {};
+    for(SCurve &sc : curve) {
+        int i;
+        if(sc.source == SCurve::Source::A) {
+            i = 0;
+        } else if(sc.source == SCurve::Source::B) {
+            i = 1;
+        } else {
+            continue;
+        }
+        // Only the interior points that a split created; the endpoints of a
+        // curve are its shell's own vertices, and an exact curve's endpoints
+        // may lie outside the real geometry entirely (issue #1452).
+        for(int j = 1; j < sc.pts.n - 1; j++) {
+            if(sc.pts[j].vertex) vert[i].Add(&(sc.pts[j].p));
+        }
+    }
+
+    if(!vert[0].IsEmpty() || !vert[1].IsEmpty()) {
+        for(SCurve &sc : curve) {
+            int i;
+            if(sc.source == SCurve::Source::A) {
+                i = 1;
+            } else if(sc.source == SCurve::Source::B) {
+                i = 0;
+            } else {
+                continue;
+            }
+
+            Vector cmax = {VERY_NEGATIVE, VERY_NEGATIVE, VERY_NEGATIVE},
+                   cmin = {VERY_POSITIVE, VERY_POSITIVE, VERY_POSITIVE};
+            for(const SCurvePt &scpt : sc.pts) {
+                scpt.p.MakeMaxMin(&cmax, &cmin);
+            }
+
+            for(const Vector &p : vert[i]) {
+                if(p.OutsideAndNotOn(cmax, cmin)) continue;
+                InsertVertexIntoCurve(&sc, p);
+            }
+        }
+    }
+
+    vert[0].Clear();
+    vert[1].Clear();
+}
+
 void SShell::CopyCurvesSplitAgainst(bool opA, SShell *agnst, SShell *into) {
 #pragma omp parallel for
     for(int i=0; i<curve.n; i++) {
@@ -858,6 +967,11 @@ void SShell::MakeFromBoolean(SShell *a, SShell *b, SSurface::CombineAs type) {
     // shell.
     a->CopyCurvesSplitAgainst(/*opA=*/true,  b, this);
     b->CopyCurvesSplitAgainst(/*opA=*/false, a, this);
+
+    // Where the two shells touch without crossing, a curve of one shell can
+    // cross a curve of the other at a point that splitting against surfaces
+    // finds on only one of the two curves; carry those points across.
+    SplitCurvesAtCrossings();
 
     // Generate the intersection curves for each surface in A against all
     // the surfaces in B (which is all of the intersection curves).

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -402,6 +402,7 @@ public:
     void MakeFromIntersectionOf(SShell *a, SShell *b);
     void MakeFromBoolean(SShell *a, SShell *b, SSurface::CombineAs type);
     void CopyCurvesSplitAgainst(bool opA, SShell *agnst, SShell *into);
+    void SplitCurvesAtCrossings();
     void CopySurfacesTrimAgainst(SShell *sha, SShell *shb, SShell *into, SSurface::CombineAs type);
     void MakeIntersectionCurvesAgainst(SShell *against, SShell *into);
     void MakeClassifyingBsps(SShell *useCurvesFrom);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ set(testsuite_SOURCES
     request/workplane/test.cpp
     group/boolean_coplanar_union/test.cpp
     group/boolean_cross_vertex/test.cpp
+    group/boolean_cross_vertex_tangent_crossing/test.cpp
     group/boolean_knife_edge/test.cpp
     group/boolean_tangent_crossing/test.cpp
     group/boolean_tangent_edge/test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(testsuite_SOURCES
     request/ttf_text/test.cpp
     request/workplane/test.cpp
     group/boolean_coplanar_union/test.cpp
+    group/boolean_cross_vertex/test.cpp
     group/boolean_knife_edge/test.cpp
     group/boolean_tangent_crossing/test.cpp
     group/boolean_tangent_edge/test.cpp

--- a/test/group/boolean_cross_vertex/normal.slvs
+++ b/test/group/boolean_cross_vertex/normal.slvs
@@ -1,0 +1,2130 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=sketch-square
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=extrude-cube
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7001
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 00070000 1002
+    29 00070001 1002
+    30 00070002 1002
+    31 00070000 1001
+    32 00070001 1001
+    33 00070002 1001
+    34 00070000 1004
+    35 00070001 1003
+    36 00070002 1003
+    37 80020000 1002
+    38 80020000 1001
+    39 80020001 1002
+    40 80020002 1002
+    41 80020001 1001
+    42 80020002 1001
+    43 80020002 1003
+    44 00000000 1001
+    45 00000000 1002
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=sketch-fillet
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6001
+Group.skipFirst=0
+Group.predef.origin.v=80030018
+Group.predef.entityB.v=8003000d
+Group.predef.entityC.v=80030016
+Group.predef.swapUV=0
+Group.predef.negateU=1
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=cut
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7001
+Group.skipFirst=0
+Group.meshCombine=1
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00080000 1002
+    2 00080001 1002
+    3 00080002 1002
+    4 00080000 1001
+    5 00080001 1001
+    6 00080002 1001
+    7 00080000 1004
+    8 00080001 1003
+    9 00080002 1003
+    10 00090000 1002
+    11 00090001 1002
+    12 00090002 1002
+    13 00090000 1001
+    14 00090001 1001
+    15 00090002 1001
+    16 00090000 1004
+    17 00090001 1003
+    18 00090002 1003
+    19 000a0000 1002
+    20 000a0001 1002
+    21 000a0002 1002
+    22 000a0003 1002
+    23 000a0004 1002
+    24 000a0000 1001
+    25 000a0001 1001
+    26 000a0002 1001
+    27 000a0003 1001
+    28 000a0004 1001
+    29 000a0001 1003
+    30 000a0002 1003
+    31 000a0003 1003
+    32 000a0004 1003
+    33 80040000 1002
+    34 80040000 1001
+    35 80040001 1002
+    36 80040002 1002
+    37 80040001 1001
+    38 80040002 1001
+    39 80040002 1003
+    40 00000000 1001
+    41 00000000 1002
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00040011
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00040013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00040014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00050010
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00050011
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00050013
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00050014
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060010
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00060013
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00060014
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00070010
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070011
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00070013
+Param.val=-30.00000000000000000000
+AddParam
+
+Param.h.v.=00070014
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=00080010
+Param.val=13.75569688166065063228
+AddParam
+
+Param.h.v.=00080011
+AddParam
+
+Param.h.v.=00080013
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=00080014
+AddParam
+
+Param.h.v.=00090010
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=00090011
+AddParam
+
+Param.h.v.=00090013
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=00090014
+Param.val=48.78837126472273411082
+AddParam
+
+Param.h.v.=000a0010
+Param.val=13.75569688166065063228
+AddParam
+
+Param.h.v.=000a0011
+AddParam
+
+Param.h.v.=000a0013
+Param.val=48.78060959786832029295
+AddParam
+
+Param.h.v.=000a0014
+AddParam
+
+Param.h.v.=000a0016
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=000a0017
+Param.val=17.73538976911678588522
+AddParam
+
+Param.h.v.=000a0019
+Param.val=60.00000000000000000000
+AddParam
+
+Param.h.v.=000a001a
+Param.val=48.78837126472273411082
+AddParam
+
+Param.h.v.=4000000d
+Param.val=0.22926161469434416795
+AddParam
+
+Param.h.v.=4000000f
+Param.val=0.81313952107871223518
+AddParam
+
+Param.h.v.=40000017
+Param.val=0.36351674198930805648
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=30.00000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=-35.68076426785469834613
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000005
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000006
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000a
+Request.type=300
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00050001
+Entity.point[1].v=00050002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00060001
+Entity.point[1].v=00060002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.point[1].v=00080002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0000
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=000a0001
+Entity.point[1].v=000a0002
+Entity.point[2].v=000a0003
+Entity.point[3].v=000a0004
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0003
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-12.26461023088321411478
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0004
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vx=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000b
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000f
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030014
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030019
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030018
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003001d
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001d
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=80030021
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030020
+Entity.point[1].v=8003001d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030027
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80030028
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030028
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030029
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002a
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002b
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=8003002a
+Entity.point[1].v=80030028
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002c
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003002a
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003002d
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80030028
+Entity.actPoint.z=-30.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vy=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050005
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=30.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000e
+Entity.point[1].v=8005000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000f
+Entity.point[1].v=8005000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050015
+Entity.point[2].v=80050016
+Entity.point[3].v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-12.26461023088321411478
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=8005001a
+Entity.point[2].v=8005001b
+Entity.point[3].v=8005001c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-16.24430311833934936772
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=18.78060959786832029295
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=-12.26461023088321411478
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=30.00000000000000000000
+Entity.actPoint.y=18.78837126472273411082
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001a
+Entity.point[1].v=80050015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001b
+Entity.point[1].v=80050016
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050020
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001c
+Entity.point[1].v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050026
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050027
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050026
+Entity.point[1].v=80050024
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=-5.68076426785469834613
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050029
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actPoint.x=-30.00000000000000000000
+Entity.actPoint.y=-30.00000000000000000000
+Entity.actPoint.z=65.68076426785469834613
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000001
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040001
+Constraint.ptB.v=00050002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000002
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050001
+Constraint.ptB.v=00060002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000003
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00060001
+Constraint.ptB.v=00070002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000004
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00040002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000006
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000007
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000008
+Constraint.type=61
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00070002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000009
+Constraint.type=62
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050002
+Constraint.ptB.v=00070001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000a
+Constraint.type=50
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00070000
+Constraint.entityB.v=00060000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000b
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=60.00000000000000000000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00070002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=10.00000000000000000000
+AddConstraint
+
+Constraint.h.v=0000000c
+Constraint.type=50
+Constraint.group.v=00000003
+Constraint.entityA.v=80030024
+Constraint.entityB.v=8003001f
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000d
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000d
+Constraint.ptA.v=00080001
+Constraint.entityA.v=8003000d
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000e
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080002
+Constraint.ptB.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000f
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000f
+Constraint.ptA.v=00090002
+Constraint.entityA.v=80030004
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000010
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080001
+Constraint.ptB.v=000a0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090002
+Constraint.ptB.v=000a0004
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000013
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=Corner
+Constraint.disp.offset.x=0.20241264915207013431
+Constraint.disp.offset.y=-3.59163429853392557334
+Constraint.disp.offset.z=-2.21417101842298524872
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000a0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=P1
+Constraint.disp.offset.x=1.63427326092519353828
+Constraint.disp.offset.y=1.80363269244023460836
+Constraint.disp.offset.z=-3.40170696078009004992
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=1000
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000a0003
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=P2
+Constraint.disp.offset.x=0.00123499079765074238
+Constraint.disp.offset.y=-4.38799135888326219401
+Constraint.disp.offset.z=0.22945940412293114319
+AddConstraint
+
+Constraint.h.v=00000016
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090001
+Constraint.ptB.v=8003000f
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000017
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=40000017
+Constraint.ptA.v=000a0003
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Surface 00000001 00646464 8003002c 1 1
+SCtrl 0 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000b 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000a 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000006 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000003 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 0000001d 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+TrimBy 0000001c 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000001e 0 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddSurface
+Surface 00000002 00646464 8003002d 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000005 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000008 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000007 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 0000000c 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030010 1 1
+SCtrl 0 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000009 0 30.00000000000000355271 -30.00000000000000355271 -5.68076426785470278702  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000007 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000001 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000b 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 00000016 0 -16.24430311833935292043 -30.00000000000000000000 -5.68076426785470189884  30.00000000000000000000 -30.00000000000000000000 -5.68076426785470367520
+TrimBy 00000019 0 -16.24430311833935292043 -30.00000000000000000000 30.00000000000000000000  -16.24430311833935292043 -30.00000000000000000000 -5.68076426785470189884
+AddSurface
+Surface 00000004 00646464 80030019 1 1
+SCtrl 0 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000003 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+TrimBy 0000000c 0 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000002 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000001 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000005 00646464 80030022 1 1
+SCtrl 0 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000006 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000005 0 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000004 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000002 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddSurface
+Surface 00000006 00646464 80030007 1 1
+SCtrl 0 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+TrimBy 00000008 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000009 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000  30.00000000000000000000 -30.00000000000000000000 -5.68076426785470367520
+TrimBy 00000004 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000  30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+TrimBy 00000017 0 30.00000000000000000000 -30.00000000000000000000 -5.68076426785470367520  30.00000000000000000000 18.78837126472273411082 -5.68076426785470545155
+TrimBy 00000018 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785470545155  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddSurface
+Surface 00000007 00646464 80050029 1 1
+SCtrl 0 0 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 0 1 29.99999999999999644729 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 0 -16.24430311833934936772 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 1 29.99999999999999644729 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+AddSurface
+Surface 00000008 00646464 80050028 1 1
+SCtrl 0 0 29.99999999999999644729 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 0 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 0 29.99999999999999644729 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 1 -16.24430311833934936772 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+TrimBy 00000014 0 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613  29.99999999999999644729 18.78837126472273411082 -5.68076426785469834613
+TrimBy 0000000f 0 29.99999999999999644729 18.78837126472273411082 -5.68076426785469834613  29.99999999999999644729 -30.00000000000000000000 -5.68076426785469834613
+TrimBy 00000010 0 29.99999999999999644729 -30.00000000000000000000 -5.68076426785469834613  -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+AddSurface
+Surface 00000009 00646464 00000000 3 1
+SCtrl 0 0 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -12.26461023088321411478 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -12.26461023088321411478 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 2 0 18.78060959786832029295 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 2 1 18.78060959786832029295 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 3 0 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 3 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+TrimBy 00000014 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613  -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+TrimBy 00000012 0 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000  30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613
+TrimBy 00000011 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613  -16.24430311833934936772 -30.00000000000000000000 29.99999999999999289457
+TrimBy 0000001c 0 -16.24430311833934936772 -30.00000000000000000000 29.99999999999999289457  30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddSurface
+Surface 0000000a 00646464 80050010 1 1
+SCtrl 0 0 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 0 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+AddSurface
+Surface 0000000b 00646464 80050007 1 1
+SCtrl 0 0 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 0 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 0 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+SCtrl 1 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000003 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000004 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000001 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000005 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000002 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000001 00000005
+CCtrl 0 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000002 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000002 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000006 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 29.99999999999999644729 -30.00000000000000000000 -5.68076426785469834613
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 0000000a 1 1 00000001 00000006
+CCtrl 0 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000001 00000003
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000002 00000004
+CCtrl 0 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -30.00000000000000000000 -30.00000000000000000000 -30.00000000000000000000
+CurvePt 1 -30.00000000000000000000 30.00000000000000000000 -30.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000007 0000000b
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613
+AddCurve
+Curve 0000000e 1 1 00000007 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613
+AddCurve
+Curve 0000000f 1 1 00000008 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613
+AddCurve
+Curve 00000010 1 1 00000008 0000000b
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+AddCurve
+Curve 00000011 1 1 0000000b 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613
+CurvePt 1 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+AddCurve
+Curve 00000012 1 1 00000009 0000000a
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613
+AddCurve
+Curve 00000013 1 1 0000000a 0000000b
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 65.68076426785469834613
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613
+AddCurve
+Curve 00000014 1 3 00000008 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 2 30.00000000000000000000 -12.26461023088321411478 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+CurvePt 0 -9.95303016255717487581 -29.79324196511841549295 -5.68076426785469834613
+CurvePt 0 -4.20126241934326838390 -29.17728211637465562944 -5.68076426785469834613
+CurvePt 0 1.02943682797025548581 -28.15859183762023931763 -5.68076426785469834613
+CurvePt 0 5.75750429605128477561 -26.74364251270666059668 -5.68076426785469834613
+CurvePt 0 10.00137670156770752783 -24.93890552548542771660 -5.68076426785469834613
+CurvePt 0 13.77949076118740912023 -22.75085225980804892743 -5.68076426785469834613
+CurvePt 0 17.11028319157827581876 -20.18595409952602182102 -5.68076426785469834613
+CurvePt 0 20.01219070940820188298 -17.25068242849086175283 -5.68076426785469834613
+CurvePt 0 22.50365003134506736160 -13.95150863055406986746 -5.68076426785469834613
+CurvePt 0 24.60309787405675763239 -10.29490408956715086219 -5.68076426785469834613
+CurvePt 0 26.32897095421116873126 -6.28734018938160943435 -5.68076426785469834613
+CurvePt 0 27.69970598847617893057 -1.93528831384895116940 -5.68076426785469834613
+CurvePt 0 28.73373969351968071351 2.75478015317931657080 -5.68076426785469834613
+CurvePt 0 29.44950878600955945785 7.77639382785168997714 -5.68076426785469834613
+CurvePt 0 29.86544998261370409409 13.12308132631666524048 -5.68076426785469834613
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613
+AddCurve
+Curve 00000015 1 3 00000007 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 2 30.00000000000000000000 -12.26461023088321411478 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613
+CurvePt 0 -9.95303016255717487581 -29.79324196511841549295 65.68076426785469834613
+CurvePt 0 -4.20126241934326838390 -29.17728211637465562944 65.68076426785469834613
+CurvePt 0 1.02943682797025548581 -28.15859183762023931763 65.68076426785469834613
+CurvePt 0 5.75750429605128477561 -26.74364251270666059668 65.68076426785469834613
+CurvePt 0 10.00137670156770752783 -24.93890552548542771660 65.68076426785469834613
+CurvePt 0 13.77949076118740912023 -22.75085225980804892743 65.68076426785469834613
+CurvePt 0 17.11028319157827581876 -20.18595409952602182102 65.68076426785469834613
+CurvePt 0 20.01219070940820188298 -17.25068242849086175283 65.68076426785469834613
+CurvePt 0 22.50365003134506736160 -13.95150863055406986746 65.68076426785469834613
+CurvePt 0 24.60309787405675763239 -10.29490408956715086219 65.68076426785469834613
+CurvePt 0 26.32897095421116873126 -6.28734018938160943435 65.68076426785469834613
+CurvePt 0 27.69970598847617893057 -1.93528831384895116940 65.68076426785469834613
+CurvePt 0 28.73373969351968071351 2.75478015317931657080 65.68076426785469834613
+CurvePt 0 29.44950878600955945785 7.77639382785168997714 65.68076426785469834613
+CurvePt 0 29.86544998261370409409 13.12308132631666524048 65.68076426785469834613
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613
+AddCurve
+Curve 00000016 1 1 00000003 00000008
+CCtrl 0 -16.24430311833933515686 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613
+AddCurve
+Curve 00000017 1 1 00000006 00000008
+CCtrl 0 30.00000000000000000000 -29.99999999999999289457 -5.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785469834613
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613
+AddCurve
+Curve 00000018 1 1 00000006 00000009
+CCtrl 0 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 65.68076426785469834613
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 -5.68076426785469834613
+AddCurve
+Curve 00000019 1 1 00000003 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613 Weight 1.00000000000000000000
+CCtrl 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 65.68076426785469834613
+CurvePt 1 -16.24430311833934581500 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 -5.68076426785469834613
+AddCurve
+Curve 0000001a 1 1 00000003 0000000a
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 -5.68076426785470012248 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785470012248
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 00000006 0000000b
+CCtrl 0 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785472410330 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 -5.68076426785470012248
+AddCurve
+Curve 0000001c 1 3 00000001 00000009
+CCtrl 0 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 18.78060959786832029295 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 30.00000000000000000000 -12.26461023088321411478 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934936772 -30.00000000000000000000 30.00000000000000000000
+CurvePt 0 -9.95303016255717487581 -29.79324196511841549295 30.00000000000000000000
+CurvePt 0 -4.20126241934326838390 -29.17728211637465562944 30.00000000000000000000
+CurvePt 0 1.02943682797025548581 -28.15859183762023931763 30.00000000000000000000
+CurvePt 0 5.75750429605128477561 -26.74364251270666059668 30.00000000000000000000
+CurvePt 0 10.00137670156770752783 -24.93890552548542771660 30.00000000000000000000
+CurvePt 0 13.77949076118740912023 -22.75085225980804892743 30.00000000000000000000
+CurvePt 0 17.11028319157827581876 -20.18595409952602182102 30.00000000000000000000
+CurvePt 0 20.01219070940820188298 -17.25068242849086175283 30.00000000000000000000
+CurvePt 0 22.50365003134506736160 -13.95150863055406986746 30.00000000000000000000
+CurvePt 0 24.60309787405675763239 -10.29490408956715086219 30.00000000000000000000
+CurvePt 0 26.32897095421116873126 -6.28734018938160943435 30.00000000000000000000
+CurvePt 0 27.69970598847617893057 -1.93528831384895116940 30.00000000000000000000
+CurvePt 0 28.73373969351968071351 2.75478015317931657080 30.00000000000000000000
+CurvePt 0 29.44950878600955945785 7.77639382785168997714 30.00000000000000000000
+CurvePt 0 29.86544998261370409409 13.12308132631666524048 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273411082 30.00000000000000000000
+AddCurve
+Curve 0000001d 1 1 00000001 0000000a
+CCtrl 0 30.00000000000000000000 -29.99999999999998578915 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 18.78837126472273766353 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 30.00000000000000000000 -29.99999999999998578915 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 18.78837126472273766353 30.00000000000000000000
+AddCurve
+Curve 0000001e 1 1 00000001 0000000b
+CCtrl 0 -16.24430311833934226229 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -16.24430311833934226229 -30.00000000000000000000 30.00000000000000000000
+CurvePt 1 30.00000000000000000000 -30.00000000000000000000 30.00000000000000000000
+AddCurve

--- a/test/group/boolean_cross_vertex/test.cpp
+++ b/test/group/boolean_cross_vertex/test.cpp
@@ -1,0 +1,37 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// A cube minus a tool swept along a spline profile. The profile is tangent to
+// one face of the cube, and the tool's flat cap face is coincident with that
+// same face of the cube, so the tool's tangent edge runs within the cube's
+// face and crosses the cube's own edge there. That crossing point is a vertex
+// of neither input shell, and neither curve passes through a surface of the
+// other shell transversally at it, so SCurve::MakeCopySplitAgainst() splits
+// only the tool's edge (which does cross the cube's face) and leaves the
+// cube's edge whole. The cube's face is then trimmed by an edge whose two
+// halves classify differently, its trim polygon fails to assemble, and two
+// faces of the result go missing (issue #1743; the model is phkahler's
+// cube_cut_2).
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The same value that the mesh Boolean gives for this model (build it
+    // with Group.forceToMesh set), to twelve significant figures.
+    CHECK_EQ_EPS(m->CalculateVolume() / 203485.2242132, 1.0);
+}
+

--- a/test/group/boolean_cross_vertex_tangent_crossing/normal.slvs
+++ b/test/group/boolean_cross_vertex_tangent_crossing/normal.slvs
@@ -1,0 +1,1855 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=tirangle
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5100
+Group.order=2
+Group.name=prism
+Group.opA.v=00000002
+Group.color=00646464
+Group.subtype=7000
+Group.skipFirst=0
+Group.predef.entityB.v=80020000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00040000 1002
+    2 00040001 1002
+    3 00040002 1002
+    4 00040000 1001
+    5 00040001 1001
+    6 00040002 1001
+    7 00040000 1004
+    8 00040001 1003
+    9 00040002 1003
+    10 00050000 1002
+    11 00050001 1002
+    12 00050002 1002
+    13 00050000 1001
+    14 00050001 1001
+    15 00050002 1001
+    16 00050000 1004
+    17 00050001 1003
+    18 00050002 1003
+    19 00060000 1002
+    20 00060001 1002
+    21 00060002 1002
+    22 00060000 1001
+    23 00060001 1001
+    24 00060002 1001
+    25 00060000 1004
+    26 00060001 1003
+    27 00060002 1003
+    28 80020000 1002
+    29 80020000 1001
+    30 80020001 1002
+    31 80020002 1002
+    32 80020001 1001
+    33 80020002 1001
+    34 80020002 1003
+    35 00000000 1001
+    36 00000000 1002
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=bspline
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=8003001f
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5100
+Group.order=4
+Group.name=bspline_fillet
+Group.opA.v=00000004
+Group.color=00646464
+Group.subtype=7001
+Group.skipFirst=0
+Group.meshCombine=1
+Group.predef.entityB.v=80040000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 00070000 1002
+    2 00070001 1002
+    3 00070002 1002
+    4 00070003 1002
+    5 00070004 1002
+    6 00070000 1001
+    7 00070001 1001
+    8 00070002 1001
+    9 00070003 1001
+    10 00070004 1001
+    11 00070001 1003
+    12 00070002 1003
+    13 00070003 1003
+    14 00070004 1003
+    15 00080000 1002
+    16 00080001 1002
+    17 00080002 1002
+    18 00080000 1001
+    19 00080001 1001
+    20 00080002 1001
+    21 00080000 1004
+    22 00080001 1003
+    23 00080002 1003
+    24 00090000 1002
+    25 00090001 1002
+    26 00090002 1002
+    27 00090000 1001
+    28 00090001 1001
+    29 00090002 1001
+    30 00090000 1004
+    31 00090001 1003
+    32 00090002 1003
+    33 80040000 1002
+    34 80040000 1001
+    35 80040001 1002
+    36 80040002 1002
+    37 80040001 1001
+    38 80040002 1001
+    39 80040002 1003
+    40 00000000 1001
+    41 00000000 1002
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00040010
+AddParam
+
+Param.h.v.=00040011
+Param.val=2.00000000000000000000
+AddParam
+
+Param.h.v.=00040013
+AddParam
+
+Param.h.v.=00040014
+AddParam
+
+Param.h.v.=00050010
+AddParam
+
+Param.h.v.=00050011
+AddParam
+
+Param.h.v.=00050013
+Param.val=2.00000000000000000000
+AddParam
+
+Param.h.v.=00050014
+AddParam
+
+Param.h.v.=00060010
+Param.val=2.00000000000000000000
+AddParam
+
+Param.h.v.=00060011
+AddParam
+
+Param.h.v.=00060013
+AddParam
+
+Param.h.v.=00060014
+Param.val=2.00000000000000000000
+AddParam
+
+Param.h.v.=00070010
+AddParam
+
+Param.h.v.=00070011
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00070013
+AddParam
+
+Param.h.v.=00070014
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00070016
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00070017
+AddParam
+
+Param.h.v.=00070019
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=0007001a
+AddParam
+
+Param.h.v.=00080010
+AddParam
+
+Param.h.v.=00080011
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00080013
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=00080014
+AddParam
+
+Param.h.v.=00090010
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=00090011
+AddParam
+
+Param.h.v.=00090013
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00090014
+AddParam
+
+Param.h.v.=4000000f
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=40000011
+Param.val=0.75000000000000000000
+AddParam
+
+Param.h.v.=40000016
+Param.val=0.75000000000000000000
+AddParam
+
+Param.h.v.=80030000
+AddParam
+
+Param.h.v.=80030001
+AddParam
+
+Param.h.v.=80030002
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=80050000
+AddParam
+
+Param.h.v.=80050001
+AddParam
+
+Param.h.v.=80050002
+Param.val=0.50000000000000000000
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000004
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000005
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000006
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000007
+Request.type=300
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00040001
+Entity.point[1].v=00040002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00040002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00050001
+Entity.point[1].v=00050002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00050002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00060001
+Entity.point[1].v=00060002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00060002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070000
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=00070001
+Entity.point[1].v=00070002
+Entity.point[2].v=00070003
+Entity.point[3].v=00070004
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.y=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070003
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00070004
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.point[1].v=00080002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.y=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030003
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030004
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030006
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=2.00000000000000000000
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030006
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030007
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.actPoint.y=2.00000000000000000000
+Entity.actNormal.vx=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030008
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030005
+Entity.point[1].v=80030002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030009
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030006
+Entity.point[1].v=80030003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000b
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000b
+Entity.type=2010
+Entity.construction=0
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000e
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003000f
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=2.00000000000000000000
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030010
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030011
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000e
+Entity.point[1].v=8003000b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8003000f
+Entity.point[1].v=8003000c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030013
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030014
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030015
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030018
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030017
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=2.00000000000000000000
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030018
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=2.00000000000000000000
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030019
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.actPoint.x=2.00000000000000000000
+Entity.actNormal.vx=-0.70710678118654746172
+Entity.actNormal.vy=-0.70710678118654746172
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001a
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030017
+Entity.point[1].v=80030014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80030018
+Entity.point[1].v=80030015
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001e
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8003001f
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8003001f
+Entity.type=2010
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030020
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030021
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=2.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030022
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80030021
+Entity.point[1].v=8003001f
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030023
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80030021
+Entity.actPoint.z=2.00000000000000000000
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030024
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=8003001f
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050002
+Entity.point[1].v=80050003
+Entity.point[2].v=80050004
+Entity.point[3].v=80050005
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=0.50000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=12000
+Entity.construction=0
+Entity.point[0].v=80050007
+Entity.point[1].v=80050008
+Entity.point[2].v=80050009
+Entity.point[3].v=8005000a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=0.50000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=0.50000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050007
+Entity.point[1].v=80050002
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050008
+Entity.point[1].v=80050003
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050009
+Entity.point[1].v=80050004
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005000a
+Entity.point[1].v=80050005
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050010
+Entity.point[1].v=80050011
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050013
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.y=1.00000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=80050013
+Entity.actPoint.y=1.00000000000000000000
+Entity.actNormal.vx=0.70710678118654746172
+Entity.actNormal.vy=-0.70710678118654746172
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050013
+Entity.point[1].v=80050010
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050014
+Entity.point[1].v=80050011
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050019
+Entity.point[1].v=8005001a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001c
+Entity.point[1].v=8005001d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001c
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001d
+Entity.type=2010
+Entity.construction=0
+Entity.actPoint.x=1.00000000000000000000
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001e
+Entity.type=5001
+Entity.construction=0
+Entity.point[0].v=8005001c
+Entity.actPoint.x=-1.00000000000000000000
+Entity.actNormal.vy=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001c
+Entity.point[1].v=80050019
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050020
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005001d
+Entity.point[1].v=8005001a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050023
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050024
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050026
+Entity.type=2010
+Entity.construction=1
+Entity.actPoint.z=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050027
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050026
+Entity.point[1].v=80050024
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050026
+Entity.actPoint.z=0.50000000000000000000
+Entity.actNormal.vz=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050029
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=80050024
+Entity.actPoint.z=-0.50000000000000000000
+Entity.actNormal.vz=-1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000001
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00040000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000002
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040002
+Constraint.ptB.v=00050001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000003
+Constraint.type=80
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000004
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00050002
+Constraint.ptB.v=00060001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000005
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040001
+Constraint.ptB.v=00060002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000006
+Constraint.type=50
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00050000
+Constraint.entityB.v=00040000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000007
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00040002
+Constraint.ptB.v=80020002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000008
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=2.00000000000000000000
+Constraint.ptA.v=00050001
+Constraint.ptB.v=00050002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=-4.01877485198767292474
+AddConstraint
+
+Constraint.h.v=00000009
+Constraint.type=50
+Constraint.group.v=00000003
+Constraint.entityA.v=80030011
+Constraint.entityB.v=8003000a
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000c
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00070001
+Constraint.ptB.v=00080001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000d
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080002
+Constraint.ptB.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000e
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00070004
+Constraint.ptB.v=00090002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000f
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000000f
+Constraint.ptA.v=00090001
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=40000011
+Constraint.ptA.v=00070003
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000012
+Constraint.type=70
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00080001
+Constraint.entityA.v=00040000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=50
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00090000
+Constraint.entityB.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=70
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00090002
+Constraint.entityA.v=00050000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000016
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=40000016
+Constraint.ptA.v=00070002
+Constraint.entityA.v=00040000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000017
+Constraint.type=30
+Constraint.group.v=00000005
+Constraint.valA=1.00000000000000000000
+Constraint.ptA.v=80050026
+Constraint.ptB.v=80050024
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=0.06181401316574321181
+Constraint.disp.offset.y=0.13771237628628646421
+AddConstraint
+
+Constraint.h.v=00000018
+Constraint.type=32
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valA=-0.50000000000000000000
+Constraint.ptA.v=00070003
+Constraint.entityA.v=80030001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000019
+Constraint.type=32
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valA=-0.50000000000000000000
+Constraint.ptA.v=00070002
+Constraint.entityA.v=8003000a
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Surface 00000001 00646464 80030023 1 1
+SCtrl 0 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 2.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000001 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000  2.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+TrimBy 00000007 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000  0.00000000000000000000 2.00000000000000000000 2.00000000000000000000
+TrimBy 00000004 0 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000  0.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+AddSurface
+Surface 00000002 00646464 80030024 1 1
+SCtrl 0 0 2.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000005 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000  2.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000008 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000  0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+TrimBy 00000002 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 2.00000000000000000000 0.00000000000000000000
+TrimBy 00000013 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000  1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000014 0 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000003 00646464 80030019 1 1
+SCtrl 0 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000001 1 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000  0.00000000000000000000 2.00000000000000000000 2.00000000000000000000
+TrimBy 00000002 0 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000  2.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000003 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000  2.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+TrimBy 00000009 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000  0.00000000000000000000 2.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000004 00646464 80030010 1 1
+SCtrl 0 0 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000015 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000  0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+TrimBy 00000016 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000  1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+AddSurface
+Surface 00000005 00646464 80030007 1 1
+SCtrl 0 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000008 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000  0.00000000000000000000 2.00000000000000000000 0.00000000000000000000
+TrimBy 00000009 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000  0.00000000000000000000 2.00000000000000000000 2.00000000000000000000
+TrimBy 00000007 1 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000  0.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+TrimBy 00000006 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000  0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+TrimBy 00000017 0 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000  0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+TrimBy 00000018 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000  0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddSurface
+Surface 00000006 00646464 80050028 1 1
+SCtrl 0 0 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -1.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 1.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000  0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+TrimBy 0000000d 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000  1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+TrimBy 00000017 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000  0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+AddSurface
+Surface 00000007 00646464 80050029 1 1
+SCtrl 0 0 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 1.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -1.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 00000008 00646464 00000000 3 1
+SCtrl 0 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.50000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 0 0.00000000000000000000 0.50000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000000000000 0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 3 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 3 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000  1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+TrimBy 0000000c 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000  1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+TrimBy 00000012 1 0.00000000000000044409 0.99999999999998911981 0.00000000000000000000  0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+TrimBy 00000013 1 0.99999999995164756683 0.00000000000000000000 0.00000000000000000000  0.00000000000000044409 0.99999999999998911981 0.00000000000000000000
+AddSurface
+Surface 00000009 00646464 8005001e 1 1
+SCtrl 0 0 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Surface 0000000a 00646464 80050015 1 1
+SCtrl 0 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000001 00000003
+CCtrl 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000
+CurvePt 1 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+AddCurve
+Curve 00000002 1 1 00000002 00000003
+CCtrl 0 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000
+CurvePt 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000003 1 1 00000003 00000004
+CCtrl 0 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+CurvePt 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000004 1 1 00000001 00000004
+CCtrl 0 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 2.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000002 00000004
+CCtrl 0 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 2.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000006 1 1 00000004 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000007 1 1 00000001 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 2.00000000000000000000
+CurvePt 1 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000
+AddCurve
+Curve 00000008 1 1 00000002 00000005
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000005 00000003
+CCtrl 0 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 2.00000000000000000000 2.00000000000000000000
+CurvePt 1 0.00000000000000000000 2.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 0000000a 1 3 00000006 00000008
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.50000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 0.50000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+CurvePt 0 0.00573730468750000000 0.90637207031250000000 0.50000000000000000000
+CurvePt 0 0.02246093750000000000 0.81347656250000000000 0.50000000000000000000
+CurvePt 0 0.04943847656250000000 0.72204589843750000000 0.50000000000000000000
+CurvePt 0 0.08593750000000000000 0.63281250000000000000 0.50000000000000000000
+CurvePt 0 0.13122558593750000000 0.54650878906250000000 0.50000000000000000000
+CurvePt 0 0.18457031250000000000 0.46386718750000000000 0.50000000000000000000
+CurvePt 0 0.24523925781250000000 0.38562011718750000000 0.50000000000000000000
+CurvePt 0 0.31250000000000000000 0.31250000000000000000 0.50000000000000000000
+CurvePt 0 0.38562011718750000000 0.24523925781250000000 0.50000000000000000000
+CurvePt 0 0.46386718750000000000 0.18457031250000000000 0.50000000000000000000
+CurvePt 0 0.54650878906250000000 0.13122558593750000000 0.50000000000000000000
+CurvePt 0 0.63281250000000000000 0.08593750000000000000 0.50000000000000000000
+CurvePt 0 0.72204589843750000000 0.04943847656250000000 0.50000000000000000000
+CurvePt 0 0.81347656250000000000 0.02246093750000000000 0.50000000000000000000
+CurvePt 0 0.90637207031250000000 0.00573730468750000000 0.50000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+AddCurve
+Curve 0000000b 1 3 00000007 00000008
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.50000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 0.50000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000
+CurvePt 0 0.00573730468750000000 0.90637207031250000000 -0.50000000000000000000
+CurvePt 0 0.02246093750000000000 0.81347656250000000000 -0.50000000000000000000
+CurvePt 0 0.04943847656250000000 0.72204589843750000000 -0.50000000000000000000
+CurvePt 0 0.08593750000000000000 0.63281250000000000000 -0.50000000000000000000
+CurvePt 0 0.13122558593750000000 0.54650878906250000000 -0.50000000000000000000
+CurvePt 0 0.18457031250000000000 0.46386718750000000000 -0.50000000000000000000
+CurvePt 0 0.24523925781250000000 0.38562011718750000000 -0.50000000000000000000
+CurvePt 0 0.31250000000000000000 0.31250000000000000000 -0.50000000000000000000
+CurvePt 0 0.38562011718750000000 0.24523925781250000000 -0.50000000000000000000
+CurvePt 0 0.46386718750000000000 0.18457031250000000000 -0.50000000000000000000
+CurvePt 0 0.54650878906250000000 0.13122558593750000000 -0.50000000000000000000
+CurvePt 0 0.63281250000000000000 0.08593750000000000000 -0.50000000000000000000
+CurvePt 0 0.72204589843750000000 0.04943847656250000000 -0.50000000000000000000
+CurvePt 0 0.81347656250000000000 0.02246093750000000000 -0.50000000000000000000
+CurvePt 0 0.90637207031250000000 0.00573730468750000000 -0.50000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 0000000c 1 1 00000008 00000009
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000006 00000009
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+AddCurve
+Curve 0000000e 1 1 00000007 00000009
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 0000000f 1 1 00000009 0000000a
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000010 1 1 00000006 0000000a
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+AddCurve
+Curve 00000011 1 1 00000007 0000000a
+CCtrl 0 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000012 1 1 0000000a 00000008
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000013 1 3 00000002 00000008
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.50000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 2 0.50000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 3 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 0 0.00573730468750000000 0.90637207031250000000 0.00000000000000000000
+CurvePt 0 0.02246093750000000000 0.81347656250000000000 0.00000000000000000000
+CurvePt 0 0.04943847656250000000 0.72204589843750000000 0.00000000000000000000
+CurvePt 0 0.08593750000000000000 0.63281250000000000000 0.00000000000000000000
+CurvePt 0 0.13122558593750000000 0.54650878906250000000 0.00000000000000000000
+CurvePt 0 0.18457031250000000000 0.46386718750000000000 0.00000000000000000000
+CurvePt 0 0.24523925781250000000 0.38562011718750000000 0.00000000000000000000
+CurvePt 0 0.31250000000000000000 0.31250000000000000000 0.00000000000000000000
+CurvePt 0 0.38562011718750000000 0.24523925781250000000 0.00000000000000000000
+CurvePt 0 0.46386718750000000000 0.18457031250000000000 0.00000000000000000000
+CurvePt 0 0.54650878906250000000 0.13122558593750000000 0.00000000000000000000
+CurvePt 0 0.63281250000000000000 0.08593750000000000000 0.00000000000000000000
+CurvePt 0 0.72204589843750000000 0.04943847656250000000 0.00000000000000000000
+CurvePt 0 0.81347656250000000000 0.02246093750000000000 0.00000000000000000000
+CurvePt 0 0.90637207031250000000 0.00573730468750000000 0.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000014 1 1 00000002 00000009
+CCtrl 0 1.00000000000000000000 -0.00000000000000000000 -0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 -0.00000000000000000000 -0.00000000000000000000
+CurvePt 1 -0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+AddCurve
+Curve 00000015 1 1 00000004 00000006
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+AddCurve
+Curve 00000016 1 1 00000004 00000008
+CCtrl 0 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 1.00000000000000000000 0.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000017 1 1 00000005 00000006
+CCtrl 0 -0.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+AddCurve
+Curve 00000018 1 1 00000005 00000008
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 -0.50000000000000000000
+AddCurve
+Curve 00000019 1 1 00000005 00000009
+CCtrl 0 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.00000000000000000000
+CurvePt 1 0.00000000000000000000 0.00000000000000000000 0.50000000000000000000
+AddCurve
+Curve 0000001a 1 1 00000005 0000000a
+CCtrl 0 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.50000000000000000000
+CurvePt 1 0.00000000000000000000 1.00000000000000000000 0.00000000000000000000
+AddCurve

--- a/test/group/boolean_cross_vertex_tangent_crossing/test.cpp
+++ b/test/group/boolean_cross_vertex_tangent_crossing/test.cpp
@@ -1,0 +1,31 @@
+#include "solvespace.h"
+
+#include "harness.h"
+
+// A 2mm high prism with an isosceles right triangle with legs of 2mm as the
+// base. The fillet part is a bezier spline, tool's flat cap face is outside
+// the prism. On one side this reproduces #1291 and on the other #1743. The
+// model is ruevs's "1291_1743_cube_cut_tangent_outside_still_fails_simplified"
+// This case covers both "boolean_cross_vertex" and "boolean_tangent_crossing".
+TEST_CASE(normal_watertight_volume) {
+    CHECK_LOAD("normal.slvs");
+
+    Group *g = SK.GetGroup(SS.GW.activeGroup);
+    g->GenerateDisplayItems();
+    SMesh *m = &g->displayMesh;
+    CHECK_FALSE(m->l.IsEmpty());
+
+    SEdgeList el = {};
+    bool inters, leaks;
+    SKdNode::From(m)->MakeCertainEdgesInto(&el,
+        EdgeKind::NAKED_OR_SELF_INTER, /*coplanarIsInter=*/true, &inters, &leaks);
+    CHECK_FALSE(inters);
+    CHECK_FALSE(leaks);
+    CHECK_TRUE(el.l.IsEmpty());
+    el.Clear();
+
+    // The same value that the mesh Boolean gives for this model (build it
+    // with Group.forceToMesh set), to twelve significant figures.
+    CHECK_EQ_EPS(m->CalculateVolume() / 3.880640, 1.0);
+}
+


### PR DESCRIPTION
This PR combines https://github.com/BoykoNeov/solvespace/pull/5 with https://github.com/BoykoNeov/solvespace/pull/6 rebased on top of it. In addition I added an extra commit that adds [1291_1743_cube_cut_tangent_outside_still_fails_simplified.zip](https://github.com/user-attachments/files/30458058/1291_1743_cube_cut_tangent_outside_still_fails_simplified.zip) as a test case that covers both #1291 and #1743.

The original comments form Claude Opus 5:

# https://github.com/BoykoNeov/solvespace/pull/5

Fixes the tangent-outside case from #1291 — @ruevs' `1291_cube_cut_tangent_outside_still_fails.slvs`, which still failed after the nine commits of #1731 that are now in master.

This continues that work and sits directly on current master. It does **not** include the two commits from #1731 that you decided against (the `SKdNode::FindEdgeOn` relaxation and its tests) — this fix is independent of them, and I rebased it off them so there is nothing to re-litigate here.

### Both of the obvious explanations are wrong

I had two candidates going in, and I want to record that they're dead so nobody spends time on them:

1. **"The tangent intersection curve is never generated"** — the interior-profile-tangency limitation I documented in #1731. It does not apply. The profile cubic has `ctrl[2] = (30, −12.2621)` and `ctrl[3] = (30, 18.7884)`, both at `x = 30`, so the tangency is at the bezier's *endpoint*, and the exact-in-plane path from that PR fires correctly: `EXACT-IN-PLANE (30, 18.7884, 30) → (30, 18.7884, 0)`.
2. **"906cf739 discards it"** (*Don't keep Boolean intersection edges that lie along the trim boundary*) — ablating that commit gives byte-identical output. Not the culprit.

The curve is generated correctly and then **thrown away by misclassification.** It reaches `MakeCopyTrimAgainst` as three chains, all with `KEEP = 0` (`ins = COINC_OPP, outs = OUTSIDE` in one direction, reversed in the other). The cube's `x = +30` face is left with five edges, `AssemblePolygon` fails with `failed: I=5, avoid=4`, and the face disappears from the output.

### Root cause

In `SShell::ClassifyEdge()`'s edge-on-edge case (`src/srf/raycast.cpp`), the `edge_inters == 2` **mixed** branches — where one face's direction cosine is ~0 and the other's is not — assume that a face whose normal is parallel to ours is *coincident* with our surface. It may instead be merely **tangent** at the shell's edge and curving away immediately. First-order data at the point of contact cannot tell those apart.

This is the same class of defect as the both-tangent branch fixed in #1731, in the branches that PR left alone. I flagged it there as out of scope for lack of a model that reached it; @ruevs' file is that model.

### The fix

Extract the both-tangent branch's existing geometry probe as `ProbeTangentFace()` and apply it to the mixed branches too: probe the parallel-normal face a short distance into itself (scaled by that face's own control-net size) and see whether it stays in the tangent plane or leaves it. If it curves away, that side is classified `SURF_INSIDE` / `SURF_OUTSIDE` by the sign of `dev * surf_n·inter_surf_n` rather than being called coincident.

Faces that really are flat take the old path unchanged, so nothing that worked before changes answer.

### Regression test

`test/group/boolean_tangent_crossing/` — @ruevs' file verbatim, checking that the display mesh is watertight (no naked or self-intersecting edges) and that the volume matches. Fails with `(leaks) = true` without the fix. Volume rather than image checks, consistent with the other Boolean cases.

### Verification

- Full suite passes in Debug **and** Release: 263 cases / 931 checks (master is 262 / 925).
- The NURBS result matches the mesh-Boolean ground truth of the same model (`forceToMesh = 1`) **to the last digit**: 38 triangles / volume 204432.7149 / 0 naked edges, against 54 triangles / 204432.7149 / 0 naked edges.
- The 12-model sweep of every repro from #1291, #1619 and #1091 is unchanged, with every previously documented volume still exact.
- Since this branch does *not* carry the naked-edge checker change from #1731, the "0 naked edges" above was re-established with the **unpatched** checker.

### Not addressed

**@phkahler's two-sided-extrusion case.** There is no model attached to the issue for it yet. Flipping a working model's group subtype 7000 → 7001 does produce failures, but that is not his geometry — it doubles the tool length so it pokes out of the top of the cube, and the tangency still involves one tangent and one crossing face rather than being tangent to both fillet faces. Those failures are pre-existing and unchanged by this PR. I'd rather wait for the real model than claim a fix I can't demonstrate.

Please **fetch and fast-forward this branch** rather than using the merge button on my fork — that keeps it a clean fast-forward for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# https://github.com/BoykoNeov/solvespace/pull/6 

*Written by Claude Opus 5 — both this text and the code it describes; posted by @BoykoNeov.*

Fixes the `cube_cut_2` case from #1743. Two commits on top of master `790bf74c`.

## Root cause

@phkahler's hypothesis in #1743 is right, and this is the trace that proves it.

Where the two shells **touch** rather than pass through each other, a curve of one shell can cross a curve of the other at a point that is a vertex of neither input shell, and that lies on no surface which either curve crosses transversally. `SCurve::MakeCopySplitAgainst()` splits curves against *surfaces*, so at such a point it splits only whichever of the two curves does meet a transversal surface there, and leaves the other one whole.

The unsplit curve then contributes a single trim edge whose two halves classify differently. That cannot be represented: `MakeCopyTrimAgainst()` assembles the trim polygon from chains that `FindChainAvoiding()` builds, classifies each chain from one representative edge, and keeps or discards it whole. So the edge is lost along with the rest of its chain, `AssemblePolygon()` fails, and the face goes missing.

@ruevs' simplified model is the clearest example. A 2×2×2 triangular prism, minus a tool swept along a bezier profile from (1,0) to (0,1), z ∈ [−0.5, 0.5]. The tool's flat base face lies in the plane y=0, coincident with the prism's y=0 face, and the profile is tangent to y=0 at its (1,0) end. So the tool's corner edge x=1, y=0 runs *within* the prism's y=0 face, and crosses the prism's own bottom-front edge y=0, z=0 at **(1,0,0)**.

The tool's edge does get split there — it crosses the prism's z=0 face transversally. The prism's edge does not: the only tool surfaces it meets at x=1 are the coplanar base face and the tangent swept face, neither of which it crosses. An instrumented run then shows the whole 5-edge boundary of the prism's y=0 face arriving as one chain:

```
ORIGCHAIN A3 n=5 (0,0,0.5)->(2,0,2) ins=CSAME outs=CSAME KEEP=0
...
final: 2 edges
failed: I=3, avoid=3
```

`CSAME` is correct for the half of that boundary inside the coincident patch (x ≤ 1) and wrong for the half outside it — which is exactly the situation the missing split creates.

The asymmetry within the same model is worth noting, because it shows the rule at work: at the profile's *other* end the tool's third face crosses the prism's x=0 face transversally, so **that** prism edge did get split, at y=1. Only the touching end fails.

## The fix

`SShell::SplitCurvesAtCrossings()`, called from `MakeFromBoolean()` immediately after the two `CopyCurvesSplitAgainst()` calls: collect the interior `vertex == true` points of every source-A curve and every source-B curve, and insert each into the other operand's curves wherever it lies within one of their piecewise linear segments (axis-aligned bounding box prefilter, strict 0 < t < 1, within `LENGTH_EPS` of the chord) and — for exact curves — within `LENGTH_EPS` of the exact curve, since the chord of a curved segment is not the curve.

Interior points only, deliberately. A curve's endpoints are its own shell's vertices, which `FindVertsOnCurve()` already propagates from the trims, and an exact intersection curve's endpoints may lie outside the real geometry entirely — which is what #1452 was about. `test/group/boolean_coplanar_union` stays green.

It runs before `MakeIntersectionCurvesAgainst()`, and `RemoveShortSegments()` runs after it, so a point landing very close to an existing one cannot leave a degenerate segment behind (the `Equals` check already rejects anything within `LENGTH_EPS` of an existing point, so the shortest new segment is longer than that).

## Regression test

`test/group/boolean_cross_vertex/` — @phkahler's `cube_cut_2` from the issue, unmodified. Watertight, not self-intersecting, and a volume check.

The expected volume is the value the same model gives when built as a **mesh** Boolean instead of a NURBS one (`Group.forceToMesh`): 203485.224213202 against the NURBS result's 203485.224213201, which is agreement to 2.9e-15 relative. That is the real validation — the constant is not just "whatever this build printed".

No `CHECK_SAVE`/`CHECK_RENDER`, following the other Boolean cases here: the surface cache holds last-ulp floats that `PrepareSavefile` does not normalize.

The committed test against unmodified `boolean.cpp` fails `(inters) = true` with two `failed to assemble polygon to trim nurbs surface in uv space` messages.

## Verification

| model | master | this branch | mesh-Boolean truth |
|---|---|---|---|
| `cube_cut_2` | 28 tris / 171862.60 / **17 naked** | 38 / **202243.1316** / **0 naked** | 56 / 202243.1315 / 0 |
| ruevs' simplified | 22 / **10 naked** | 24 / **6 naked** | 48 / 0 naked |

- Full suite **263 cases / 931 checks**, Debug **and** Release (master baseline 262 / 925).
- The 12 repro models from #1619 / #1091 / #1291 all still exact, every documented volume unchanged to the last digit, Debug and Release identical.
- 5 repeated runs with OpenMP on give a single sorted triangle set for both models.
- `Vector::WithMagnitude(1) of zero vector!` appears three times while this test runs. It is the pre-existing triangulator diagnostic on tangent geometry, not something this patch introduces: on unmodified master `boolean_knife_edge` prints it 18 times, `boolean_tangent_spline` 6, `boolean_tangent_fillet` 3.

## What this does not fix

**ruevs' simplified model still has 6 naked edges on this branch alone.** It needs a second, independent fix — the tangent-crossing classification in `ClassifyEdge()` — and with that stacked on top it comes out clean at 28 triangles, 0 naked. The two defects are genuinely separate: `cube_cut_2` is fixed by this change alone, and the classification change alone leaves `cube_cut_2` at 17 naked edges.

**`curve_curve.slvs` is a third, different defect, and this does not touch it.** It is not the original-curve split at all. The failing curves are the two **intersection** curves on the plane y = 21.873392, which should each be split where they cross the box's x=0 face at z = ∓13.164015. One of them is, by `AllPointsIntersecting()` inside surfinter.cpp's own `MakeCopySplitAgainst()` call — leaving a spurious segment 1.9e-5 long. Its mirror image is not: its nearest piecewise linear point sits 2.5e-5 away from the point it needs. `FindVertsOnCurve()` is not involved anywhere on this model; instrumented, it yields zero candidates. So the gap is about 1e-5 wide and `LENGTH_EPS` is 1e-6 — propagating vertices cannot bridge it, and closing it means changing a tolerance, which I did not want to do speculatively.

So the two models @phkahler attached are **not** two instances of one cause. `cube_cut_2`'s two missing faces are (that is the "two of them for the same reason"); `curve_curve` is a separate accuracy problem in the intersection-curve split.

One more thing worth knowing about `curve_curve`: it is **OpenMP-nondeterministic on master and on every branch here**, cycling through four outcomes (88 tris/4 naked, 75/13, 71/15, 63/17) and deterministic only with `OMP_NUM_THREADS=1`. Single-run comparisons on that model will mislead whoever picks it up.

---

If this looks right, please fetch and fast-forward rather than using the merge button, so the history stays linear for upstream.
