### PR TITLE
Issue1743

### DIFF
--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -519,6 +519,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
         edge.deg = degn;
         if (edge.PointOnThisAndCurve(curve, &p)) {
             edge.ClosestPointTo(p, v); *u=0.0;
+            dbp("found U=0.0, V=%g point=(%.3f %.3f %.3f)", *v, CO(p) );
             return true;
         }
       }
@@ -527,6 +528,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
         edge.deg = degn;              
         if (edge.PointOnThisAndCurve(curve, &p)) {
             edge.ClosestPointTo(p, v); *u=1.0;
+            dbp("found U=1.0, V=%g point=(%.3f %.3f %.3f)", *v, CO(p) );
             return true;
         }
       }
@@ -537,6 +539,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
         edge.deg = degm;
         if (edge.PointOnThisAndCurve(curve, &p)) {
             edge.ClosestPointTo(p, u); *v=0.0;
+            dbp("found U=%g, V=0.0", *u);
             return true;
         }      
       } else { // v > 0.5
@@ -544,6 +547,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
         edge.deg = degm;
         if (edge.PointOnThisAndCurve(curve, &p)) {
             edge.ClosestPointTo(p, u); *v=1.0;
+            dbp("found U=%g, V=1.0", *u);
             return true;
         }            
       }

--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -503,6 +503,53 @@ bool SSurface::ClosestPointNewton(Vector p, double *u, double *v, bool mustConve
     return false;
 }
 
+// This checks the nearest edge of our surface for intersection with curve.
+// It is common for curve/surface intersection to fail because the curve
+// is tangent to the surface at the intersection point, which is often on
+// the edge of the surface - that's just how people design things...
+bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
+{
+    SBezier edge = {};
+    // we already have a starting point in space
+    Vector p = PointAt(*u, *v);
+    if(fabs(*u - 0.5) > fabs(*v - 0.5)) {
+    // u is closer to 0 or 1 than v
+      if(*u < 0.5) {
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[0][n]; edge.weight[n]=weight[0][n]; }
+        edge.deg = degn;
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, v); *u=0.0;
+            return true;
+        }
+      }
+      else { // u > 0.5
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[degm][n]; edge.weight[n]=weight[degm][n]; }
+        edge.deg = degn;              
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, v); *u=1.0;
+            return true;
+        }
+      }
+    } else {
+    // v is closer to 0 or 1
+      if(*v < 0.5) {
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][0]; edge.weight[n]=weight[n][0]; }
+        edge.deg = degm;
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, u); *v=0.0;
+            return true;
+        }      
+      } else { // v > 0.5
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][degn]; edge.weight[n]=weight[n][degn]; }
+        edge.deg = degm;
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, u); *v=1.0;
+            return true;
+        }            
+      }
+    }
+    return false;
+}
 bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v) const
 {
     int i;
@@ -533,6 +580,14 @@ bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v)
         double du = dp.Dot(tx), dv = dp.Dot(ty);
         *u += du / tx.MagSquared();
         *v += dv / ty.MagSquared();
+    }
+    // Lets try the edge of the surface against the line
+    SBezier curve = {};
+    curve.ctrl[0] = p0; curve.weight[0] = 1.0;
+    curve.ctrl[1] = p1; curve.weight[1] = 1.0;
+    curve.deg = 1;
+    if (EdgeCurveIntersection(u,v, &curve)) {
+      return true;
     }
     dbp("didn't converge (surface intersecting line)");
     return false;

--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -222,6 +222,33 @@ void SSurface::AllPointsIntersectingUntrimmed(Vector a, Vector b,
             l->Add(&inter);
         } else {
             // Might not converge if line is almost tangent to surface...
+
+            // It is common for this to happen along a surface boundary so check one
+            SBezier edge = {};
+            if(fabs(inter.p.x - 0.5) > fabs(inter.p.y - 0.5)) {
+            // u is closer to 0 or 1 than v
+              if(inter.p.x < 0.5) {
+                for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[0][n]; edge.weight[n]=weight[0][n]; }
+                edge.deg = degn;
+
+              }
+              else { // u > 0.5
+                for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[degm][n]; edge.weight[n]=weight[degm][n]; }
+                edge.deg = degn;              
+
+              }
+            } else {
+            // v is closer to 0 or 1
+              if(inter.p.y < 0.5) {
+                for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][0]; edge.weight[n]=weight[n][0]; }
+                edge.deg = degm;
+              
+              } else { // v > 0.5
+                for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][degn]; edge.weight[n]=weight[n][degn]; }
+                edge.deg = degm;
+              
+              }
+            }
         }
         return;
     }

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -339,6 +339,7 @@ public:
     void ClosestPointTo(Vector p, double *u, double *v, bool mustConverge=true);
     bool ClosestPointNewton(Vector p, double *u, double *v, bool mustConverge=true) const;
 
+    bool EdgeCurveIntersection(double *u, double *v, SBezier *curve) const;
     bool PointIntersectingLine(Vector p0, Vector p1, double *u, double *v) const;
     Vector ClosestPointOnThisAndSurface(SSurface *srf2, Vector p);
     void PointOnSurfaces(SSurface *s1, SSurface *s2, double *u, double *v);


### PR DESCRIPTION
This is an attempt to fix the issue in #1743.  When a line-surface intersection fails tangent, we try the nearest edge of the surface in a curve-curve intersection test. So far this fixes the problematic surface but for some reason breaks the other one.