### PR TITLE
When line surface intersection fails due to tangency, try the nearest…

### DIFF
--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -107,6 +107,17 @@ void SBezier::ClosestPointTo(Vector p, double *t, bool mustConverge) const {
     }
 }
 
+bool SBezier::PointOnNonparallelCurve(const SBezier *curve, Vector *p) const {
+    if(deg + curve->deg == 2) {  // check for parallel lines
+        Vector d1 = ctrl[1].Minus(ctrl[0]).WithMagnitude(1.0);
+        Vector d2 = curve->ctrl[1].Minus(curve->ctrl[0]).WithMagnitude(1.0);
+        if(fabs(1.0 - d1.Dot(d2)) < 10*RATPOLY_EPS) {
+            return false;
+        }
+    }
+    return PointOnThisAndCurve(curve, p);
+}
+
 bool SBezier::PointOnThisAndCurve(const SBezier *sbb, Vector *p) const {
     double ta, tb;
     this->ClosestPointTo(*p, &ta, /*mustConverge=*/false);
@@ -517,7 +528,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
       if(*u < 0.5) {
         for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[0][n]; edge.weight[n]=weight[0][n]; }
         edge.deg = degn;
-        if (edge.PointOnThisAndCurve(curve, &p)) {
+        if (edge.PointOnNonparallelCurve(curve, &p)) {
             edge.ClosestPointTo(p, v); *u=0.0;
             dbp("found U=0.0, V=%g point=(%.3f %.3f %.3f)", *v, CO(p) );
             return true;
@@ -526,7 +537,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
       else { // u > 0.5
         for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[degm][n]; edge.weight[n]=weight[degm][n]; }
         edge.deg = degn;              
-        if (edge.PointOnThisAndCurve(curve, &p)) {
+        if (edge.PointOnNonparallelCurve(curve, &p)) {
             edge.ClosestPointTo(p, v); *u=1.0;
             dbp("found U=1.0, V=%g point=(%.3f %.3f %.3f)", *v, CO(p) );
             return true;
@@ -537,7 +548,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
       if(*v < 0.5) {
         for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][0]; edge.weight[n]=weight[n][0]; }
         edge.deg = degm;
-        if (edge.PointOnThisAndCurve(curve, &p)) {
+        if (edge.PointOnNonparallelCurve(curve, &p)) {
             edge.ClosestPointTo(p, u); *v=0.0;
             dbp("found U=%g, V=0.0 point=(%.3f %.3f %.3f)", *u, CO(p));
             return true;
@@ -545,7 +556,7 @@ bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
       } else { // v > 0.5
         for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][degn]; edge.weight[n]=weight[n][degn]; }
         edge.deg = degm;
-        if (edge.PointOnThisAndCurve(curve, &p)) {
+        if (edge.PointOnNonparallelCurve(curve, &p)) {
             edge.ClosestPointTo(p, u); *v=1.0;
             dbp("found U=%g, V=1.0 point=(%.3f %.3f %.3f)", *u, CO(p));
             return true;

--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -503,6 +503,57 @@ bool SSurface::ClosestPointNewton(Vector p, double *u, double *v, bool mustConve
     return false;
 }
 
+// This checks the nearest edge of our surface for intersection with curve.
+// It is common for curve/surface intersection to fail because the curve
+// is tangent to the surface at the intersection point, which is often on
+// the edge of the surface - that's just how people design things...
+bool SSurface::EdgeCurveIntersection(double *u, double *v, SBezier *curve) const
+{
+    SBezier edge = {};
+    // we already have a starting point in space
+    Vector p = PointAt(*u, *v);
+    if(fabs(*u - 0.5) > fabs(*v - 0.5)) {
+    // u is closer to 0 or 1 than v
+      if(*u < 0.5) {
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[0][n]; edge.weight[n]=weight[0][n]; }
+        edge.deg = degn;
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, v); *u=0.0;
+            dbp("found U=0.0, V=%g point=(%.3f %.3f %.3f)", *v, CO(p) );
+            return true;
+        }
+      }
+      else { // u > 0.5
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[degm][n]; edge.weight[n]=weight[degm][n]; }
+        edge.deg = degn;              
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, v); *u=1.0;
+            dbp("found U=1.0, V=%g point=(%.3f %.3f %.3f)", *v, CO(p) );
+            return true;
+        }
+      }
+    } else {
+    // v is closer to 0 or 1
+      if(*v < 0.5) {
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][0]; edge.weight[n]=weight[n][0]; }
+        edge.deg = degm;
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, u); *v=0.0;
+            dbp("found U=%g, V=0.0 point=(%.3f %.3f %.3f)", *u, CO(p));
+            return true;
+        }      
+      } else { // v > 0.5
+        for(int n=0;n<4;n++) { edge.ctrl[n]=ctrl[n][degn]; edge.weight[n]=weight[n][degn]; }
+        edge.deg = degm;
+        if (edge.PointOnThisAndCurve(curve, &p)) {
+            edge.ClosestPointTo(p, u); *v=1.0;
+            dbp("found U=%g, V=1.0 point=(%.3f %.3f %.3f)", *u, CO(p));
+            return true;
+        }            
+      }
+    }
+    return false;
+}
 bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v) const
 {
     int i;
@@ -521,7 +572,7 @@ bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v)
             break;
         }
 
-        // Check for convergence
+        // Check for convergence - success exits
         if(pi.Equals(p, RATPOLY_EPS)) return true;
 
         n = tu.Cross(tv);
@@ -533,6 +584,14 @@ bool SSurface::PointIntersectingLine(Vector p0, Vector p1, double *u, double *v)
         double du = dp.Dot(tx), dv = dp.Dot(ty);
         *u += du / tx.MagSquared();
         *v += dv / ty.MagSquared();
+    }
+    // Lets try the edge of the surface against the line before giving up
+    SBezier curve = {};
+    curve.ctrl[0] = p0; curve.weight[0] = 1.0;
+    curve.ctrl[1] = p1; curve.weight[1] = 1.0;
+    curve.deg = 1;
+    if (EdgeCurveIntersection(u,v, &curve)) {
+      return true;
     }
     dbp("didn't converge (surface intersecting line)");
     return false;

--- a/src/srf/ratpoly.cpp
+++ b/src/srf/ratpoly.cpp
@@ -111,11 +111,27 @@ bool SBezier::PointOnNonparallelCurve(const SBezier *curve, Vector *p) const {
     if(deg + curve->deg == 2) {  // check for parallel lines
         Vector d1 = ctrl[1].Minus(ctrl[0]).WithMagnitude(1.0);
         Vector d2 = curve->ctrl[1].Minus(curve->ctrl[0]).WithMagnitude(1.0);
-        if(fabs(1.0 - d1.Dot(d2)) < 10*RATPOLY_EPS) {
+        // I'm not sure what the angle tollerance should be here.
+        if(d1.Cross(d2).Magnitude() < LENGTH_EPS) {
             return false;
         }
     }
-    return PointOnThisAndCurve(curve, p);
+    // we will not tail call here because of one more check afterward.
+    if(!PointOnThisAndCurve(curve, p)) {
+        return false;
+    }
+    // if it did converge we need to verify that it is not a parallel situation
+    // since it will not have converged all the way and would produce bad results.
+    double ta, tb;
+    this->ClosestPointTo(*p, &ta, /*mustConverge=*/false);
+    curve->ClosestPointTo(*p, &tb, /*mustConverge=*/false);
+    Vector da = this->TangentAt(ta).WithMagnitude(1),
+           db = curve->TangentAt(tb).WithMagnitude(1);
+    // for some reason using RATPOLY_EPS here causes leaks in one of the test cases?
+    if(da.Cross(db).Magnitude() < LENGTH_EPS) {
+        return false;
+    }
+    return true;    
 }
 
 bool SBezier::PointOnThisAndCurve(const SBezier *sbb, Vector *p) const {

--- a/src/srf/raycast.cpp
+++ b/src/srf/raycast.cpp
@@ -222,6 +222,7 @@ void SSurface::AllPointsIntersectingUntrimmed(Vector a, Vector b,
             l->Add(&inter);
         } else {
             // Might not converge if line is almost tangent to surface...
+            dbp("AllPointsIntersectingUntrimmed failed");
         }
         return;
     }

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -339,6 +339,7 @@ public:
     void ClosestPointTo(Vector p, double *u, double *v, bool mustConverge=true);
     bool ClosestPointNewton(Vector p, double *u, double *v, bool mustConverge=true) const;
 
+    bool EdgeCurveIntersection(double *u, double *v, SBezier *curve) const;
     bool PointIntersectingLine(Vector p0, Vector p1, double *u, double *v) const;
     Vector ClosestPointOnThisAndSurface(SSurface *srf2, Vector p);
     void PointOnSurfaces(SSurface *s1, SSurface *s2, double *u, double *v);

--- a/src/srf/surface.h
+++ b/src/srf/surface.h
@@ -96,6 +96,7 @@ public:
     Vector TangentAt(double t) const;
     void ClosestPointTo(Vector p, double *t, bool mustConverge=true) const;
     void SplitAt(double t, SBezier *bef, SBezier *aft) const;
+    bool PointOnNonparallelCurve(const SBezier *curve, Vector *p) const;
     bool PointOnThisAndCurve(const SBezier *sbb, Vector *p) const;
 
     Vector Start() const;


### PR DESCRIPTION
… edge of the surface in a curve-curve intersection test.


This is my attempt to fix #1743.  It does fix the failing edge/surface in the file 1291_1743_cube_cut....

The problem is that it breaks the opposite face. It seem to be splitting the crucial edge on that face into abou 10 segments for reasons I don't understand. A previous version of this also failed ASAN for reasons I don't understand - let's see if this one does too.

IMHO this approach should be better than the other fixes because it addresses the problem at the source in ratpoly.cpp when an edge/surface intersection fails due to being tangent we try something else to get the intersection.