### PR TITLE
Export: warn instead of crashing on freehand/zigzag stipple

### DIFF
--- a/src/exportvector.cpp
+++ b/src/exportvector.cpp
@@ -674,7 +674,9 @@ static std::string MakeStipplePattern(StipplePattern pattern, double scale, char
 
         case StipplePattern::FREEHAND:
         case StipplePattern::ZIGZAG:
-            ssassert(false, "Freehand and zigzag export not implemented");
+            dbp("Freehand and zigzag export not implemented; "
+                "exporting as continuous line");
+            break;
     }
     std::replace(result.begin(), result.end(), '_', delimiter);
     return result;


### PR DESCRIPTION
Fixes #1506.

Exporting a 2D view with a line style that uses the freehand or zigzag stipple pattern crashed with an assertion failure in MakeStipplePattern(), since those patterns have no vector-export equivalent. The on-screen renderer handles them via the OpenGL StippleAtlas, so the crash only occurred on vector export (SVG/PDF/EPS/DXF).

Replace the ssassert() with a dbp() warning and fall through to export the line as continuous, so a valid file is produced instead of aborting.