### PR TITLE
Color picker: show current color instead of black

### DIFF
--- a/src/textwin.cpp
+++ b/src/textwin.cpp
@@ -333,9 +333,17 @@ void TextWindow::ShowEditControlWithColorPicker(int col, RgbaColor rgb) {
 
     editControl.colorPicker.show = true;
     editControl.colorPicker.rgb = rgb;
-    editControl.colorPicker.h = 0;
-    editControl.colorPicker.s = 0;
-    editControl.colorPicker.v = 1;
+
+    // Convert the current RGB color to HSV so the picker reflects it, rather
+    // than always resetting to black (issue #1127). RgbToHsv() returns the
+    // hue in [0,6), but the picker stores it normalized to [0,1], so divide
+    // by 6 before storing.
+    Vector hs = RgbToHsv({rgb.redF(), rgb.greenF(), rgb.blueF()});
+
+    editControl.colorPicker.h = hs.x / 6;
+    editControl.colorPicker.s = hs.y;
+    editControl.colorPicker.v = hs.z;
+
     ShowEditControl(col, ssprintf("%.2f, %.2f, %.2f", rgb.redF(), rgb.greenF(), rgb.blueF()));
 }
 
@@ -686,6 +694,47 @@ Vector TextWindow::HsvToRgb(Vector hsv) {
     rgb = rgb.Plus({m, m, m});
 
     return rgb;
+}
+
+//----------------------------------------------------------------------------
+// Given (x, y, z) = (r, g, b) in [0,1), [0,1], [0,1], return (x, y, z) =
+// (h, s, v) all in [0,6], [0,1], [0,1].
+//----------------------------------------------------------------------------
+Vector TextWindow::RgbToHsv(Vector rgb) {
+
+    Vector hsv;
+
+    double r = rgb.x;
+    double g = rgb.y;
+    double b = rgb.z;
+
+    double max = fmax(r, fmax(g, b));
+    double min = fmin(r, fmin(g, b));
+    double delta = max - min;
+
+    double h = 0;
+    double s = 0;
+    double v = 1 - min;
+
+    if (delta != 0 && v != 0) {
+        s = delta / v;
+
+        if (max == r)
+            h = (g - b) / delta;
+        else if (max == g)
+            h = 2 + (b - r) / delta;
+        else
+            h = 4 + (r - g) / delta;
+
+        if (h < 0)
+            h += 6;
+    }
+
+    hsv.x = h;
+    hsv.y = s;
+    hsv.z = v;
+
+    return hsv;
 }
 
 std::shared_ptr<Pixmap> TextWindow::HsvPattern2d(int w, int h) {

--- a/src/ui.h
+++ b/src/ui.h
@@ -268,6 +268,7 @@ public:
     Button *hoveredButton;
 
     Vector HsvToRgb(Vector hsv);
+    Vector RgbToHsv(Vector rgb);
     std::shared_ptr<Pixmap> HsvPattern2d(int w, int h);
     std::shared_ptr<Pixmap> HsvPattern1d(double hue, double sat, int w, int h);
     void ColorPickerDone();


### PR DESCRIPTION
Fixes #1127.

The on-screen color picker stored the incoming RGB in colorPicker.rgb but hardcoded the HSV state to (h=0, s=0, v=1), so the hue/saturation crosshair and value slider always reset to black regardless of the current color. Convert the current RGB to HSV (normalized to the picker's [0,1] convention, with hue in [0,6) as consumed by HsvToRgb) when showing the picker so it reflects the actual color.