### PR TITLE
Mark file unsaved when a missing image is relocated

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1016,7 +1016,10 @@ bool SolveSpaceUI::ReloadLinkedImage(const Platform::Path &saveFile,
             if(pixmap == NULL) {
                 Error("The image '%s' is corrupted.", filename->raw.c_str());
             }
-            // We know where the file is now, good.
+            // We know where the file is now, good. The updated path must be
+            // written back to the .slvs file, so mark the document unsaved
+            // (issue #1238).
+            SS.unsaved = true;
         } else if(canCancel) {
             return false;
         }

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -200,8 +200,12 @@ bool SolveSpaceUI::Load(const Platform::Path &filename) {
         saveFile.Clear();
         NewFile();
     }
+    // Capture whether loading modified the document (e.g. the user relocated
+    // a missing image, which sets unsaved in ReloadLinkedImage) before
+    // AfterNewFile() resets it (issue #1238).
+    bool unsavedDuringLoad = unsaved;
     AfterNewFile();
-    unsaved = autosaveLoaded;
+    unsaved = autosaveLoaded || unsavedDuringLoad;
     return fileLoaded;
 }
 


### PR DESCRIPTION
Fixes #1238.

When a linked image is missing and the user relocates it through the file dialog, the new path was stored in memory but SS.unsaved was never set, so closing the file did not prompt to save and the updated path was lost.

Set SS.unsaved = true in ReloadLinkedImage() when the path changes. However, SolveSpaceUI::Load() calls AfterNewFile() after loading, which unconditionally resets unsaved to false, wiping the flag. So capture the unsaved state set during loading and restore it after AfterNewFile().