### PR TITLE
Revert "Mark file unsaved when a missing image is relocated"

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1016,10 +1016,7 @@ bool SolveSpaceUI::ReloadLinkedImage(const Platform::Path &saveFile,
             if(pixmap == NULL) {
                 Error("The image '%s' is corrupted.", filename->raw.c_str());
             }
-            // We know where the file is now, good. The updated path must be
-            // written back to the .slvs file, so mark the document unsaved
-            // (issue #1238).
-            SS.unsaved = true;
+            // We know where the file is now, good.
         } else if(canCancel) {
             return false;
         }

--- a/src/solvespace.cpp
+++ b/src/solvespace.cpp
@@ -200,12 +200,8 @@ bool SolveSpaceUI::Load(const Platform::Path &filename) {
         saveFile.Clear();
         NewFile();
     }
-    // Capture whether loading modified the document (e.g. the user relocated
-    // a missing image, which sets unsaved in ReloadLinkedImage) before
-    // AfterNewFile() resets it (issue #1238).
-    bool unsavedDuringLoad = unsaved;
     AfterNewFile();
-    unsaved = autosaveLoaded || unsavedDuringLoad;
+    unsaved = autosaveLoaded;
     return fileLoaded;
 }
 


### PR DESCRIPTION
This reverts commit 52c21e2753fb13754c3e188083b54ff643f7bf6c.

That "fixed" issue #1238 which it did while introducing new bugs by introducing a new flag that was not properly handled. I think it best to revert that entirely and make a clean fix. Unfortunately that one is quite far back in the history at this point, so I think it best to use a second commit to revert it rather than trying to rewrite the history since then.