### PR TITLE
Don't crash in the headless CLI when a linked file is missing

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -874,6 +874,14 @@ static Platform::MessageDialog::Response LocateImportedFile(const Platform::Path
     Platform::MessageDialogRef dialog = CreateMessageDialog(SS.GW.window);
 
     using Platform::MessageDialog;
+    if(!dialog) {
+        // When running the headless CLI version no dialog is possible, so
+        // decline to locate the file.
+        dbp("The linked file '%s' is not present; continuing without it.",
+            filename.raw.c_str());
+        return MessageDialog::Response::NO;
+    }
+
     dialog->SetType(MessageDialog::Type::QUESTION);
     dialog->SetTitle(C_("title", "Missing File"));
     dialog->SetMessage(ssprintf(C_("dialog", "The linked file “%s” is not present."),


### PR DESCRIPTION
Loading a sketch whose linked image or sketch has moved kills any headless
build. `LocateImportedFile()` asks the user whether to look for the file, and
`guinone.cpp` has no dialogs to run: `CreateMessageDialog()` returns an empty
handle, which is then dereferenced. The GUI is unaffected — its window exists
before the file is loaded, so the dialog is real.

So it is `solvespace-cli` that dies: `export-mesh`, `regenerate`, `thumbnail`,
anything batch.

Answer as declining to locate it, which is the only thing a batch run can
sensibly do, and name the file on the console.

Of 171 of my own sketches, 17 died on load this way, every one because of a PNG
that had been traced over and has since moved. With this they all load, and all
17 turn out to be geometrically fine.

Repro: save a sketch with a linked image, move the image, then run
`solvespace-cli export-mesh --output out.stl sketch.slvs`.
