### PR TITLE
Windows: ship solvespace-cli in the release assets

### DIFF
--- a/.github/scripts/build-windows.sh
+++ b/.github/scripts/build-windows.sh
@@ -43,13 +43,17 @@ cmake --build . --config "${BUILD_TYPE}" -t test_solvespace -- -maxcpucount
 if [ "$3" = "x64" ]; then
 	if [ "$2" != "openmp" ]; then
 		mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_single_core_x64.exe
+		mv bin/$BUILD_TYPE/solvespace-cli.exe bin/$BUILD_TYPE/solvespace-cli_single_core_x64.exe
 	else
 		mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_x64.exe
+		mv bin/$BUILD_TYPE/solvespace-cli.exe bin/$BUILD_TYPE/solvespace-cli_x64.exe
 	fi
 else
 	if [ "$2" != "openmp" ]; then
 		mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_single_core_x86.exe
+		mv bin/$BUILD_TYPE/solvespace-cli.exe bin/$BUILD_TYPE/solvespace-cli_single_core_x86.exe
     else
         mv bin/$BUILD_TYPE/solvespace.exe bin/$BUILD_TYPE/solvespace_x86.exe
+        mv bin/$BUILD_TYPE/solvespace-cli.exe bin/$BUILD_TYPE/solvespace-cli_x86.exe
 	fi
 fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: windows_single_core_x86
-          path: build/bin/RelWithDebInfo/solvespace_single_core_x86.exe
+          path: |
+            build/bin/RelWithDebInfo/solvespace_single_core_x86.exe
+            build/bin/RelWithDebInfo/solvespace-cli_single_core_x86.exe
 
   build_release_windows_openmp_x86:
     needs: [test_ubuntu, test_windows, test_macos]
@@ -88,7 +90,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: windows_x86
-          path: build/bin/RelWithDebInfo/solvespace_x86.exe
+          path: |
+            build/bin/RelWithDebInfo/solvespace_x86.exe
+            build/bin/RelWithDebInfo/solvespace-cli_x86.exe
 
   build_release_windows_x64:
     needs: [test_ubuntu, test_windows, test_macos]
@@ -106,7 +110,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: windows_single_core_x64
-          path: build/bin/RelWithDebInfo/solvespace_single_core_x64.exe
+          path: |
+            build/bin/RelWithDebInfo/solvespace_single_core_x64.exe
+            build/bin/RelWithDebInfo/solvespace-cli_single_core_x64.exe
 
   build_release_windows_openmp_x64:
     needs: [test_ubuntu, test_windows, test_macos]
@@ -124,7 +130,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: windows_x64
-          path: build/bin/RelWithDebInfo/solvespace_x64.exe
+          path: |
+            build/bin/RelWithDebInfo/solvespace_x64.exe
+            build/bin/RelWithDebInfo/solvespace-cli_x64.exe
 
   build_release_macos:
     needs: [test_ubuntu, test_windows, test_macos]
@@ -224,7 +232,11 @@ jobs:
       with:
         files: |
           windows_single_core_x86/solvespace_single_core_x86.exe
+          windows_single_core_x86/solvespace-cli_single_core_x86.exe
           windows_x86/solvespace_x86.exe
+          windows_x86/solvespace-cli_x86.exe
           windows_single_core_x64/solvespace_single_core_x64.exe
+          windows_single_core_x64/solvespace-cli_single_core_x64.exe
           windows_x64/solvespace_x64.exe
+          windows_x64/solvespace-cli_x64.exe
           macos/SolveSpace.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Solver:
 * Improved ability to solve constraints with large dimensions/values.
 
 Misc:
+* Windows releases now also ship the command-line interface, `solvespace-cli_*.exe`.
 * Initialize the color picker to the current color instead of black.
 * Fix some file dialog issues.
 * small fixes in the web version


### PR DESCRIPTION
Fixes #1770.

The Windows release jobs already build `solvespace-cli.exe` — it shows up in every CD run:

```
solvespace-cli.vcxproj -> D:\a\solvespace\solvespace\build\bin\RelWithDebInfo\solvespace-cli.exe
```

but `build-windows.sh` renames only `solvespace.exe`, and each job uploads only that one path, so the CLI is discarded at the end of the build. macOS ships it inside the app bundle and Linux distributions package it; Windows is the only platform where it cannot be obtained without compiling.

This renames `solvespace-cli.exe` with the same suffix as the GUI binary it was built alongside, uploads it in the same artifact, and adds the four files to the release assets. No build configuration changes — the binary is already produced by the existing `ENABLE_CLI` default, and it is statically linked (`/MT`, in-tree cairo/libpng/zlib) like the GUI executable, so it needs no extra runtime files.

Verified by running the modified workflow end to end on a fork. All four Windows release jobs passed, and the `windows_x86` artifact contained both binaries:

```
solvespace_x86.exe        8,740,864
solvespace-cli_x86.exe    7,242,752
```

Running that `solvespace-cli_x86.exe` on a clean Windows 11 machine, with nothing else installed:

```
> solvespace-cli_x86.exe export-view --output "%.svg" --view top demo.slvs
Written 'demo.svg'.
```

Happy to trim this to just the two OpenMP builds if eight Windows assets is more than you want on the release page.
